### PR TITLE
Clone instead of re-creating IndexInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Add jVector search query statistics [#62](https://github.com/opensearch-project/opensearch-jvector/issues/62)
 ### Enhancements
 * Upgrade to java 22 so that we can use Foreign Memory API and MemorySegmentReader
+* Clone instead of recreating index inputs [#83](https://github.com/opensearch-project/opensearch-jvector/issues/83)
 ### Bug Fixes
 * Fix CVE-2024-57699 by updating json-path dependencies.
 * Fix concurrency issue [#50](https://github.com/opensearch-project/opensearch-jvector/issues/50)

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorRandomAccessReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorRandomAccessReader.java
@@ -19,6 +19,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 @Log4j2
 public class JVectorRandomAccessReader implements RandomAccessReader {
@@ -114,25 +115,7 @@ public class JVectorRandomAccessReader implements RandomAccessReader {
 
     @Override
     public void close() throws IOException {
-        log.info("Attempting to close JVectorRandomAccessReader for file {}", indexInputDelegate);
-        boolean success = false;
-        if (!closed) {
-            try {
-                indexInputDelegate.close();
-                log.info("Successfully closed JVectorRandomAccessReader for file {}", indexInputDelegate);
-                success = true;
-            } catch (Exception e) {
-                log.error("Error closing JVectorRandomAccessReader for file {}", indexInputDelegate, e);
-            } finally {
-                if (!closed && !success) {
-                    IOUtils.closeWhileHandlingException(this::close);
-                    log.info("Closed JVectorRandomAccessReader after handling exception for file {}", indexInputDelegate);
-                }
-                closed = true;
-            }
-        } else {
-            log.info("JVectorRandomAccessReader already closed for file {}", indexInputDelegate);
-        }
+        this.closed = true;
     }
 
     public static class Supplier implements ReaderSupplier {
@@ -140,6 +123,7 @@ public class JVectorRandomAccessReader implements RandomAccessReader {
         private final String fileName;
         private final IOContext context;
         private final AtomicInteger readerCount = new AtomicInteger(0);
+        private final AtomicReference<IndexInput> currentInput = new AtomicReference<>(null);
         private final ConcurrentHashMap<Integer, RandomAccessReader> readers = new ConcurrentHashMap<>();
 
         public Supplier(Directory directory, String fileName, IOContext context) {
@@ -151,17 +135,36 @@ public class JVectorRandomAccessReader implements RandomAccessReader {
         @Override
         public RandomAccessReader get() throws IOException {
             synchronized (directory) {
-                var reader = new JVectorRandomAccessReader(directory.openInput(fileName, context));
-                readers.put(readerCount.getAndIncrement(), reader);
+                IndexInput input = currentInput.get();
+                if (currentInput.get() != null) {
+                    input = input.clone();
+                } else {
+                    currentInput.set(directory.openInput(fileName, context));
+                    input = currentInput.get().clone();
+                }
+
+                var reader = new JVectorRandomAccessReader(input);
+                int readerId = readerCount.getAndIncrement();
+                readers.put(readerId, reader);
                 return reader;
             }
+
         }
 
         @Override
         public void close() throws IOException {
-            for (RandomAccessReader reader : readers.values()) {
-                IOUtils.close(reader::close);
+            // Close all cached inputs
+            var input = currentInput.get();
+            if (input != null) {
+                IOUtils.closeWhileHandlingException(input);
             }
+
+            // Close all readers
+            for (RandomAccessReader reader : readers.values()) {
+                IOUtils.closeWhileHandlingException(reader::close);
+            }
+            readers.clear();
+            readerCount.set(0);
         }
     }
 }


### PR DESCRIPTION
### Description
Reduces the number of open file channels by cloning the index input instead of recreating it.
This fixes the flakiness on the `testLuceneKnnIndex_multipleMerges_with_ordering_check` that sometimes had race condition due to the operating system taking time to final FileChannel release.

### Related Issues
Resolves #83 

### Check List
- [x ] New functionality includes testing.
- [x ] New functionality has been documented.
~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x ] Commits are signed per the DCO using `--signoff`.
~- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
