### PR TITLE
Add jenkinsfile and release drafter action for maven central release

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-and-publish-snapshots:
     runs-on: ubuntu-latest
-
+    if: github.repository == 'opensearch-project/opensearch-jvector'
     permissions:
       id-token: write
       contents: write
@@ -21,8 +21,8 @@ jobs:
         with:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 21
-      - uses: actions/checkout@v3
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
           aws-region: us-east-1

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,52 @@
+name: Release drafter
+
+# Push events to every tag not containing "/"
+#
+# Publish the commons JAR to Maven Local, and create 'artifacts.tar.gz'
+# using build dir and adding the contents of repository
+#
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  draft-a-release:
+    name: Draft a release
+    runs-on: ubuntu-latest
+    if: github.repository == 'opensearch-project/opensearch-jvector'
+    permissions: write-all
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - id: get_data
+        run: |
+          echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '*\n ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT
+          echo "version=$(./gradlew -Dbuild.snapshot=false properties | grep -E '^version:' | awk '{print $2}')" >> $GITHUB_OUTPUT
+      - uses: trstringer/manual-approval@v1
+        with:
+          secret: ${{ github.TOKEN }}
+          approvers: ${{ steps.get_data.outputs.approvers }}
+          minimum-approvals: 2
+          issue-title: 'Release OpenSearch jVector ${{ steps.get_data.outputs.version }}'
+          issue-body: "Please approve or deny the release of OpenSearch jVector **TAG**: ${{ github.ref_name }}  **COMMIT**: ${{ github.sha }} **VERSION** : ${{ steps.get_data.outputs.version }} "
+          exclude-workflow-initiator-as-approver: true
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'temurin'
+          cache: gradle
+      - name: Build with Gradle
+        run: |
+          ./gradlew --no-daemon -Dbuild.snapshot=false publishNebulaPublicationToLocalRepoRepository
+          ./gradlew --no-daemon -Dbuild.snapshot=false publishPluginZipPublicationToLocalRepoRepository
+          tar -C build -cvf artifacts.tar.gz repository
+      - name: Draft a release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          generate_release_notes: true
+          files: |
+            artifacts.tar.gz
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix CVE-2024-57699 by updating json-path dependencies.
 ### Infrastructure
 * Add localrepo / license / scm / developer / description / url for maven central
+* Add jenkinsfile and release drafter action for maven central release
 ### Documentation
 ### Maintenance
 ### Refactoring

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -38,3 +38,23 @@ When releasing a new version, update the `bwc.version` to the latest, previous m
 
 The release process is standard across repositories in this org and is run by a release manager volunteering from amongst [MAINTAINERS](MAINTAINERS.md).
 
+### Standalone Maven Central Release (Before Onboarding Bundle)
+
+**DO NOT cut a tag by going to release section of Github UI. It will mess up the Github Action.**
+
+Note: A maintainer must remember to perform steps 1, 2 and 4 (require total of 3 maintainers, 1 cut tag, 2 approve).
+1. Run these commands from the upstream opensearch-jvector repository, not a forked one: 
+```
+git checkout main
+git fetch origin
+git rebase origin/main
+git tag <version>
+git push origin <version> 
+```
+2. Wait for Github Actions to run and open the newly created issue. Two maintainers should comment `approve` in the issue.
+3. Wait for Jenkins to be triggered, pull the artifacts built by Actions, push to sonatype release channel on remote. Wait for an hour or so for Sonatype to copy it into Maven Central.
+4. Bump [build.gradle](./build.gradle), update [release-notes](./release-notes/), and clean up entries from [CHANGELOG.md](./CHANGELOG.md) via a PR.
+
+
+Thanks.
+

--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -1,0 +1,17 @@
+lib = library(identifier: 'jenkins@1.5.3', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
+
+standardReleasePipelineWithGenericTrigger(
+    overrideDockerImage: 'opensearchstaging/ci-runner:release-centos7-clients-v4',
+    tokenIdCredential: 'jenkins-opensearch-jvector-generic-webhook-token',
+    causeString: 'A tag was cut on opensearch-project/opensearch-jvector repository causing this workflow to run',
+    downloadReleaseAsset: true,
+    publishRelease: true) {
+        publishToMaven(
+            signingArtifactsPath: "$WORKSPACE/repository/",
+            mavenArtifactsPath: "$WORKSPACE/repository/",
+            autoPublish: true
+        )
+    }


### PR DESCRIPTION
### Description
Add jenkinsfile and release drafter action for maven central release

### Related Issues
https://github.com/opensearch-project/.github/issues/312

### Check List
- ~~[ ] New functionality includes testing.~~
- ~~[ ] New functionality has been documented.~~
- ~~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~~
- [x] Commits are signed per the DCO using `--signoff`.
- ~~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
