### PR TITLE
fix for search that wasn't previously ported over from private repo

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
@@ -38,6 +38,7 @@ import java.util.Set;
 @Log4j2
 public class JVectorReader extends KnnVectorsReader {
     private static final VectorTypeSupport VECTOR_TYPE_SUPPORT = VectorizationProvider.getInstance().getVectorTypeSupport();
+    private static final int DEFAULT_OVER_QUERY_FACTOR = 5; // We will query 5x more than topKFor reranking
 
     private final FieldInfos fieldInfos;
     private final String indexDataFileName;
@@ -125,7 +126,7 @@ public class JVectorReader extends KnnVectorsReader {
             ssp = SearchScoreProvider.exact(q, fieldEntryMap.get(field).similarityFunction, index.getView());
         }
         io.github.jbellis.jvector.util.Bits compatibleBits = doc -> acceptDocs == null || acceptDocs.get(doc);
-        final var sr = fieldEntryMap.get(field).graphSearcher.search(ssp, knnCollector.k(), compatibleBits);
+        final var sr = fieldEntryMap.get(field).graphSearcher.search(ssp, knnCollector.k(), knnCollector.k() * DEFAULT_OVER_QUERY_FACTOR, 0.0f, 0.0f, compatibleBits);
         for (SearchResult.NodeScore ns : sr.getNodes()) {
             knnCollector.collect(ns.node, ns.score);
         }

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
@@ -126,7 +126,14 @@ public class JVectorReader extends KnnVectorsReader {
             ssp = SearchScoreProvider.exact(q, fieldEntryMap.get(field).similarityFunction, index.getView());
         }
         io.github.jbellis.jvector.util.Bits compatibleBits = doc -> acceptDocs == null || acceptDocs.get(doc);
-        final var sr = fieldEntryMap.get(field).graphSearcher.search(ssp, knnCollector.k(), knnCollector.k() * DEFAULT_OVER_QUERY_FACTOR, 0.0f, 0.0f, compatibleBits);
+        final var sr = fieldEntryMap.get(field).graphSearcher.search(
+            ssp,
+            knnCollector.k(),
+            knnCollector.k() * DEFAULT_OVER_QUERY_FACTOR,
+            0.0f,
+            0.0f,
+            compatibleBits
+        );
         for (SearchResult.NodeScore ns : sr.getNodes()) {
             knnCollector.collect(ns.node, ns.score);
         }


### PR DESCRIPTION
### Description
Fix for search results for PQ that wasn't migrated over from the original previous repo.
And currently creating jitterness in some of the search result tests.

### Related Issues
Migration issue from private repo to fix jittery tests.

### Check List
- [ x] New functionality includes testing.
- [x ] New functionality has been documented.
- [ x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ x] Commits are signed per the DCO using `--signoff`.
- [ x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
