### PR TITLE
upgrade to latest jvector, java 22, OpenSearch 3.0.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,7 +36,7 @@ jobs:
   Build-k-NN-Linux:
     strategy:
       matrix:
-        java: [21, 23]
+        java: [22, 23]
 
     env:
        CC: gcc10-gcc
@@ -81,7 +81,7 @@ jobs:
   Build-k-NN-MacOS:
     strategy:
       matrix:
-        java: [21, 23]
+        java: [22, 23]
 
     name: Build and Test jVector k-NN Plugin on MacOS
     needs: Get-CI-Image-Tag
@@ -104,7 +104,7 @@ jobs:
   Build-k-NN-Windows:
     strategy:
       matrix:
-        java: [21, 23]
+        java: [22, 23]
 
     name: Build and Test jVector k-NN Plugin on Windows
     needs: Get-CI-Image-Tag

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -36,7 +36,7 @@ jobs:
   integ-test-with-security-linux:
     strategy:
       matrix:
-        java: [21]
+        java: [22]
     env:
        CC: gcc10-gcc
        CXX: gcc10-g++

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 * upgrade to opensearch 3.0.0-SNAPSHOT and remove Java SecurityManager
 ### Enhancements
+* Upgrade to java 22 so that we can use Foreign Memory API and MemorySegmentReader
 ### Bug Fixes
 * Fix CVE-2024-57699 by updating json-path dependencies.
 * Fix concurrency issue [#50](https://github.com/opensearch-project/opensearch-jvector/issues/50)

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -39,18 +39,18 @@ git clone https://github.com/[your username]/OpenSearch.git
 
 ### Install Prerequisites
 
-#### JDK 21
+#### JDK 22+
 
-OpenSearch builds using Java 21 at a minimum. This means you must have a JDK 21 installed with the environment variable 
-`JAVA_HOME` referencing the path to Java home for your JDK 21 installation, e.g. `JAVA_HOME=/usr/lib/jvm/jdk-21`.
+OpenSearch builds using Java 21 at a minimum with 22+ recommended. For this plugin you must have a JDK 22+ installed with the environment variable 
+`JAVA_HOME` referencing the path to Java home for your JDK 22 installation, e.g. `JAVA_HOME=/usr/lib/jvm/jdk-22`.
 
-One easy way to get Java 21 on *nix is to use [sdkman](https://sdkman.io/).
+One easy way to get Java 22 on *nix is to use [sdkman](https://sdkman.io/).
 
 ```bash
 curl -s "https://get.sdkman.io" | bash
 source ~/.sdkman/bin/sdkman-init.sh
-sdk install java 21.0.2-open
-sdk use java 21.0.2-open
+sdk install java 22.0.2-open
+sdk use java 22.0.2-open
 ```
 Next, obtain a minimum distribution tarball of the jVector k-NN version you want to build:
 
@@ -113,10 +113,10 @@ Please follow these formatting guidelines:
 OpenSearch k-NN uses a [Gradle](https://docs.gradle.org/6.6.1/userguide/userguide.html) wrapper for its build. 
 Run `gradlew` on Unix systems.
 
-Tests use `JAVA21_HOME` environment variable, make sure to add it in the export path else the tests might fail. 
+Tests use `JAVA22_HOME` environment variable, make sure to add it in the export path else the tests might fail. 
 e.g 
 ```
-echo "export JAVA21_HOME=<JDK21 path>" >> ~/.zshrc
+echo "export JAVA22_HOME=<JDK22 path>" >> ~/.zshrc
 source ~/.zshrc
 ```
 

--- a/benchmark-jmh/build.gradle
+++ b/benchmark-jmh/build.gradle
@@ -21,6 +21,7 @@ def awssdk_version="2.21.10"
 configurations.all {
     resolutionStrategy {
         force 'org.apache.commons:commons-math3:3.6.1'  // Force the newer version
+        force 'org.ow2.asm:asm:9.7.1'  // Force the newer ASM version
     }
 }
 
@@ -37,7 +38,7 @@ dependencies {
     api "org.apache.logging.log4j:log4j-core:${versions.log4j}"
 
     // Add other dependencies from main project that are needed for benchmarks
-    implementation 'io.github.jbellis:jvector:4.0.0-beta.1'
+    implementation "io.github.jbellis:jvector:${jvector_version}"
     implementation 'org.agrona:agrona:1.20.0'
 
     //testImplementation "org.opensearch.test:framework:${opensearch_version}"
@@ -114,6 +115,6 @@ jmh {
 
 // Ensure Java compatibility matches the main project
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_22
+    targetCompatibility = JavaVersion.VERSION_22
 }

--- a/benchmark-jmh/src/jmh/java/org/opensearch/knn/index/codec/jvector/datasets/MMapReader.java
+++ b/benchmark-jmh/src/jmh/java/org/opensearch/knn/index/codec/jvector/datasets/MMapReader.java
@@ -54,7 +54,16 @@ public class MMapReader implements RandomAccessReader {
     }
 
     @Override
-    public float readFloat() throws IOException {
+    public long readLong() {
+        try {
+            return buffer.memory().getLong(position);
+        } finally {
+            position += Long.BYTES;
+        }
+    }
+
+    @Override
+    public float readFloat() {
         try {
             return buffer.memory().getFloat(position);
         } finally {

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
         // build.version_qualifier parameter applies to knn plugin artifacts only. OpenSearch version must be set
         // explicitly as 'opensearch.version' property, for instance opensearch.version=2.0.0-rc1-SNAPSHOT
         opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
-        version_qualifier = System.getProperty("build.version_qualifier", "alpha1")
+        version_qualifier = System.getProperty("build.version_qualifier", "")
         opensearch_group = "org.opensearch"
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 
@@ -58,7 +58,7 @@ plugins {
     id 'java-test-fixtures'
     id 'idea'
     id "com.diffplug.spotless" version "6.25.0" apply false
-    id 'io.freefair.lombok' version '8.4'
+    id 'io.freefair.lombok' version '8.13.1'
     id "de.undercouch.download" version "5.3.0"
     id "me.champeau.jmh" version "0.7.1"
 }
@@ -164,6 +164,7 @@ def getBreakerSetting() {
     return System.getProperty(propertyKeys.breaker.useRealMemory, 'true')
 }
 
+
 allprojects {
     group = 'org.opensearch.knn'
     version = opensearch_version.tokenize('-')[0] + '.0'
@@ -175,7 +176,7 @@ allprojects {
     }
     apply from: rootProject.file('build-tools/repositories.gradle').absoluteFile
     plugins.withId('java') {
-        sourceCompatibility = targetCompatibility = "21"
+        sourceCompatibility = targetCompatibility = java_release_version
     }
 
     afterEvaluate {
@@ -248,12 +249,15 @@ publishing {
 /*** Setting up lombok in compiler args ***/
 compileJava {
     options.compilerArgs.addAll(["-processor", 'lombok.launch.AnnotationProcessorHider$AnnotationProcessor'])
+    options.release = java_release_version.toInteger()
 }
 compileTestJava {
     options.compilerArgs.addAll(["-processor", 'lombok.launch.AnnotationProcessorHider$AnnotationProcessor'])
+    options.release = java_release_version.toInteger()
 }
 compileTestFixturesJava {
     options.compilerArgs.addAll(["-processor", 'lombok.launch.AnnotationProcessorHider$AnnotationProcessor'])
+    options.release = java_release_version.toInteger()
 }
 
 /*** End of lombok setup ***/
@@ -322,7 +326,8 @@ dependencies {
     testFixturesImplementation "org.opensearch:common-utils:${version}"
     implementation 'com.github.oshi:oshi-core:6.4.13'
 
-    implementation 'io.github.jbellis:jvector:4.0.0-beta.1'
+    implementation "io.github.jbellis:jvector:${jvector_version}"
+    //api "io.github.jbellis:jvector-native:${jvector_version}"
     implementation 'org.agrona:agrona:1.20.0'
 
     // OpenSearch core is using slf4j 1.7.36. Therefore, we cannot change the version here.
@@ -335,6 +340,18 @@ test {
     systemProperty 'tests.security.manager', 'false'
     systemProperty 'opensearch.set.netty.runtime.available.processors', 'false'
     systemProperty 'log4j.configurationFile', "$rootDir/src/test/resources/log4j2.properties"
+
+    // Enable preview features for Foreign Memory API
+    jvmArgs = [
+            '--add-modules', 'jdk.incubator.vector',
+            '--add-opens', 'java.base/java.nio=ALL-UNNAMED',
+            '--add-opens', 'java.base/sun.nio.ch=ALL-UNNAMED',
+            '-Djdk.incubator.foreign.restricted=permit',
+            '--enable-native-access=ALL-UNNAMED',
+            '-Dio.netty.tryReflectionSetAccessible=true',
+            '--enable-preview'
+    ]
+
 
     //this change enables mockito-inline that supports mocking of static classes/calls
     systemProperty "jdk.attach.allowAttachSelf", true
@@ -486,5 +503,4 @@ task updateVersion {
         }
     }
 }
-
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,9 +5,17 @@
 
 version=1.0.0
 systemProp.bwc.version=1.3.4
+jvector_version=4.0.0-beta.4
+java_release_version=22
 
-#org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+# org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
 #  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
 #  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
 #  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
-#  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+#  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+#  --enable-native-access=ALL-UNNAMED \
+#  --add-opens java.base/java.nio=ALL-UNNAMED \
+#  --add-opens java.base/sun.nio.ch=ALL-UNNAMED \
+#  --add-opens java.base/jdk.internal.ref=ALL-UNNAMED \
+#  --enable-preview \
+#  -Djdk.incubator.foreign.restricted=permit

--- a/qa/build.gradle
+++ b/qa/build.gradle
@@ -48,8 +48,8 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
 
 allprojects {
     java {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
+        sourceCompatibility = JavaVersion.VERSION_22
+        targetCompatibility = JavaVersion.VERSION_22
     }
 }
 

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFloatVectorValues.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFloatVectorValues.java
@@ -50,7 +50,7 @@ public class JVectorFloatVectorValues extends FloatVectorValues {
     public DocIndexIterator iterator() {
         return new DocIndexIterator() {
             private int docId = -1;
-            private final NodesIterator nodesIterator = onDiskGraphIndex.getNodes();
+            private final NodesIterator nodesIterator = onDiskGraphIndex.getNodes(0);
 
             @Override
             public long cost() {

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
@@ -24,7 +24,7 @@ import org.apache.lucene.store.*;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.IOUtils;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
-import io.github.jbellis.jvector.disk.ReaderSupplierFactory;
+import io.github.jbellis.jvector.disk.MemorySegmentReader;
 import org.opensearch.knn.index.codec.KNN80Codec.KNN80CompoundDirectory;
 
 import java.io.IOException;
@@ -232,7 +232,7 @@ public class JVectorReader extends KnnVectorsReader {
             }
 
             // Load the graph index
-            this.readerSupplier = ReaderSupplierFactory.open(indexFilePath);
+            this.readerSupplier = new MemorySegmentReader.Supplier(indexFilePath);
             this.index = OnDiskGraphIndex.load(readerSupplier, sliceOffset + vectorIndexOffset);
             // If quantized load the compressed product quantized vectors with their codebooks
             if (pqCodebooksAndVectorsLength > 0) {

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -11,6 +11,9 @@ import io.github.jbellis.jvector.graph.ListRandomAccessVectorValues;
 import io.github.jbellis.jvector.graph.OnHeapGraphIndex;
 import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
 import io.github.jbellis.jvector.graph.disk.*;
+import io.github.jbellis.jvector.graph.disk.feature.Feature;
+import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
+import io.github.jbellis.jvector.graph.disk.feature.InlineVectors;
 import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
 import io.github.jbellis.jvector.quantization.ProductQuantization;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
@@ -399,7 +402,8 @@ public class JVectorWriter extends KnnVectorsWriter {
                 maxConn,
                 beamWidth,
                 degreeOverflow,
-                alpha
+                alpha,
+                false
             );
         }
 

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
@@ -15,6 +15,7 @@ import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.FSLockFactory;
 import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.tests.mockfile.FixedFSProvider;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.Assert;
 import org.junit.Test;
@@ -35,6 +36,11 @@ import static org.opensearch.knn.index.codec.jvector.JVectorFormat.DEFAULT_MINIM
 @LuceneTestCase.SuppressSysoutChecks(bugUrl = "")
 @Log4j2
 public class KNNJVectorTests extends LuceneTestCase {
+    static {
+        System.setProperty("io.netty.tryReflectionSetAccessible", "true");
+        // This enables the new memory mapping API
+        System.setProperty("jdk.incubator.foreign.restricted", "permit");
+    }
 
     /**
      * Test to verify that the JVector codec is able to successfully search for the nearest neighbours
@@ -53,7 +59,9 @@ public class KNNJVectorTests extends LuceneTestCase {
         indexWriterConfig.setUseCompoundFile(false);
         indexWriterConfig.setCodec(new JVectorCodec());
         indexWriterConfig.setMergePolicy(new ForceMergesOnlyMergePolicy());
-        final Path indexPath = createTempDir();
+        final Path luceneWrappedIndexPath = createTempDir();
+        // switch to {@link FixedFSProvider} to avoid the failure of the UT due to the {@link FileChannel#map(...)} function
+        final Path indexPath = new FixedFSProvider(luceneWrappedIndexPath.getFileSystem()).wrapPath(luceneWrappedIndexPath);
         log.info("Index path: {}", indexPath);
         try (Directory dir = newFSDirectory(indexPath); RandomIndexWriter w = new RandomIndexWriter(random(), dir, indexWriterConfig)) {
             final float[] target = new float[] { 0.0f, 0.0f };
@@ -116,7 +124,9 @@ public class KNNJVectorTests extends LuceneTestCase {
         indexWriterConfig.setUseCompoundFile(false);
         indexWriterConfig.setCodec(new JVectorCodec());
         indexWriterConfig.setMergePolicy(new ForceMergesOnlyMergePolicy(false));
-        final Path indexPath = createTempDir();
+        final Path luceneWrappedIndexPath = createTempDir();
+        // switch to {@link FixedFSProvider} to avoid the failure of the UT due to the {@link FileChannel#map(...)} function
+        final Path indexPath = new FixedFSProvider(luceneWrappedIndexPath.getFileSystem()).wrapPath(luceneWrappedIndexPath);
         log.info("Index path: {}", indexPath);
         try (
             FSDirectory dir = new NIOFSDirectory(indexPath, FSLockFactory.getDefault());
@@ -182,7 +192,9 @@ public class KNNJVectorTests extends LuceneTestCase {
         indexWriterConfig.setCodec(new JVectorCodec());
         indexWriterConfig.setMergePolicy(new ForceMergesOnlyMergePolicy());
         indexWriterConfig.setMergeScheduler(new SerialMergeScheduler());
-        final Path indexPath = createTempDir();
+        final Path luceneWrappedIndexPath = createTempDir();
+        // switch to {@link FixedFSProvider} to avoid the failure of the UT due to the {@link FileChannel#map(...)} function
+        final Path indexPath = new FixedFSProvider(luceneWrappedIndexPath.getFileSystem()).wrapPath(luceneWrappedIndexPath);
         log.info("Index path: {}", indexPath);
         try (
             FSDirectory dir = new NIOFSDirectory(indexPath, FSLockFactory.getDefault());
@@ -254,7 +266,9 @@ public class KNNJVectorTests extends LuceneTestCase {
         indexWriterConfig.setCodec(new JVectorCodec());
         indexWriterConfig.setMergePolicy(new ForceMergesOnlyMergePolicy());
         indexWriterConfig.setMergeScheduler(new SerialMergeScheduler());
-        final Path indexPath = createTempDir();
+        final Path luceneWrappedIndexPath = createTempDir();
+        // switch to {@link FixedFSProvider} to avoid the failure of the UT due to the {@link FileChannel#map(...)} function
+        final Path indexPath = new FixedFSProvider(luceneWrappedIndexPath.getFileSystem()).wrapPath(luceneWrappedIndexPath);
         log.info("Index path: {}", indexPath);
         try (
             FSDirectory dir = new NIOFSDirectory(indexPath, FSLockFactory.getDefault());
@@ -329,7 +343,9 @@ public class KNNJVectorTests extends LuceneTestCase {
         indexWriterConfig.setCodec(new JVectorCodec());
         indexWriterConfig.setMergePolicy(new ForceMergesOnlyMergePolicy(true));
         indexWriterConfig.setMergeScheduler(new SerialMergeScheduler());
-        final Path indexPath = createTempDir();
+        final Path luceneWrappedIndexPath = createTempDir();
+        // switch to {@link FixedFSProvider} to avoid the failure of the UT due to the {@link FileChannel#map(...)} function
+        final Path indexPath = new FixedFSProvider(luceneWrappedIndexPath.getFileSystem()).wrapPath(luceneWrappedIndexPath);
         log.info("Index path: {}", indexPath);
         try (
             FSDirectory dir = new NIOFSDirectory(indexPath, FSLockFactory.getDefault());
@@ -399,7 +415,9 @@ public class KNNJVectorTests extends LuceneTestCase {
         indexWriterConfig.setCodec(new JVectorCodec());
         indexWriterConfig.setMergePolicy(new ForceMergesOnlyMergePolicy(true));
         indexWriterConfig.setMergeScheduler(new SerialMergeScheduler());
-        final Path indexPath = createTempDir();
+        final Path luceneWrappedIndexPath = createTempDir();
+        // switch to {@link FixedFSProvider} to avoid the failure of the UT due to the {@link FileChannel#map(...)} function
+        final Path indexPath = new FixedFSProvider(luceneWrappedIndexPath.getFileSystem()).wrapPath(luceneWrappedIndexPath);
         log.info("Index path: {}", indexPath);
         try (
             FSDirectory dir = new NIOFSDirectory(indexPath, FSLockFactory.getDefault());
@@ -462,7 +480,9 @@ public class KNNJVectorTests extends LuceneTestCase {
         indexWriterConfig.setUseCompoundFile(false);
         indexWriterConfig.setCodec(new JVectorCodec());
         indexWriterConfig.setMergePolicy(new ForceMergesOnlyMergePolicy());
-        final Path indexPath = createTempDir();
+        final Path luceneWrappedIndexPath = createTempDir();
+        // switch to {@link FixedFSProvider} to avoid the failure of the UT due to the {@link FileChannel#map(...)} function
+        final Path indexPath = new FixedFSProvider(luceneWrappedIndexPath.getFileSystem()).wrapPath(luceneWrappedIndexPath);
         log.info("Index path: {}", indexPath);
         try (Directory dir = newFSDirectory(indexPath); RandomIndexWriter w = new RandomIndexWriter(random(), dir, indexWriterConfig)) {
             final byte[] source = new byte[] { (byte) 0, (byte) 0 };
@@ -485,7 +505,9 @@ public class KNNJVectorTests extends LuceneTestCase {
         indexWriterConfig.setUseCompoundFile(false);
         indexWriterConfig.setCodec(new JVectorCodec());
         indexWriterConfig.setMergePolicy(new ForceMergesOnlyMergePolicy());
-        final Path indexPath = createTempDir();
+        final Path luceneWrappedIndexPath = createTempDir();
+        // switch to {@link FixedFSProvider} to avoid the failure of the UT due to the {@link FileChannel#map(...)} function
+        final Path indexPath = new FixedFSProvider(luceneWrappedIndexPath.getFileSystem()).wrapPath(luceneWrappedIndexPath);
         log.info("Index path: {}", indexPath);
         try (Directory dir = newFSDirectory(indexPath); RandomIndexWriter w = new RandomIndexWriter(random(), dir, indexWriterConfig)) {
             final float[] target = new float[] { 0.0f, 0.0f };
@@ -548,7 +570,9 @@ public class KNNJVectorTests extends LuceneTestCase {
         indexWriterConfig.setMaxBufferedDocs(10000); // force flush every 10000 docs, this way we make sure that we only have a single
                                                      // segment for a totalNumberOfDocs < 1000
         indexWriterConfig.setRAMPerThreadHardLimitMB(1000); // 1000MB per thread, this way we make sure that no premature flush will occur
-        final Path indexPath = createTempDir();
+        final Path luceneWrappedIndexPath = createTempDir();
+        // switch to {@link FixedFSProvider} to avoid the failure of the UT due to the {@link FileChannel#map(...)} function
+        final Path indexPath = new FixedFSProvider(luceneWrappedIndexPath.getFileSystem()).wrapPath(luceneWrappedIndexPath);
         log.info("Index path: {}", indexPath);
         try (
             FSDirectory dir = new NIOFSDirectory(indexPath, FSLockFactory.getDefault());
@@ -641,7 +665,9 @@ public class KNNJVectorTests extends LuceneTestCase {
         indexWriterConfig.setMaxBufferedDocs(10000); // force flush every 10000 docs, this way we make sure that we only have a single
         // segment for a totalNumberOfDocs < 1000
         indexWriterConfig.setRAMPerThreadHardLimitMB(1000); // 1000MB per thread, this way we make sure that no premature flush will occur
-        final Path indexPath = createTempDir();
+        final Path luceneWrappedIndexPath = createTempDir();
+        // switch to {@link FixedFSProvider} to avoid the failure of the UT due to the {@link FileChannel#map(...)} function
+        final Path indexPath = new FixedFSProvider(luceneWrappedIndexPath.getFileSystem()).wrapPath(luceneWrappedIndexPath);
         log.info("Index path: {}", indexPath);
         try (
             FSDirectory dir = new NIOFSDirectory(indexPath, FSLockFactory.getDefault());
@@ -738,7 +764,9 @@ public class KNNJVectorTests extends LuceneTestCase {
         indexWriterConfig.setMaxBufferedDocs(10000); // force flush every 10000 docs, this way we make sure that we only have a single
         // segment for a totalNumberOfDocs < 1000
         indexWriterConfig.setRAMPerThreadHardLimitMB(1000); // 1000MB per thread, this way we make sure that no premature flush will occur
-        final Path indexPath = createTempDir();
+        final Path luceneWrappedIndexPath = createTempDir();
+        // switch to {@link FixedFSProvider} to avoid the failure of the UT due to the {@link FileChannel#map(...)} function
+        final Path indexPath = new FixedFSProvider(luceneWrappedIndexPath.getFileSystem()).wrapPath(luceneWrappedIndexPath);
         log.info("Index path: {}", indexPath);
         try (
             FSDirectory dir = new NIOFSDirectory(indexPath, FSLockFactory.getDefault());
@@ -836,7 +864,9 @@ public class KNNJVectorTests extends LuceneTestCase {
         indexWriterConfig.setMaxBufferedDocs(10000); // force flush every 10000 docs, this way we make sure that we only have a single
         // segment for a totalNumberOfDocs < 1000
         indexWriterConfig.setRAMPerThreadHardLimitMB(1000); // 1000MB per thread, this way we make sure that no premature flush will occur
-        final Path indexPath = createTempDir();
+        final Path luceneWrappedIndexPath = createTempDir();
+        // switch to {@link FixedFSProvider} to avoid the failure of the UT due to the {@link FileChannel#map(...)} function
+        final Path indexPath = new FixedFSProvider(luceneWrappedIndexPath.getFileSystem()).wrapPath(luceneWrappedIndexPath);
         log.info("Index path: {}", indexPath);
         try (
             FSDirectory dir = new NIOFSDirectory(indexPath, FSLockFactory.getDefault());

--- a/src/test/java/org/opensearch/knn/index/engine/InternalKNNEngineTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/InternalKNNEngineTests.java
@@ -9,9 +9,11 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
 import org.apache.lucene.index.SegmentReader;
+import org.junit.BeforeClass;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.common.io.PathUtilsForTesting;
 import org.opensearch.common.lucene.index.OpenSearchLeafReader;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.rest.RestStatus;
@@ -27,6 +29,7 @@ import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.transport.Netty4ModulePlugin;
 
 import java.io.IOException;
+import java.nio.file.FileSystems;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -46,6 +49,13 @@ import static org.opensearch.knn.index.engine.CommonTestUtils.PROPERTIES_FIELD_N
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 1)
 @ThreadLeakFilters(defaultFilters = true, filters = { ThreadLeakFiltersForTests.class })
 public class InternalKNNEngineTests extends OpenSearchIntegTestCase {
+
+    @BeforeClass
+    public static void setFileSystemOverride() throws Exception {
+        // Override the default file system to use the fixed file system provider to avoid the failure of the UT due to the {@link
+        // java.nio.channels.FileChannel#map(...)} function
+        PathUtilsForTesting.installMock(FileSystems.getDefault());
+    }
 
     /** ** Enable the http client *** */
     @Override

--- a/src/test/java/org/opensearch/knn/index/engine/JVectorConcurrentQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/JVectorConcurrentQueryTests.java
@@ -7,9 +7,11 @@ package org.opensearch.knn.index.engine;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import com.google.common.primitives.Floats;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
+import org.opensearch.common.io.PathUtilsForTesting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.rest.RestStatus;
@@ -28,6 +30,7 @@ import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.transport.Netty4ModulePlugin;
 
 import java.io.IOException;
+import java.nio.file.FileSystems;
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -44,6 +47,13 @@ import static org.opensearch.knn.index.engine.CommonTestUtils.DIMENSION;
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 1)
 @ThreadLeakFilters(defaultFilters = true, filters = { ThreadLeakFiltersForTests.class })
 public class JVectorConcurrentQueryTests extends OpenSearchIntegTestCase {
+
+    @BeforeClass
+    public static void setFileSystemOverride() throws Exception {
+        // Override the default file system to use the fixed file system provider to avoid the failure of the UT due to the {@link
+        // java.nio.channels.FileChannel#map(...)} function
+        PathUtilsForTesting.installMock(FileSystems.getDefault());
+    }
 
     private static final int NUM_VECTORS = 100;
     private static final int NUM_QUERIES = 10;

--- a/src/testFixtures/java/org/apache/lucene/tests/mockfile/FixedFSProvider.java
+++ b/src/testFixtures/java/org/apache/lucene/tests/mockfile/FixedFSProvider.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.apache.lucene.tests.mockfile;
+
+import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.nio.channels.FileChannel;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
+import java.util.Set;
+
+/**
+ * A fixed file system provider for the LuceneTestCases.
+ * Those otherwise break due to the failover to the default implementation of {@link FileChannel#map} that is not implemented.
+ *
+ * This FileSystem provider is to be wrapped up around every LuceneTestCase generated Path in the following manner
+ * Path luceneGeneratedPath = createTempDir();
+ * Path wrappedPath = new FixedFSProvider(luceneGeneratedPath.getFileSystem()).wrapPath(luceneGeneratedPath);
+ * this can later be used within the tests with no concerns regarding the {@link FileChannel#map} functionality to throw an UnsupportedOperationException exception.
+ */
+public class FixedFSProvider extends FilterFileSystemProvider {
+    /**
+     * Create a new instance, wrapping {@code delegate}.
+     *
+     * @param delegate
+     */
+    public FixedFSProvider(FileSystem delegate) {
+        super("fixedFs://", delegate);
+    }
+
+    @Override
+    public FileChannel newFileChannel(Path path, Set<? extends OpenOption> options, FileAttribute<?>... attrs) throws IOException {
+        while (path instanceof FilterPath) {
+            path = ((FilterPath) path).getDelegate();
+        }
+        return new FilterFileChannel(FileSystems.getDefault().provider().newFileChannel(path, options, attrs)) {
+            @Override
+            public MemorySegment map(MapMode mode, long offset, long size, Arena arena) throws IOException {
+                return delegate.map(mode, offset, size, arena);
+            }
+        };
+    }
+}

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -126,8 +126,6 @@ public class KNNRestTestCase extends ODFERestTestCase {
 
     @AfterClass
     public static void dumpCoverage() throws IOException, MalformedObjectNameException {
-        // Hack to avoid security manager checks on this static method
-        System.setSecurityManager(null);
         // jacoco.dir is set in esplugin-coverage.gradle, if it doesn't exist we don't
         // want to collect coverage so we can return early
         String jacocoBuildPath = System.getProperty("jacoco.dir");


### PR DESCRIPTION
### Description
Achieves the following:
1. Fixes an issue where `jvector-native` dependency was missing in previous releases
2. Fixes an issue where SegmentReader will fail back to `SimpleSegmentReader` and now `MemoryMappedSegmentReader` will be used appropriately.
3. Fixes an issue where the max index segment that could be read was 2GB (due to issue # 2)

### Check List
- [ x] New functionality includes testing.
- [ x] New functionality has been documented.
~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x ] Commits are signed per the DCO using `--signoff`.
~- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
