### PR TITLE
upgrade to OpenSearch 3.0.0-SNAPSHOT and remove security manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 3.0](https://github.com/opensearch-project/k-NN/compare/2.x...HEAD)
 ### Features
+* upgrade to opensearch 3.0.0-SNAPSHOT and remove Java SecurityManager
 ### Enhancements
 ### Bug Fixes
 * Fix CVE-2024-57699 by updating json-path dependencies.

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
     ext {
         // build.version_qualifier parameter applies to knn plugin artifacts only. OpenSearch version must be set
         // explicitly as 'opensearch.version' property, for instance opensearch.version=2.0.0-rc1-SNAPSHOT
-        opensearch_version = System.getProperty("opensearch.version", "3.0.0-alpha1-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
         version_qualifier = System.getProperty("build.version_qualifier", "alpha1")
         opensearch_group = "org.opensearch"
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")

--- a/src/main/java/org/opensearch/knn/plugin/JVectorKNNPlugin.java
+++ b/src/main/java/org/opensearch/knn/plugin/JVectorKNNPlugin.java
@@ -61,10 +61,6 @@ import org.opensearch.threadpool.FixedExecutorBuilder;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.watcher.ResourceWatcherService;
 
-import java.security.AccessController;
-import java.security.AllPermission;
-import java.security.Permission;
-import java.security.PrivilegedAction;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -123,21 +119,6 @@ public class JVectorKNNPlugin extends Plugin
 
     public JVectorKNNPlugin() {
         super();
-        /*
-         * Work around to avoid security manager checks
-         */
-        AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
-            System.setSecurityManager(new SecurityManager() {
-
-                @Override
-                public void checkPermission(Permission perm) {
-                    if (perm instanceof AllPermission) {
-                        throw new SecurityException();
-                    }
-                }
-            });
-            return null;
-        });
     }
 
     @Override


### PR DESCRIPTION
### Description
upgrade to OpenSearch 3.0.0-SNAPSHOT and remove security manager.
Required to prepare for a 3.0 branch and 3.0.0.0 release.

### Check List
- [x ] New functionality includes testing.
- [ x] New functionality has been documented.
~-[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x ] Commits are signed per the DCO using `--signoff`.
~- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
