### PR TITLE
add regression test for codec detection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -322,8 +322,6 @@ dependencies {
     implementation 'io.github.jbellis:jvector:4.0.0-beta.1'
     implementation 'org.agrona:agrona:1.20.0'
 
-    api "net.java.dev.jna:jna:5.13.0"
-    api "net.java.dev.jna:jna-platform:5.13.0"
     // OpenSearch core is using slf4j 1.7.36. Therefore, we cannot change the version here.
     implementation 'org.slf4j:slf4j-api:1.7.36'
 

--- a/build.gradle
+++ b/build.gradle
@@ -305,6 +305,8 @@ dependencies {
     testFixturesImplementation "org.opensearch.test:framework:${opensearch_version}"
     // Add the high-level client dependency
     testImplementation "org.opensearch.client:opensearch-rest-high-level-client:${opensearch_version}"
+    // Add netty dependency so we can use it within internal test clusters (not just external ones)
+    testImplementation "org.opensearch.plugin:transport-netty4-client:${opensearch_version}"
 
     // json-path 2.9.0 depends on slf4j 2.0.11, which conflicts with the version used by OpenSearch core.
     // Excluding slf4j here since json-path is only used for testing, and logging failures in this context are acceptable.
@@ -330,6 +332,7 @@ dependencies {
 
 test {
     systemProperty 'tests.security.manager', 'false'
+    systemProperty 'opensearch.set.netty.runtime.available.processors', 'false'
     systemProperty 'log4j.configurationFile', "$rootDir/src/test/resources/log4j2.properties"
 
     //this change enables mockito-inline that supports mocking of static classes/calls

--- a/src/test/java/org/opensearch/knn/index/ThreadLeakFiltersForTests.java
+++ b/src/test/java/org/opensearch/knn/index/ThreadLeakFiltersForTests.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index;
+
+import com.carrotsearch.randomizedtesting.ThreadFilter;
+
+/**
+ * Filter for ForkJoinPool worker threads used by JVector
+ * This is used to ignore the ForkJoinPool worker threads used by JVector while still enabling thread leak detection
+ */
+public class ThreadLeakFiltersForTests implements ThreadFilter {
+    @Override
+    public boolean reject(Thread thread) {
+        return thread.getName().startsWith("ForkJoinPool")
+            && (thread.getThreadGroup().getName().contains("InternalKNNEngineTests")
+                || thread.getThreadGroup().getName().startsWith("TGRP-KNNJVectorTests"));
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.knn.index.codec.jvector;
 
-import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.document.*;
 import org.apache.lucene.index.*;
@@ -18,6 +18,7 @@ import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.Assert;
 import org.junit.Test;
+import org.opensearch.knn.index.ThreadLeakFiltersForTests;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -30,7 +31,7 @@ import static org.opensearch.knn.index.codec.jvector.JVectorFormat.DEFAULT_MINIM
 // Currently {@link IndexGraphBuilder} is using the default ForkJoinPool.commonPool() which is not being shutdown.
 // Ignore thread leaks until we remove the ForkJoinPool.commonPool() usage from IndexGraphBuilder
 // TODO: Wire the execution thread pool to {@link IndexGraphBuilder} to avoid the failure of the UT due to leaked thread pool warning.
-@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+@ThreadLeakFilters(defaultFilters = true, filters = { ThreadLeakFiltersForTests.class })
 @LuceneTestCase.SuppressSysoutChecks(bugUrl = "")
 @Log4j2
 public class KNNJVectorTests extends LuceneTestCase {

--- a/src/test/java/org/opensearch/knn/index/engine/CommonTestUtils.java
+++ b/src/test/java/org/opensearch/knn/index/engine/CommonTestUtils.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine;
+
+import com.google.common.collect.ImmutableMap;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.KNNVectorSimilarityFunction;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.opensearch.knn.KNNRestTestCase.FIELD_NAME;
+import static org.opensearch.knn.common.KNNConstants.DISK_ANN;
+import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
+import static org.opensearch.knn.index.KNNSettings.KNN_INDEX;
+
+public class CommonTestUtils {
+    public static final int DIMENSION = 3;
+    public static final String DOC_ID = "doc1";
+    public static final String DOC_ID_2 = "doc2";
+    public static final String DOC_ID_3 = "doc3";
+    public static final int EF_CONSTRUCTION = 128;
+    public static final String COLOR_FIELD_NAME = "color";
+    public static final String TASTE_FIELD_NAME = "taste";
+    public static final int M = 16;
+
+    public static final Float[][] TEST_INDEX_VECTORS = { { 1.0f, 1.0f, 1.0f }, { 2.0f, 2.0f, 2.0f }, { 3.0f, 3.0f, 3.0f } };
+    public static final Float[][] TEST_COSINESIMIL_INDEX_VECTORS = { { 6.0f, 7.0f, 3.0f }, { 3.0f, 2.0f, 5.0f }, { 4.0f, 5.0f, 7.0f } };
+    public static final Float[][] TEST_INNER_PRODUCT_INDEX_VECTORS = {
+        { 1.0f, 1.0f, 1.0f },
+        { 2.0f, 2.0f, 2.0f },
+        { 3.0f, 3.0f, 3.0f },
+        { -1.0f, -1.0f, -1.0f },
+        { -2.0f, -2.0f, -2.0f },
+        { -3.0f, -3.0f, -3.0f } };
+
+    public static final float[][] TEST_QUERY_VECTORS = { { 1.0f, 1.0f, 1.0f }, { 2.0f, 2.0f, 2.0f }, { 3.0f, 3.0f, 3.0f } };
+
+    public static final Map<KNNVectorSimilarityFunction, Function<Float, Float>> VECTOR_SIMILARITY_TO_SCORE = ImmutableMap.of(
+        KNNVectorSimilarityFunction.EUCLIDEAN,
+        (similarity) -> 1 / (1 + similarity),
+        KNNVectorSimilarityFunction.DOT_PRODUCT,
+        (similarity) -> (1 + similarity) / 2,
+        KNNVectorSimilarityFunction.COSINE,
+        (similarity) -> (1 + similarity) / 2,
+        KNNVectorSimilarityFunction.MAXIMUM_INNER_PRODUCT,
+        (similarity) -> similarity <= 0 ? 1 / (1 - similarity) : similarity + 1
+    );
+    public static final String DIMENSION_FIELD_NAME = "dimension";
+    public static final String KNN_VECTOR_TYPE = "knn_vector";
+    public static final String PROPERTIES_FIELD_NAME = "properties";
+    public static final String TYPE_FIELD_NAME = "type";
+    public static final String INTEGER_FIELD_NAME = "int_field";
+    public static final String FILED_TYPE_INTEGER = "integer";
+    public static final String NON_EXISTENT_INTEGER_FIELD_NAME = "nonexistent_int_field";
+
+    public static Settings getDefaultIndexSettings() {
+        return Settings.builder().put("number_of_shards", 1).put("number_of_replicas", 0).put(KNN_INDEX, true).build();
+    }
+
+    public static String createIndexMapping(int dimension, SpaceType spaceType, VectorDataType vectorDataType) throws IOException {
+        XContentBuilder builder = jsonBuilder().startObject()
+            .startObject(PROPERTIES_FIELD_NAME)
+            .startObject(FIELD_NAME)
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, dimension)
+            .field(VECTOR_DATA_TYPE_FIELD, vectorDataType)
+            .startObject(KNNConstants.KNN_METHOD)
+            .field(KNNConstants.NAME, DISK_ANN)
+            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            .field(KNNConstants.KNN_ENGINE, KNNEngine.JVECTOR.getName())
+            .startObject(KNNConstants.PARAMETERS)
+            .field(KNNConstants.METHOD_PARAMETER_M, M)
+            .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, EF_CONSTRUCTION)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        return builder.toString();
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/engine/InternalKNNEngineTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/InternalKNNEngineTests.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
+import org.apache.lucene.index.SegmentReader;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.common.lucene.index.OpenSearchLeafReader;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.engine.Engine;
+import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.ThreadLeakFiltersForTests;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.plugin.JVectorKNNPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.transport.Netty4ModulePlugin;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.opensearch.knn.common.KNNConstants.*;
+import static org.opensearch.knn.index.KNNSettings.KNN_INDEX;
+
+/**
+ * Internal integration tests for k-NN
+ * This allows us to not only test rest cases but also get access to the cluster nodes and files
+ * This becomes very useful when attempting to detect conditions in the cluster internal state or files
+ */
+
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 1)
+@ThreadLeakFilters(defaultFilters = true, filters = { ThreadLeakFiltersForTests.class })
+public class InternalKNNEngineTests extends OpenSearchIntegTestCase {
+
+    /** ** Enable the http client *** */
+    @Override
+    protected boolean addMockHttpTransport() {
+        return false;
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        // Add the JVector plugin to the cluster
+        return List.of(Netty4ModulePlugin.class, JVectorKNNPlugin.class);
+    }
+
+    /**
+     * Test to validate that the mapping to use JVector engine actually creates the right per field index format with JVector.
+     * This test verifies that when JVector engine is specified in the mapping, the index files created use the JVector format.
+     */
+    public void testJVectorEngineCreatesJVectorFormat() throws Exception {
+        // Create an index with JVector engine specified in the mapping
+        createKnnIndexMappingWithJVectorEngine(DIMENSION, SpaceType.L2, VectorDataType.FLOAT);
+
+        // Add a document with a vector
+        Float[] vector = new Float[] { 1.0f, 2.0f, 3.0f };
+        client().prepareIndex(INDEX_NAME).setId(DOC_ID).setSource(FIELD_NAME, vector).get();
+
+        // Refresh the index to ensure the document is searchable
+        refresh(INDEX_NAME);
+        forceMerge(1);
+
+        // Verify the index mapping has JVector engine specified
+        Map<String, Object> indexMapping = getIndexMappingAsMap(INDEX_NAME);
+        Map<String, Object> properties = (Map<String, Object>) indexMapping.get(PROPERTIES_FIELD_NAME);
+        Map<String, Object> fieldMapping = (Map<String, Object>) properties.get(FIELD_NAME);
+        Map<String, Object> methodMapping = (Map<String, Object>) fieldMapping.get(KNNConstants.KNN_METHOD);
+
+        // Verify the engine is set to JVector
+        assertEquals(KNNEngine.JVECTOR.getName(), methodMapping.get(KNN_ENGINE));
+
+        // Verify the index mapping has JVector engine specified and the JVector engine is being used
+        // This checks both the mapping configuration and verifies search functionality
+        boolean jvectorEngineConfirmed = verifyJVectorEngineIsUsed();
+        assertTrue("JVector engine should be confirmed through mapping and index format verification", jvectorEngineConfirmed);
+    }
+
+    private static final int DIMENSION = 3;
+    private static final String DOC_ID = "doc1";
+    private static final int EF_CONSTRUCTION = 128;
+    private static final int M = 16;
+
+    private static final String DIMENSION_FIELD_NAME = "dimension";
+    private static final String KNN_VECTOR_TYPE = "knn_vector";
+    private static final String PROPERTIES_FIELD_NAME = "properties";
+    private static final String TYPE_FIELD_NAME = "type";
+
+    public static final String FIELD_NAME = "test_field";
+
+    public static final String INDEX_NAME = "test_index";
+
+    private void createKnnIndexMappingWithJVectorEngine(int dimension, SpaceType spaceType, VectorDataType vectorDataType)
+        throws Exception {
+        XContentBuilder builder = jsonBuilder().startObject()
+            .startObject(PROPERTIES_FIELD_NAME)
+            .startObject(FIELD_NAME)
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, dimension)
+            .field(VECTOR_DATA_TYPE_FIELD, vectorDataType)
+            .startObject(KNNConstants.KNN_METHOD)
+            .field(KNNConstants.NAME, DISK_ANN)
+            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            .field(KNNConstants.KNN_ENGINE, KNNEngine.JVECTOR.getName())
+            .startObject(KNNConstants.PARAMETERS)
+            .field(KNNConstants.METHOD_PARAMETER_M, M)
+            .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, EF_CONSTRUCTION)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        String mapping = builder.toString();
+        Settings indexSettings = getDefaultIndexSettings();
+        // indexSettings = Settings.builder().put(indexSettings).put(INDEX_USE_COMPOUND_FILE.getKey(), false).build();
+        createKnnIndex(INDEX_NAME, indexSettings, mapping);
+    }
+
+    /**
+     * Create KNN Index
+     */
+    protected void createKnnIndex(String index, Settings settings, String mapping) throws IOException {
+        createIndex(index, settings);
+        putMappingRequest(index, mapping);
+    }
+
+    /**
+     * For a given index, make a mapping request
+     */
+    protected void putMappingRequest(String index, String mapping) throws IOException {
+        // Put KNN mapping
+        Request request = new Request("PUT", "/" + index + "/_mapping");
+
+        request.setJsonEntity(mapping);
+        Response response = getRestClient().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+    }
+
+    protected Settings getDefaultIndexSettings() {
+        return Settings.builder().put("number_of_shards", 1).put("number_of_replicas", 0).put(KNN_INDEX, true).build();
+    }
+
+    /**
+     * Helper method to verify that the JVector engine is being used correctly.
+     * This method verifies that the JVector engine is being used by checking the mapping
+     * and validating the codec and per-field format of the files in the index.
+     *
+     * @return true if JVector engine is confirmed to be in use, false otherwise
+     */
+    private boolean verifyJVectorEngineIsUsed() throws Exception {
+        // We'll verify the JVector engine is being used by checking:
+        // 1. The mapping has a JVector engine specified
+        // 2. The files in the index are readable by the JVector codec
+
+        // Check the mapping to verify JVector engine is specified
+        Map<String, Object> indexMapping = getIndexMappingAsMap(INDEX_NAME);
+        Map<String, Object> properties = (Map<String, Object>) indexMapping.get(PROPERTIES_FIELD_NAME);
+        Map<String, Object> fieldMapping = (Map<String, Object>) properties.get(FIELD_NAME);
+        Map<String, Object> methodMapping = (Map<String, Object>) fieldMapping.get(KNNConstants.KNN_METHOD);
+
+        boolean jvectorEngineInMapping = KNNEngine.JVECTOR.getName().equals(methodMapping.get(KNN_ENGINE));
+        logger.info("JVector engine specified in mapping: {}", jvectorEngineInMapping);
+
+        // Get index files
+        final ShardRouting shardRouting = internalCluster().clusterService().state().routingTable().allShards(INDEX_NAME).get(0);
+        try (Engine.Searcher indexSearcher = getIndexShard(shardRouting, INDEX_NAME).acquireSearcher("verify_jvector_engine_is_used")) {
+            indexSearcher.getLeafContexts().forEach(leafContext -> {
+                // Check the index files to verify JVector codec is being used
+                var vectorReader = ((SegmentReader) (((OpenSearchLeafReader) leafContext.reader()).getDelegate())).getVectorReader();
+                assertTrue(vectorReader instanceof PerFieldKnnVectorsFormat.FieldsReader);
+                var perFieldReader = ((PerFieldKnnVectorsFormat.FieldsReader) vectorReader).getFieldReader(FIELD_NAME);
+                assertTrue("JVector codec should be used", perFieldReader instanceof org.opensearch.knn.index.codec.jvector.JVectorReader);
+            });
+        }
+
+        // If both the mapping specifies JVector engine and the index stats show JVector files, then we can confirm JVector is being used
+        return jvectorEngineInMapping;
+    }
+
+    /**
+     * Get index mapping as map
+     *
+     * @param index name of index to fetch
+     * @return index mapping a map
+     */
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> getIndexMappingAsMap(String index) throws Exception {
+        Request request = new Request("GET", "/" + index + "/_mapping");
+
+        Response response = getRestClient().performRequest(request);
+
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+
+        String responseBody = EntityUtils.toString(response.getEntity());
+
+        Map<String, Object> responseMap = createParser(MediaTypeRegistry.getDefaultMediaType().xContent(), responseBody).map();
+
+        return (Map<String, Object>) ((Map<String, Object>) responseMap.get(index)).get("mappings");
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/engine/JVectorEngineIT.java
+++ b/src/test/java/org/opensearch/knn/index/engine/JVectorEngineIT.java
@@ -25,7 +25,6 @@ import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.TestUtils;
 import org.opensearch.knn.common.KNNConstants;
-import org.opensearch.knn.index.KNNVectorSimilarityFunction;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
@@ -33,54 +32,14 @@ import org.opensearch.knn.index.query.KNNQueryBuilder;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.opensearch.index.engine.EngineConfig.INDEX_USE_COMPOUND_FILE;
 import static org.opensearch.knn.common.KNNConstants.DISK_ANN;
-import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
+import static org.opensearch.knn.index.engine.CommonTestUtils.*;
 
 public class JVectorEngineIT extends KNNRestTestCase {
-
-    private static final int DIMENSION = 3;
-    private static final String DOC_ID = "doc1";
-    private static final String DOC_ID_2 = "doc2";
-    private static final String DOC_ID_3 = "doc3";
-    private static final int EF_CONSTRUCTION = 128;
-    private static final String COLOR_FIELD_NAME = "color";
-    private static final String TASTE_FIELD_NAME = "taste";
-    private static final int M = 16;
-
-    private static final Float[][] TEST_INDEX_VECTORS = { { 1.0f, 1.0f, 1.0f }, { 2.0f, 2.0f, 2.0f }, { 3.0f, 3.0f, 3.0f } };
-    private static final Float[][] TEST_COSINESIMIL_INDEX_VECTORS = { { 6.0f, 7.0f, 3.0f }, { 3.0f, 2.0f, 5.0f }, { 4.0f, 5.0f, 7.0f } };
-    private static final Float[][] TEST_INNER_PRODUCT_INDEX_VECTORS = {
-        { 1.0f, 1.0f, 1.0f },
-        { 2.0f, 2.0f, 2.0f },
-        { 3.0f, 3.0f, 3.0f },
-        { -1.0f, -1.0f, -1.0f },
-        { -2.0f, -2.0f, -2.0f },
-        { -3.0f, -3.0f, -3.0f } };
-
-    private static final float[][] TEST_QUERY_VECTORS = { { 1.0f, 1.0f, 1.0f }, { 2.0f, 2.0f, 2.0f }, { 3.0f, 3.0f, 3.0f } };
-
-    private static final Map<KNNVectorSimilarityFunction, Function<Float, Float>> VECTOR_SIMILARITY_TO_SCORE = ImmutableMap.of(
-        KNNVectorSimilarityFunction.EUCLIDEAN,
-        (similarity) -> 1 / (1 + similarity),
-        KNNVectorSimilarityFunction.DOT_PRODUCT,
-        (similarity) -> (1 + similarity) / 2,
-        KNNVectorSimilarityFunction.COSINE,
-        (similarity) -> (1 + similarity) / 2,
-        KNNVectorSimilarityFunction.MAXIMUM_INNER_PRODUCT,
-        (similarity) -> similarity <= 0 ? 1 / (1 - similarity) : similarity + 1
-    );
-    private static final String DIMENSION_FIELD_NAME = "dimension";
-    private static final String KNN_VECTOR_TYPE = "knn_vector";
-    private static final String PROPERTIES_FIELD_NAME = "properties";
-    private static final String TYPE_FIELD_NAME = "type";
-    private static final String INTEGER_FIELD_NAME = "int_field";
-    private static final String FILED_TYPE_INTEGER = "integer";
-    private static final String NON_EXISTENT_INTEGER_FIELD_NAME = "nonexistent_int_field";
 
     @After
     public final void cleanUp() throws IOException {
@@ -565,27 +524,8 @@ public class JVectorEngineIT extends KNNRestTestCase {
 
     private void createKnnIndexMappingWithJVectorEngine(int dimension, SpaceType spaceType, VectorDataType vectorDataType)
         throws Exception {
-        XContentBuilder builder = jsonBuilder().startObject()
-            .startObject(PROPERTIES_FIELD_NAME)
-            .startObject(FIELD_NAME)
-            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
-            .field(DIMENSION_FIELD_NAME, dimension)
-            .field(VECTOR_DATA_TYPE_FIELD, vectorDataType)
-            .startObject(KNNConstants.KNN_METHOD)
-            .field(KNNConstants.NAME, DISK_ANN)
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.JVECTOR.getName())
-            .startObject(KNNConstants.PARAMETERS)
-            .field(KNNConstants.METHOD_PARAMETER_M, M)
-            .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, EF_CONSTRUCTION)
-            .endObject()
-            .endObject()
-            .endObject()
-            .endObject()
-            .endObject();
-
-        String mapping = builder.toString();
-        Settings indexSettings = getDefaultIndexSettings();
+        String mapping = CommonTestUtils.createIndexMapping(dimension, spaceType, vectorDataType);
+        Settings indexSettings = CommonTestUtils.getDefaultIndexSettings();
         // indexSettings = Settings.builder().put(indexSettings).put(INDEX_USE_COMPOUND_FILE.getKey(), false).build();
         createKnnIndex(INDEX_NAME, indexSettings, mapping);
     }
@@ -607,7 +547,7 @@ public class JVectorEngineIT extends KNNRestTestCase {
 
     private void validateQueries(SpaceType spaceType, String fieldName, Map<String, ?> methodParameters) throws Exception {
 
-        int k = JVectorEngineIT.TEST_INDEX_VECTORS.length;
+        int k = CommonTestUtils.TEST_INDEX_VECTORS.length;
         for (float[] queryVector : TEST_QUERY_VECTORS) {
             Response response = searchKNNIndex(INDEX_NAME, buildSearchQuery(fieldName, k, queryVector, methodParameters), k);
             String responseBody = EntityUtils.toString(response.getEntity());

--- a/src/test/java/org/opensearch/knn/index/engine/JVectorEngineIT.java
+++ b/src/test/java/org/opensearch/knn/index/engine/JVectorEngineIT.java
@@ -29,7 +29,6 @@ import org.opensearch.knn.index.KNNVectorSimilarityFunction;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
-import org.opensearch.test.OpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.util.*;
@@ -42,7 +41,6 @@ import static org.opensearch.index.engine.EngineConfig.INDEX_USE_COMPOUND_FILE;
 import static org.opensearch.knn.common.KNNConstants.DISK_ANN;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 
-@OpenSearchIntegTestCase.ClusterScope(numDataNodes = 1)
 public class JVectorEngineIT extends KNNRestTestCase {
 
     private static final int DIMENSION = 3;


### PR DESCRIPTION
### Description
- Adding a regression test for codec detection. This allows us to detect bugs in which mapping doesn't correspond to the actual codec used. Follow up to the [hot-fix for 2.19](https://github.com/opensearch-project/opensearch-jvector/pull/41)
- Add thread leak filter so we don't have to disable thread leak detections due to ForkJoinPool in jVector
- Remove additional unused dependencies carried over from the original KNN plugin

### Related Issues
Follow up to the [hot-fix for 2.19](https://github.com/opensearch-project/opensearch-jvector/pull/41)

### Check List
~- [ ] New functionality includes testing.~
~- [ ] New functionality has been documented.~
~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [ x] Commits are signed per the DCO using `--signoff`.
~- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
