### PR TITLE
add release 3.0.0.0-alpha1

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -25,4 +25,4 @@ jobs:
       - uses: ncipollo/release-action@v1
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}
-          bodyFile: release-notes/opensearch-knn.release-notes-${{steps.tag.outputs.tag}}.md
+          bodyFile: release-notes/opensearch-jvector-knn.release-notes-${{steps.tag.outputs.tag}}.md

--- a/release-notes/opensearch-jvector-knn.release-notes-3.0.0.0-alpha1.md
+++ b/release-notes/opensearch-jvector-knn.release-notes-3.0.0.0-alpha1.md
@@ -1,0 +1,7 @@
+## What's Changed
+* initial release of jVector KNN plugin
+
+## New Contributors
+* @sam-herman @jimdickinson @tjake @sandoichi
+
+**Full Changelog**: https://github.com/opensearch-project/opensearch-jvector/commits/3.0.0.0-alpha1


### PR DESCRIPTION
### Description
fix release script to find the right release notes format.
Adding release notes generated for [3.0.0.0-alpha](https://github.com/opensearch-project/opensearch-jvector/releases/tag/3.0.0.0-alpha1)

### Related Issues
https://github.com/opensearch-project/.github/issues/311#issuecomment-2769836092

### Check List
- [ x] New functionality includes testing.
- [ x] New functionality has been documented.
- [ x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ x] Commits are signed per the DCO using `--signoff`.
- [ x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
