### PR TITLE
fix the json path CVE https://github.com/opensearch-project/opensearc…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 ### Enhancements
 ### Bug Fixes
+* Fix CVE-2024-57699 by updating json-path dependencies.
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/build.gradle
+++ b/build.gradle
@@ -300,7 +300,10 @@ dependencies {
     // Excluding slf4j here since json-path is only used for testing, and logging failures in this context are acceptable.
     testFixturesImplementation('com.jayway.jsonpath:json-path:2.9.0') {
         exclude group: 'org.slf4j', module: 'slf4j-api'
+        exclude group: 'net.minidev', module: 'json-smart'
     }
+    // Explicitly include a safe version of json-smart for test fixtures
+    testFixturesImplementation group: 'net.minidev', name: 'json-smart', version: "${versions.json_smart}"
     testFixturesImplementation "org.opensearch:common-utils:${version}"
     implementation 'com.github.oshi:oshi-core:6.4.13'
 


### PR DESCRIPTION
### Description
Fixes the CVE mentioned here:
https://github.com/opensearch-project/opensearch-jvector/issues/5#issue-2918329803
https://github.com/advisories/GHSA-pq2g-wx69-c263

### Related Issues
Resolves 
https://github.com/opensearch-project/opensearch-jvector/issues/5#issue-2918329803
https://github.com/advisories/GHSA-pq2g-wx69-c263

### Check List
- [x ] New functionality includes testing.
- [ x] New functionality has been documented.
- [ x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ x] Commits are signed per the DCO using `--signoff`.
- [ x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
