### PR TITLE
fix leak for file handles during query time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix CVE-2024-57699 by updating json-path dependencies.
 * Fix concurrency issue [#50](https://github.com/opensearch-project/opensearch-jvector/issues/50)
 * Fix the limitation of the 2 GB segment with backwards compatibility to JDK21 and move default build to 21 target
+* Fix file handle leak during queries
 ### Infrastructure
 * Add localrepo / license / scm / developer / description / url for maven central
 * Add jenkinsfile and release drafter action for maven central release


### PR DESCRIPTION
### Description
We currently have a leak for file handles during query time as `getView` creates new fileChannel every time and doesn't close it until the Supplier is closed.

### Changes
New test was added to exhaust the MockFS file handles which are limited to under <1000.
Before applying the fix the test would fail after 1000 queries:
```
  2> java.io.UncheckedIOException: java.nio.file.FileSystemException: /Users/samuelherman/projects/opensearch-jvector/build/testrun/test/temp/org.opensearch.knn.index.codec.jvector.KNNJVectorTests_F414A68E642EBD27-001/tempDir-001/_f__vec.data-jvector: Too many open files
        at __randomizedtesting.SeedInfo.seed([F414A68E642EBD27:759CC20892041D3D]:0)
        at io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex.getView(OnDiskGraphIndex.java:253)
        at org.opensearch.knn.index.codec.jvector.JVectorReader.search(JVectorReader.java:112)
        at org.apache.lucene.index.CodecReader.searchNearestVectors(CodecReader.java:272)
        at org.apache.lucene.search.KnnFloatVectorQuery.approximateSearch(KnnFloatVectorQuery.java:97)
        at org.apache.lucene.search.AbstractKnnVectorQuery.getLeafResults(AbstractKnnVectorQuery.java:128)
        at org.apache.lucene.search.AbstractKnnVectorQuery.searchLeaf(AbstractKnnVectorQuery.java:110)
        at org.apache.lucene.search.AbstractKnnVectorQuery.lambda$rewrite$0(AbstractKnnVectorQuery.java:93)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
        at org.apache.lucene.search.TaskExecutor$Task.run(TaskExecutor.java:173)
        at org.apache.lucene.search.TaskExecutor.invokeAll(TaskExecutor.java:111)
        at org.apache.lucene.search.AbstractKnnVectorQuery.rewrite(AbstractKnnVectorQuery.java:95)
        at org.apache.lucene.search.KnnFloatVectorQuery.rewrite(KnnFloatVectorQuery.java:46)
        at org.apache.lucene.search.IndexSearcher.rewrite(IndexSearcher.java:873)
        at org.apache.lucene.tests.search.AssertingIndexSearcher.rewrite(AssertingIndexSearcher.java:67)
        at org.apache.lucene.search.IndexSearcher.rewrite(IndexSearcher.java:884)
        at org.apache.lucene.search.IndexSearcher.search(IndexSearcher.java:749)
        at org.apache.lucene.search.IndexSearcher.searchAfter(IndexSearcher.java:597)
        at org.apache.lucene.search.IndexSearcher.search(IndexSearcher.java:620)
        at org.opensearch.knn.index.codec.jvector.KNNJVectorTests.testLuceneKnnIndex_multipleMerges_with_ordering_check(KNNJVectorTests.java:369)
        Caused by:
        java.nio.file.FileSystemException: /Users/samuelherman/projects/opensearch-jvector/build/testrun/test/temp/org.opensearch.knn.index.codec.jvector.KNNJVectorTests_F414A68E642EBD27-001/tempDir-001/_f__vec.data-jvector: Too many open files
            at org.apache.lucene.tests.mockfile.HandleLimitFS.onOpen(HandleLimitFS.java:67)
            at org.apache.lucene.tests.mockfile.HandleTrackingFS.callOpenHook(HandleTrackingFS.java:82)
            at org.apache.lucene.tests.mockfile.HandleTrackingFS.newFileChannel(HandleTrackingFS.java:202)
            at org.apache.lucene.tests.mockfile.FilterFileSystemProvider.newFileChannel(FilterFileSystemProvider.java:206)
            at java.base/java.nio.channels.FileChannel.open(FileChannel.java:309)
            at java.base/java.nio.channels.FileChannel.open(FileChannel.java:369)
            at org.apache.lucene.store.NIOFSDirectory.openInput(NIOFSDirectory.java:78)
            at org.apache.lucene.tests.util.LuceneTestCase.slowFileExists(LuceneTestCase.java:3064)
            at org.apache.lucene.tests.store.MockDirectoryWrapper.openInput(MockDirectoryWrapper.java:801)
            at org.opensearch.knn.index.codec.jvector.JVectorRandomAccessReader$Supplier.get(JVectorRandomAccessReader.java:153)
            at io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex.getView(OnDiskGraphIndex.java:251)
            ... 18 more
```            

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x ] New functionality includes testing.
- [x ] New functionality has been documented.
~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x ] Commits are signed per the DCO using `--signoff`.
~- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
