### PR TITLE
fix: Use compression for the artifacts.tar.gz

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           ./gradlew --no-daemon -Dbuild.snapshot=false publishNebulaPublicationToLocalRepoRepository
           ./gradlew --no-daemon -Dbuild.snapshot=false publishPluginZipPublicationToLocalRepoRepository
-          tar -C build -cvf artifacts.tar.gz repository
+          tar -C build -czvf artifacts.tar.gz repository
       - name: Draft a release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
### Description
Without the z flag, we're getting an uncompressed tar file.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
