### PR TITLE
Install jdk21 before running any gradle tasks in release drafter action

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -19,6 +19,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'temurin'
+          cache: gradle
       - id: get_data
         run: |
           echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '*\n ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT
@@ -31,12 +37,6 @@ jobs:
           issue-title: 'Release OpenSearch jVector ${{ steps.get_data.outputs.version }}'
           issue-body: "Please approve or deny the release of OpenSearch jVector **TAG**: ${{ github.ref_name }}  **COMMIT**: ${{ github.sha }} **VERSION** : ${{ steps.get_data.outputs.version }} "
           exclude-workflow-initiator-as-approver: true
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          java-version: 21
-          distribution: 'temurin'
-          cache: gradle
       - name: Build with Gradle
         run: |
           ./gradlew --no-daemon -Dbuild.snapshot=false publishNebulaPublicationToLocalRepoRepository


### PR DESCRIPTION
### Description
Install jdk21 before running any gradle tasks in release drafter action

### Related Issues
https://github.com/opensearch-project/.github/issues/312
```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'opensearch-jvector-plugin'.
> Could not resolve all artifacts for configuration ':classpath'.
   > Could not resolve org.opensearch.gradle:build-tools:3.0.0-alpha1-SNAPSHOT.
     Required by:
         root project :
      > Dependency requires at least JVM runtime version 21. This build uses a Java 17 JVM.

* Try:
> Run this build using a Java 21 or newer JVM.
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org./
```

### Check List
- ~~[ ] New functionality includes testing.~~
- ~~[ ] New functionality has been documented.~~
- ~~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~~
- [x] Commits are signed per the DCO using `--signoff`.
- ~~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
