### PR TITLE
hot fix per KNN field codec selection

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/KNN990PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/KNN990PerFieldKnnVectorsFormat.java
@@ -7,11 +7,15 @@ package org.opensearch.knn.index.codec.KNN990Codec;
 
 import org.apache.lucene.codecs.lucene99.Lucene99HnswScalarQuantizedVectorsFormat;
 import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
+import org.opensearch.common.collect.Tuple;
 import org.opensearch.index.mapper.MapperService;
+import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.codec.BasePerFieldKnnVectorsFormat;
+import org.opensearch.knn.index.codec.jvector.JVectorFormat;
 import org.opensearch.knn.index.engine.KNNEngine;
 
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Class provides per field format implementation for Lucene Knn vector type
@@ -25,10 +29,14 @@ public class KNN990PerFieldKnnVectorsFormat extends BasePerFieldKnnVectorsFormat
             Lucene99HnswVectorsFormat.DEFAULT_MAX_CONN,
             Lucene99HnswVectorsFormat.DEFAULT_BEAM_WIDTH,
             Lucene99HnswVectorsFormat::new,
-            (knnEngine, knnVectorsFormatParams) -> new Lucene99HnswVectorsFormat(
-                knnVectorsFormatParams.getMaxConnections(),
-                knnVectorsFormatParams.getBeamWidth()
-            ),
+            (knnEngine, knnVectorsFormatParams) -> switch (knnEngine) {
+                case LUCENE -> new Lucene99HnswVectorsFormat(
+                        knnVectorsFormatParams.getMaxConnections(),
+                        knnVectorsFormatParams.getBeamWidth());
+                case JVECTOR ->
+                        new JVectorFormat(knnVectorsFormatParams.getMaxConnections(), knnVectorsFormatParams.getBeamWidth());
+                default -> throw new IllegalArgumentException("Unsupported java engine: " + knnEngine);
+            },
             knnScalarQuantizedVectorsFormatParams -> new Lucene99HnswScalarQuantizedVectorsFormat(
                 knnScalarQuantizedVectorsFormatParams.getMaxConnections(),
                 knnScalarQuantizedVectorsFormatParams.getBeamWidth(),

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/KNN990PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/KNN990PerFieldKnnVectorsFormat.java
@@ -7,15 +7,12 @@ package org.opensearch.knn.index.codec.KNN990Codec;
 
 import org.apache.lucene.codecs.lucene99.Lucene99HnswScalarQuantizedVectorsFormat;
 import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
-import org.opensearch.common.collect.Tuple;
 import org.opensearch.index.mapper.MapperService;
-import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.codec.BasePerFieldKnnVectorsFormat;
 import org.opensearch.knn.index.codec.jvector.JVectorFormat;
 import org.opensearch.knn.index.engine.KNNEngine;
 
 import java.util.Optional;
-import java.util.concurrent.ExecutorService;
 
 /**
  * Class provides per field format implementation for Lucene Knn vector type
@@ -31,10 +28,10 @@ public class KNN990PerFieldKnnVectorsFormat extends BasePerFieldKnnVectorsFormat
             Lucene99HnswVectorsFormat::new,
             (knnEngine, knnVectorsFormatParams) -> switch (knnEngine) {
                 case LUCENE -> new Lucene99HnswVectorsFormat(
-                        knnVectorsFormatParams.getMaxConnections(),
-                        knnVectorsFormatParams.getBeamWidth());
-                case JVECTOR ->
-                        new JVectorFormat(knnVectorsFormatParams.getMaxConnections(), knnVectorsFormatParams.getBeamWidth());
+                    knnVectorsFormatParams.getMaxConnections(),
+                    knnVectorsFormatParams.getBeamWidth()
+                );
+                case JVECTOR -> new JVectorFormat(knnVectorsFormatParams.getMaxConnections(), knnVectorsFormatParams.getBeamWidth());
                 default -> throw new IllegalArgumentException("Unsupported java engine: " + knnEngine);
             },
             knnScalarQuantizedVectorsFormatParams -> new Lucene99HnswScalarQuantizedVectorsFormat(


### PR DESCRIPTION
### Description
Hot fix for the per KNN field codec selection. Will send the test to validate the fix on all future releases via `main` and backport to all branches.

### Related Issues
Resolves issue where Lucene is still used as the format even when jVector is selected.

### Testing
`./gadlew clean; ./gradlew build`

Validate jVector format is used:
```bash
sam.herman@Sam-Herman-FP9X7HJYJX opensearch-jvector % ls -lah build/testclusters/integTest-0/data/nodes/0/indices/LEUtL6RgQLqeSClgvSc8eg/0/index 
total 8
drwxr-xr-x@ 10 sam.herman  staff   320B Apr 21 13:50 .
drwxr-xr-x@  5 sam.herman  staff   160B Apr 21 13:50 ..
-rw-r--r--@  1 sam.herman  staff     0B Apr 21 13:50 _0.fdm
-rw-r--r--@  1 sam.herman  staff     0B Apr 21 13:50 _0.fdt
-rw-r--r--@  1 sam.herman  staff     0B Apr 21 13:50 _0_JVectorFormat_0.data-jvector
-rw-r--r--@  1 sam.herman  staff     0B Apr 21 13:50 _0_JVectorFormat_0.meta-jvector
-rw-r--r--@  1 sam.herman  staff     0B Apr 21 13:50 _0_Lucene90FieldsIndex-doc_ids_0.tmp
-rw-r--r--@  1 sam.herman  staff     0B Apr 21 13:50 _0_Lucene90FieldsIndexfile_pointers_1.tmp
-rw-r--r--@  1 sam.herman  staff   208B Apr 21 13:50 segments_2
-rw-r--r--@  1 sam.herman  staff     0B Apr 21 13:50 write.lock
```
### Check List
~- [ ] New functionality includes testing.~
~- [ ] New functionality has been documented.~
~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x ] Commits are signed per the DCO using `--signoff`.
~- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
