### PR TITLE
Use references for flat vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Upgrade to java 22 so that we can use Foreign Memory API and MemorySegmentReader
 * Clone instead of recreating index inputs [#83](https://github.com/opensearch-project/opensearch-jvector/issues/83)
 * Switch to using Lucene indexInput directly and fix integrity verification for vector index files
+* Make merges happen largely off heap [#87](https://github.com/opensearch-project/opensearch-jvector/issues/87)
 ### Bug Fixes
 * Fix CVE-2024-57699 by updating json-path dependencies.
 * Fix concurrency issue [#50](https://github.com/opensearch-project/opensearch-jvector/issues/50)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 3.0](https://github.com/opensearch-project/k-NN/compare/2.x...HEAD)
 ### Features
-* upgrade to opensearch 3.0.0-SNAPSHOT and remove Java SecurityManager
 * Add jVector search query statistics [#62](https://github.com/opensearch-project/opensearch-jvector/issues/62)
 ### Enhancements
 * Upgrade to java 22 so that we can use Foreign Memory API and MemorySegmentReader
@@ -14,15 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Switch to using Lucene indexInput directly and fix integrity verification for vector index files
 * Make merges happen largely off heap [#87](https://github.com/opensearch-project/opensearch-jvector/issues/87)
 ### Bug Fixes
-* Fix CVE-2024-57699 by updating json-path dependencies.
-* Fix concurrency issue [#50](https://github.com/opensearch-project/opensearch-jvector/issues/50)
 * Fix the limitation of the 2 GB segment with backwards compatibility to JDK21 and move default build to 21 target
 * Fix file handle leak during queries
 ### Infrastructure
-* Add localrepo / license / scm / developer / description / url for maven central
-* Add jenkinsfile and release drafter action for maven central release
-* Add missing description for jvector jar publishing
-* Use z flag for tar during release, so the archive is compressed
 ### Documentation
 ### Maintenance
 ### Refactoring

--- a/benchmark-jmh/src/jmh/java/org/opensearch/knn/index/codec/jvector/BenchmarkCommon.java
+++ b/benchmark-jmh/src/jmh/java/org/opensearch/knn/index/codec/jvector/BenchmarkCommon.java
@@ -21,8 +21,8 @@ public class BenchmarkCommon {
 
     public static Codec getCodec(String codecType) {
         return switch (codecType) {
-            case JVECTOR_NOT_QUANTIZED -> new JVectorCodec(Integer.MAX_VALUE);
-            case JVECTOR_QUANTIZED -> new JVectorCodec(DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION);
+            case JVECTOR_NOT_QUANTIZED -> new JVectorCodec(Integer.MAX_VALUE, false);
+            case JVECTOR_QUANTIZED -> new JVectorCodec(DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION, false);
             case LUCENE101 -> new Lucene101Codec();
             default -> throw new IllegalStateException("Unexpected codec type: " + codecType);
         };

--- a/build.gradle
+++ b/build.gradle
@@ -465,8 +465,8 @@ run {
     // Set JVM arguments for memory
     testClusters.integTest.nodes.each { node ->
         node.jvmArgs(
-                '-Xms2g',  // Initial heap size
-                '-Xmx2g'   // Maximum heap size
+                '-Xms4g',  // Initial heap size
+                '-Xmx4g'   // Maximum heap size
         )
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120PerFieldKnnVectorsFormat.java
@@ -58,7 +58,12 @@ public class KNN9120PerFieldKnnVectorsFormat extends BasePerFieldKnnVectorsForma
                             );
                         }
                     case JVECTOR:
-                        return new JVectorFormat(knnVectorsFormatParams.getMaxConnections(), knnVectorsFormatParams.getBeamWidth());
+                        return new JVectorFormat(
+                            knnVectorsFormatParams.getMaxConnections(),
+                            knnVectorsFormatParams.getBeamWidth(),
+                            Integer.MAX_VALUE,
+                            true
+                        );
                     default:
                         throw new IllegalArgumentException("Unsupported java engine: " + knnEngine);
                 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120PerFieldKnnVectorsFormat.java
@@ -62,7 +62,7 @@ public class KNN9120PerFieldKnnVectorsFormat extends BasePerFieldKnnVectorsForma
                             knnVectorsFormatParams.getMaxConnections(),
                             knnVectorsFormatParams.getBeamWidth(),
                             JVectorFormat.DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION,
-                            false
+                            true
                         );
                     default:
                         throw new IllegalArgumentException("Unsupported java engine: " + knnEngine);

--- a/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120PerFieldKnnVectorsFormat.java
@@ -61,7 +61,7 @@ public class KNN9120PerFieldKnnVectorsFormat extends BasePerFieldKnnVectorsForma
                         return new JVectorFormat(
                             knnVectorsFormatParams.getMaxConnections(),
                             knnVectorsFormatParams.getBeamWidth(),
-                            Integer.MAX_VALUE,
+                            JVectorFormat.DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION,
                             false
                         );
                     default:

--- a/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120PerFieldKnnVectorsFormat.java
@@ -62,7 +62,7 @@ public class KNN9120PerFieldKnnVectorsFormat extends BasePerFieldKnnVectorsForma
                             knnVectorsFormatParams.getMaxConnections(),
                             knnVectorsFormatParams.getBeamWidth(),
                             Integer.MAX_VALUE,
-                            true
+                            false
                         );
                     default:
                         throw new IllegalArgumentException("Unsupported java engine: " + knnEngine);

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorCodec.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorCodec.java
@@ -14,22 +14,29 @@ public class JVectorCodec extends FilterCodec {
 
     public static final String CODEC_NAME = "JVectorCodec";
     private int minBatchSizeForQuantization;
+    private boolean mergeOnDisk;
 
     public JVectorCodec() {
-        this(CODEC_NAME, new Lucene101Codec(), JVectorFormat.DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION);
+        this(
+            CODEC_NAME,
+            new Lucene101Codec(),
+            JVectorFormat.DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION,
+            JVectorFormat.DEFAULT_MERGE_ON_DISK
+        );
     }
 
-    public JVectorCodec(int minBatchSizeForQuantization) {
-        this(CODEC_NAME, new Lucene101Codec(), minBatchSizeForQuantization);
+    public JVectorCodec(int minBatchSizeForQuantization, boolean mergeOnDisk) {
+        this(CODEC_NAME, new Lucene101Codec(), minBatchSizeForQuantization, mergeOnDisk);
     }
 
-    public JVectorCodec(String codecName, Codec delegate, int minBatchSizeForQuantization) {
+    public JVectorCodec(String codecName, Codec delegate, int minBatchSizeForQuantization, boolean mergeOnDisk) {
         super(codecName, delegate);
         this.minBatchSizeForQuantization = minBatchSizeForQuantization;
+        this.mergeOnDisk = mergeOnDisk;
     }
 
     @Override
     public KnnVectorsFormat knnVectorsFormat() {
-        return new JVectorFormat(minBatchSizeForQuantization);
+        return new JVectorFormat(minBatchSizeForQuantization, mergeOnDisk);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFormat.java
@@ -33,34 +33,44 @@ public class JVectorFormat extends KnnVectorsFormat {
     private final int maxConn;
     private final int beamWidth;
     private final int minBatchSizeForQuantization;
+    private final boolean mergeOnDisk;
 
     public JVectorFormat() {
-        this(NAME, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION);
+        this(NAME, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION, DEFAULT_MERGE_ON_DISK);
     }
 
-    public JVectorFormat(int minBatchSizeForQuantization) {
-        this(NAME, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, minBatchSizeForQuantization);
+    public JVectorFormat(int minBatchSizeForQuantization, boolean mergeOnDisk) {
+        this(NAME, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, minBatchSizeForQuantization, mergeOnDisk);
     }
 
-    public JVectorFormat(int maxConn, int beamWidth) {
-        this(NAME, maxConn, beamWidth, DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION);
+    public JVectorFormat(int maxConn, int beamWidth, int minBatchSizeForQuantization, boolean mergeOnDisk) {
+        this(NAME, maxConn, beamWidth, minBatchSizeForQuantization, mergeOnDisk);
     }
 
-    public JVectorFormat(String name, int maxConn, int beamWidth, int minBatchSizeForQuantization) {
+    public JVectorFormat(String name, int maxConn, int beamWidth, int minBatchSizeForQuantization, boolean mergeOnDisk) {
         super(name);
         this.maxConn = maxConn;
         this.beamWidth = beamWidth;
         this.minBatchSizeForQuantization = minBatchSizeForQuantization;
+        this.mergeOnDisk = mergeOnDisk;
     }
 
     @Override
     public KnnVectorsWriter fieldsWriter(SegmentWriteState state) throws IOException {
-        return new JVectorWriter(state, maxConn, beamWidth, DEFAULT_DEGREE_OVERFLOW, DEFAULT_ALPHA, minBatchSizeForQuantization);
+        return new JVectorWriter(
+            state,
+            maxConn,
+            beamWidth,
+            DEFAULT_DEGREE_OVERFLOW,
+            DEFAULT_ALPHA,
+            minBatchSizeForQuantization,
+            mergeOnDisk
+        );
     }
 
     @Override
     public KnnVectorsReader fieldsReader(SegmentReadState state) throws IOException {
-        return new JVectorReader(state);
+        return new JVectorReader(state, mergeOnDisk);
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFormat.java
@@ -28,6 +28,7 @@ public class JVectorFormat extends KnnVectorsFormat {
     private static final int DEFAULT_BEAM_WIDTH = 100;
     private static final float DEFAULT_DEGREE_OVERFLOW = 1.2f;
     private static final float DEFAULT_ALPHA = 1.2f;
+    public static final boolean DEFAULT_MERGE_ON_DISK = true;
 
     private final int maxConn;
     private final int beamWidth;

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorRandomAccessWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorRandomAccessWriter.java
@@ -10,8 +10,6 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.store.IndexOutput;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 
 /**
  * JVectorRandomAccessWriter is a wrapper around IndexOutput that implements RandomAccessWriter.

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorRandomAccessWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorRandomAccessWriter.java
@@ -11,7 +11,12 @@ import org.apache.lucene.store.IndexOutput;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
+/**
+ * JVectorRandomAccessWriter is a wrapper around IndexOutput that implements RandomAccessWriter.
+ * Note: This is not thread safe!
+ */
 @Log4j2
 public class JVectorRandomAccessWriter implements RandomAccessWriter {
     private final byte[] writeBuffer = new byte[Long.BYTES]; // used to store temporary bytes conversion before writing
@@ -100,8 +105,7 @@ public class JVectorRandomAccessWriter implements RandomAccessWriter {
 
     @Override
     public void writeFloat(float v) throws IOException {
-        ByteBuffer.wrap(writeBuffer).putFloat(v);
-        indexOutputDelegate.writeBytes(writeBuffer, 0, Float.BYTES);
+        indexOutputDelegate.writeInt(Float.floatToIntBits(v));
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
@@ -37,6 +37,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.opensearch.knn.index.codec.jvector.JVectorFormat.DEFAULT_MERGE_ON_DISK;
+
 @Log4j2
 public class JVectorReader extends KnnVectorsReader {
     private static final VectorTypeSupport VECTOR_TYPE_SUPPORT = VectorizationProvider.getInstance().getVectorTypeSupport();
@@ -91,7 +93,11 @@ public class JVectorReader extends KnnVectorsReader {
 
     @Override
     public FloatVectorValues getFloatVectorValues(String field) throws IOException {
-        return flatVectorsReader.getFloatVectorValues(field);
+        if (DEFAULT_MERGE_ON_DISK) {
+            return flatVectorsReader.getFloatVectorValues(field);
+        }
+        final FieldEntry fieldEntry = fieldEntryMap.get(field);
+        return new JVectorFloatVectorValues(fieldEntry.index, fieldEntry.similarityFunction);
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
@@ -37,12 +37,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.opensearch.knn.index.codec.jvector.JVectorFormat.DEFAULT_MERGE_ON_DISK;
-
 @Log4j2
 public class JVectorReader extends KnnVectorsReader {
     private static final VectorTypeSupport VECTOR_TYPE_SUPPORT = VectorizationProvider.getInstance().getVectorTypeSupport();
-    private static final FlatVectorsFormat FLAT_VECTORS_FORMAT = new Lucene99FlatVectorsFormat(FlatVectorScorerUtil.getLucene99FlatVectorsScorer());
+    private static final FlatVectorsFormat FLAT_VECTORS_FORMAT = new Lucene99FlatVectorsFormat(
+        FlatVectorScorerUtil.getLucene99FlatVectorsScorer()
+    );
     private static final int DEFAULT_OVER_QUERY_FACTOR = 5; // We will query 5x more than topKFor reranking
 
     private final FieldInfos fieldInfos;
@@ -52,9 +52,11 @@ public class JVectorReader extends KnnVectorsReader {
     private final Directory directory;
     private final SegmentReadState state;
     private final FlatVectorsReader flatVectorsReader;
+    private final boolean mergeOnDisk;
 
-    public JVectorReader(SegmentReadState state) throws IOException {
+    public JVectorReader(SegmentReadState state, boolean mergeOnDisk) throws IOException {
         this.state = state;
+        this.mergeOnDisk = mergeOnDisk;
         this.flatVectorsReader = FLAT_VECTORS_FORMAT.fieldsReader(state);
         this.fieldInfos = state.fieldInfos;
         this.baseDataFileName = state.segmentInfo.name + "_" + state.segmentSuffix;
@@ -93,7 +95,7 @@ public class JVectorReader extends KnnVectorsReader {
 
     @Override
     public FloatVectorValues getFloatVectorValues(String field) throws IOException {
-        if (DEFAULT_MERGE_ON_DISK) {
+        if (mergeOnDisk) {
             return flatVectorsReader.getFloatVectorValues(field);
         }
         final FieldEntry fieldEntry = fieldEntryMap.get(field);

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -566,10 +566,10 @@ public class JVectorWriter extends KnnVectorsWriter {
 
                 final float[] vector;
                 // Access to readers is always assumed to be single threaded!
-                synchronized (this) {
+                synchronized (readers[readerIdx]) {
                     vector = readers[readerIdx].vectorValue(readerOrd);
-                    return VECTOR_TYPE_SUPPORT.createFloatVector(vector);
                 }
+                return VECTOR_TYPE_SUPPORT.createFloatVector(vector);
             } catch (IOException e) {
                 log.error("Error retrieving vector at ordinal {}", ord, e);
                 throw new RuntimeException(e);

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -439,7 +439,7 @@ public class JVectorWriter extends KnnVectorsWriter {
 
         @Override
         public long ramBytesUsed() {
-            return SHALLOW_SIZE + graphIndexBuilder.getGraph().ramBytesUsed() + RamUsageEstimator.sizeOfCollection(floatVectors);
+            return SHALLOW_SIZE + RamUsageEstimator.sizeOfCollection(floatVectors);
         }
 
         io.github.jbellis.jvector.vector.VectorSimilarityFunction getVectorSimilarityFunction(FieldInfo fieldInfo) {

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -566,10 +566,10 @@ public class JVectorWriter extends KnnVectorsWriter {
 
                 final float[] vector;
                 // Access to readers is always assumed to be single threaded!
-                synchronized (readers[readerIdx]) {
+                synchronized (this) {
                     vector = readers[readerIdx].vectorValue(readerOrd);
+                    return VECTOR_TYPE_SUPPORT.createFloatVector(vector);
                 }
-                return VECTOR_TYPE_SUPPORT.createFloatVector(vector);
             } catch (IOException e) {
                 log.error("Error retrieving vector at ordinal {}", ord, e);
                 throw new RuntimeException(e);

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -369,10 +369,6 @@ public class JVectorWriter extends KnnVectorsWriter {
         private final RandomAccessVectorValues randomAccessVectorValues;
         private final BuildScoreProvider buildScoreProvider;
 
-        FieldWriter(FieldInfo fieldInfo, String segmentName) {
-            this(fieldInfo, segmentName, null);
-        }
-
         FieldWriter(FieldInfo fieldInfo, String segmentName, RandomAccessVectorValues ravv) {
             /*
              * Either field writer will use existing ravv or will allow to dynamically add values via the floatVectors.

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
@@ -1092,7 +1092,23 @@ public class KNNJVectorTests extends LuceneTestCase {
                 totalRelevantDocs++;
             }
         }
-        return ((float) totalRelevantDocs) / ((float) topDocs.scoreDocs.length);
+        float recall = ((float) totalRelevantDocs) / ((float) topDocs.scoreDocs.length);
+
+        if (recall == 0.0f) {
+            log.info("Recall is 0.0, this is probably not correct, here is some debug information\n topDocs: {}, minScoreInTopK: {}, totalRelevantDocs: {}", topDocsToString(topDocs), minScoreInTopK, totalRelevantDocs);
+        }
+        return recall;
+    }
+
+    // convert topDocs to a pretty printed string
+    private String topDocsToString(TopDocs topDocs) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("TopDocs: [");
+        for (int i = 0; i < topDocs.scoreDocs.length; i++) {
+            sb.append(topDocs.scoreDocs[i].doc).append(" (").append(topDocs.scoreDocs[i].score).append("), ");
+        }
+        sb.append("]");
+        return sb.toString();
     }
 
 }

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
@@ -996,9 +996,8 @@ public class KNNJVectorTests extends LuceneTestCase {
         final int notIdealBatchSize = DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION / 3; // Batch size that is not ideal for quantization and
         // shouldn't trigger it
         final int totalNumberOfDocs = notIdealBatchSize * 30; // 3 batches of documents each will result in quantization only when the merge
-        // is triggered, and we have a batch size of {@link
-        // MINIMUM_BATCH_SIZE_FOR_QUANTIZATION} as a result of merging all the smaller
-        // batches
+        // is triggered, and we have a batch size of {@link MINIMUM_BATCH_SIZE_FOR_QUANTIZATION}
+        // as a result of merging all the smaller batches
 
         IndexWriterConfig indexWriterConfig = LuceneTestCase.newIndexWriterConfig();
         // TODO: re-enable this after fixing the compound file augmentation for JVector
@@ -1073,7 +1072,7 @@ public class KNNJVectorTests extends LuceneTestCase {
                     new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, k }
                 );
                 final float recall = calculateRecall(topDocs, expectedMinScoreInTopK);
-                Assert.assertEquals(1.0f, recall, 0.05f);
+                Assert.assertEquals("Expected to have recall of 1.0+/-0.05 but got " + recall, 1.0f, recall, 0.05f);
                 log.info("successfully completed search tests");
             }
         }

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
@@ -24,6 +24,7 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.opensearch.knn.index.codec.jvector.JVectorFormat.DEFAULT_MERGE_ON_DISK;
 import static org.opensearch.knn.index.codec.jvector.JVectorFormat.DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION;
 
 /**
@@ -232,7 +233,7 @@ public class KNNJVectorTests extends LuceneTestCase {
     }
 
     /**
-     * Test to verify that the Lucene codec is able to successfully search for the nearest neighbours
+     * Test to verify that the jVector codec is able to successfully search for the nearest neighbors
      * in the index.
      * Single field is used to store the vectors.
      * Documents are stored in potentially multiple segments.
@@ -240,11 +241,10 @@ public class KNNJVectorTests extends LuceneTestCase {
      * Multiple merges.
      */
     @Test
-    public void testLuceneKnnIndex_multipleMerges() throws IOException {
+    public void testJVectorKnnIndex_multipleMerges() throws IOException {
         int k = 3; // The number of nearest neighbours to gather
         int totalNumberOfDocs = 10;
         IndexWriterConfig indexWriterConfig = LuceneTestCase.newIndexWriterConfig();
-        // TODO: re-enable this after fixing the compound file augmentation for JVector
         indexWriterConfig.setUseCompoundFile(false);
         indexWriterConfig.setCodec(new JVectorCodec());
         indexWriterConfig.setMergePolicy(new ForceMergesOnlyMergePolicy());
@@ -296,6 +296,70 @@ public class KNNJVectorTests extends LuceneTestCase {
                     topDocs.scoreDocs[2].score,
                     0.001f
                 );
+                log.info("successfully completed search tests");
+            }
+        }
+    }
+
+    /**
+     * Test to verify that the jVector codec is able to successfully search for the nearest neighbours
+     * in the index.
+     * A Single field is used to store the vectors.
+     * Documents are stored in potentially multiple segments.
+     * Multiple commits.
+     * Multiple merges.
+     * Large batches
+     * Use a compound file
+     */
+    @Test
+    public void testJVectorKnnIndex_multiple_merges_large_batches_no_quantization() throws IOException {
+        int segmentSize = DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION;
+        int totalNumberOfDocs = segmentSize * 4;
+        int k = 3; // The number of nearest neighbors to gather
+
+        IndexWriterConfig indexWriterConfig = LuceneTestCase.newIndexWriterConfig();
+        indexWriterConfig.setUseCompoundFile(true);
+        indexWriterConfig.setCodec(new JVectorCodec(Integer.MAX_VALUE, DEFAULT_MERGE_ON_DISK)); // effectively without quantization
+        indexWriterConfig.setMergePolicy(new ForceMergesOnlyMergePolicy(true));
+        indexWriterConfig.setMergeScheduler(new SerialMergeScheduler());
+        // We set the below parameters to make sure no permature flush will occur, this way we can have a single segment, and we can force
+        // test the quantization case
+        indexWriterConfig.setMaxBufferedDocs(10000); // force flush every 10000 docs, this way we make sure that we only have a single
+        // segment for a totalNumberOfDocs < 1000
+        indexWriterConfig.setRAMPerThreadHardLimitMB(1000); // 1000MB per thread, this way we make sure that no premature flush will occur
+
+        final Path indexPath = createTempDir();
+        log.info("Index path: {}", indexPath);
+        try (FSDirectory dir = FSDirectory.open(indexPath); IndexWriter w = new IndexWriter(dir, indexWriterConfig)) {
+            final float[] target = new float[] { 0.0f, 0.0f };
+            for (int i = 1; i < totalNumberOfDocs + 1; i++) {
+                final float[] source = new float[] { 0.0f, 1.0f / i };
+                final Document doc = new Document();
+                doc.add(new KnnFloatVectorField("test_field", source, VectorSimilarityFunction.EUCLIDEAN));
+                doc.add(new StringField("my_doc_id", Integer.toString(i, 10), Field.Store.YES));
+                w.addDocument(doc);
+                if (i % segmentSize == 0) {
+                    w.commit(); // this creates a new segment without triggering a merge
+                }
+            }
+            log.info("Done writing all files to the file system");
+
+            w.forceMerge(1); // this merges all segments into a single segment
+            log.info("Done merging all segments");
+            try (IndexReader reader = DirectoryReader.open(w)) {
+                log.info("We should now have 1 segment with {} documents", totalNumberOfDocs);
+                Assert.assertEquals(1, reader.getContext().leaves().size());
+                Assert.assertEquals(totalNumberOfDocs, reader.numDocs());
+                final Query filterQuery = new MatchAllDocsQuery();
+                final IndexSearcher searcher = newSearcher(reader);
+                KnnFloatVectorQuery knnFloatVectorQuery = new KnnFloatVectorQuery("test_field", target, k, filterQuery);
+                TopDocs topDocs = searcher.search(knnFloatVectorQuery, k);
+                assertEquals(k, topDocs.totalHits.value());
+
+                float expectedMinScoreInTopK = VectorSimilarityFunction.EUCLIDEAN.compare(target, new float[] { 0.0f, k });
+                final float recall = calculateRecall(topDocs, expectedMinScoreInTopK);
+                Assert.assertEquals(1.0f, recall, 0.01f);
+
                 log.info("successfully completed search tests");
             }
         }
@@ -724,7 +788,9 @@ public class KNNJVectorTests extends LuceneTestCase {
         IndexWriterConfig indexWriterConfig = LuceneTestCase.newIndexWriterConfig();
         // TODO: re-enable this after fixing the compound file augmentation for JVector
         indexWriterConfig.setUseCompoundFile(false);
-        indexWriterConfig.setCodec(new JVectorCodec(DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION));
+        // quantization fails with mergeOnDisk, turning it off for now during quantization test
+        // TODO: turn mergeOnDisk back on with quantization
+        indexWriterConfig.setCodec(new JVectorCodec(DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION, false));
         indexWriterConfig.setMergePolicy(new ForceMergesOnlyMergePolicy());
         // We set the below parameters to make sure no permature flush will occur, this way we can have a single segment, and we can force
         // test the quantization case
@@ -812,9 +878,10 @@ public class KNNJVectorTests extends LuceneTestCase {
         final int totalNumberOfDocs = perfectBatchSize * 2;
 
         IndexWriterConfig indexWriterConfig = LuceneTestCase.newIndexWriterConfig();
-        // TODO: re-enable this after fixing the compound file augmentation for JVector
         indexWriterConfig.setUseCompoundFile(false);
-        indexWriterConfig.setCodec(new JVectorCodec(DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION));
+        // quantization fails with mergeOnDisk, turning it off for now during quantization test
+        // TODO: turn mergeOnDisk back on with quantization
+        indexWriterConfig.setCodec(new JVectorCodec(DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION, false));
         indexWriterConfig.setMergePolicy(new ForceMergesOnlyMergePolicy());
         // We set the below parameters to make sure no permature flush will occur, this way we can have a single segment, and we can force
         // test the quantization case
@@ -906,9 +973,10 @@ public class KNNJVectorTests extends LuceneTestCase {
                                                              // batches
 
         IndexWriterConfig indexWriterConfig = LuceneTestCase.newIndexWriterConfig();
-        // TODO: re-enable this after fixing the compound file augmentation for JVector
         indexWriterConfig.setUseCompoundFile(false);
-        indexWriterConfig.setCodec(new JVectorCodec(DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION));
+        // quantization fails with mergeOnDisk, turning it off for now during quantization test
+        // TODO: turn mergeOnDisk back on with quantization
+        indexWriterConfig.setCodec(new JVectorCodec(DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION, false));
         indexWriterConfig.setMergePolicy(new ForceMergesOnlyMergePolicy());
         // We set the below parameters to make sure no permature flush will occur, this way we can have a single segment, and we can force
         // test the quantization case
@@ -1000,9 +1068,10 @@ public class KNNJVectorTests extends LuceneTestCase {
         // as a result of merging all the smaller batches
 
         IndexWriterConfig indexWriterConfig = LuceneTestCase.newIndexWriterConfig();
-        // TODO: re-enable this after fixing the compound file augmentation for JVector
         indexWriterConfig.setUseCompoundFile(true);
-        indexWriterConfig.setCodec(new JVectorCodec(DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION));
+        // quantization fails with mergeOnDisk, turning it off for now during quantization test
+        // TODO: turn mergeOnDisk back on with quantization
+        indexWriterConfig.setCodec(new JVectorCodec(DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION, false));
         indexWriterConfig.setMergePolicy(new ForceMergesOnlyMergePolicy(true));
         // We set the below parameters to make sure no permature flush will occur, this way we can have a single segment, and we can force
         // test the quantization case

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
@@ -875,7 +875,7 @@ public class KNNJVectorTests extends LuceneTestCase {
         indexWriterConfig.setUseCompoundFile(false);
         // quantization fails with mergeOnDisk, turning it off for now during quantization test
         // TODO: turn mergeOnDisk back on with quantization
-        indexWriterConfig.setCodec(new JVectorCodec(DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION, false));
+        indexWriterConfig.setCodec(new JVectorCodec(DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION, true));
         indexWriterConfig.setMergePolicy(new ForceMergesOnlyMergePolicy());
         // We set the below parameters to make sure no permature flush will occur, this way we can have a single segment, and we can force
         // test the quantization case
@@ -970,7 +970,7 @@ public class KNNJVectorTests extends LuceneTestCase {
         indexWriterConfig.setUseCompoundFile(false);
         // quantization fails with mergeOnDisk, turning it off for now during quantization test
         // TODO: turn mergeOnDisk back on with quantization
-        indexWriterConfig.setCodec(new JVectorCodec(DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION, false));
+        indexWriterConfig.setCodec(new JVectorCodec(DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION, true));
         indexWriterConfig.setMergePolicy(new ForceMergesOnlyMergePolicy());
         // We set the below parameters to make sure no permature flush will occur, this way we can have a single segment, and we can force
         // test the quantization case
@@ -1065,7 +1065,7 @@ public class KNNJVectorTests extends LuceneTestCase {
         indexWriterConfig.setUseCompoundFile(true);
         // quantization fails with mergeOnDisk, turning it off for now during quantization test
         // TODO: turn mergeOnDisk back on with quantization
-        indexWriterConfig.setCodec(new JVectorCodec(DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION, false));
+        indexWriterConfig.setCodec(new JVectorCodec(DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION, true));
         indexWriterConfig.setMergePolicy(new ForceMergesOnlyMergePolicy(true));
         // We set the below parameters to make sure no permature flush will occur, this way we can have a single segment, and we can force
         // test the quantization case

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
@@ -50,7 +50,6 @@ public class KNNJVectorTests extends LuceneTestCase {
         int k = 3; // The number of nearest neighbors to gather
         int totalNumberOfDocs = 10;
         IndexWriterConfig indexWriterConfig = LuceneTestCase.newIndexWriterConfig();
-        // TODO: re-enable this after fixing the compound file augmentation for JVector
         indexWriterConfig.setUseCompoundFile(false);
         indexWriterConfig.setCodec(new JVectorCodec());
         indexWriterConfig.setMergePolicy(new ForceMergesOnlyMergePolicy());
@@ -114,7 +113,6 @@ public class KNNJVectorTests extends LuceneTestCase {
         int k = 3; // The number of nearest neighbours to gather
         int totalNumberOfDocs = 10;
         IndexWriterConfig indexWriterConfig = LuceneTestCase.newIndexWriterConfig();
-        // TODO: re-enable this after fixing the compound file augmentation for JVector
         indexWriterConfig.setUseCompoundFile(false);
         indexWriterConfig.setCodec(new JVectorCodec());
         indexWriterConfig.setMergePolicy(new ForceMergesOnlyMergePolicy(false));
@@ -176,7 +174,6 @@ public class KNNJVectorTests extends LuceneTestCase {
         int k = 3; // The number of nearest neighbours to gather
         int totalNumberOfDocs = 10;
         IndexWriterConfig indexWriterConfig = LuceneTestCase.newIndexWriterConfig();
-        // TODO: re-enable this after fixing the compound file augmentation for JVector
         indexWriterConfig.setUseCompoundFile(false);
         indexWriterConfig.setCodec(new JVectorCodec());
         indexWriterConfig.setMergePolicy(new ForceMergesOnlyMergePolicy());
@@ -577,7 +574,6 @@ public class KNNJVectorTests extends LuceneTestCase {
         int k = 3; // The number of nearest neighbors to gather
         int totalNumberOfDocs = 10;
         IndexWriterConfig indexWriterConfig = LuceneTestCase.newIndexWriterConfig();
-        // TODO: re-enable this after fixing the compound file augmentation for JVector
         indexWriterConfig.setUseCompoundFile(true);
         indexWriterConfig.setCodec(new JVectorCodec());
         indexWriterConfig.setMergePolicy(new ForceMergesOnlyMergePolicy(true));
@@ -698,7 +694,7 @@ public class KNNJVectorTests extends LuceneTestCase {
 
     /**
      * Test to verify that the JVector codec is providing proper error if used with byte vector
-     * TODO: Create Product Quantization support for JVector codec
+     * TODO: Create Binary Quantization support for JVector codec
      */
     @Test
     public void testJVectorKnnIndex_simpleCase_withBinaryVector() throws IOException {
@@ -728,7 +724,6 @@ public class KNNJVectorTests extends LuceneTestCase {
         int k = 3; // The number of nearest neighbours to gather
         int totalNumberOfDocs = 10;
         IndexWriterConfig indexWriterConfig = LuceneTestCase.newIndexWriterConfig();
-        // TODO: re-enable this after fixing the compound file augmentation for JVector
         indexWriterConfig.setUseCompoundFile(false);
         indexWriterConfig.setCodec(new JVectorCodec());
         indexWriterConfig.setMergePolicy(new ForceMergesOnlyMergePolicy());
@@ -786,11 +781,10 @@ public class KNNJVectorTests extends LuceneTestCase {
         int k = 50; // The number of nearest neighbours to gather
         int totalNumberOfDocs = DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION;
         IndexWriterConfig indexWriterConfig = LuceneTestCase.newIndexWriterConfig();
-        // TODO: re-enable this after fixing the compound file augmentation for JVector
         indexWriterConfig.setUseCompoundFile(false);
         // quantization fails with mergeOnDisk, turning it off for now during quantization test
         // TODO: turn mergeOnDisk back on with quantization
-        indexWriterConfig.setCodec(new JVectorCodec(DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION, false));
+        indexWriterConfig.setCodec(new JVectorCodec(DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION, true));
         indexWriterConfig.setMergePolicy(new ForceMergesOnlyMergePolicy());
         // We set the below parameters to make sure no permature flush will occur, this way we can have a single segment, and we can force
         // test the quantization case

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
@@ -1095,7 +1095,12 @@ public class KNNJVectorTests extends LuceneTestCase {
         float recall = ((float) totalRelevantDocs) / ((float) topDocs.scoreDocs.length);
 
         if (recall == 0.0f) {
-            log.info("Recall is 0.0, this is probably not correct, here is some debug information\n topDocs: {}, minScoreInTopK: {}, totalRelevantDocs: {}", topDocsToString(topDocs), minScoreInTopK, totalRelevantDocs);
+            log.info(
+                "Recall is 0.0, this is probably not correct, here is some debug information\n topDocs: {}, minScoreInTopK: {}, totalRelevantDocs: {}",
+                topDocsToString(topDocs),
+                minScoreInTopK,
+                totalRelevantDocs
+            );
         }
         return recall;
     }

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/MemoryUsageAnalysisTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/MemoryUsageAnalysisTests.java
@@ -35,8 +35,8 @@ import static org.opensearch.knn.TestUtils.generateRandomVectors;
 public class MemoryUsageAnalysisTests extends LuceneTestCase {
 
     private static final int VECTOR_DIMENSION = 128;
-    private static final int TOTAL_DOCS = 10_000;
-    private static final int BATCH_SIZE = 500;
+    private static final int TOTAL_DOCS = 1000;
+    private static final int BATCH_SIZE = 100;
     private static final String VECTOR_FIELD_NAME = "vector_field";
     private static final DecimalFormat MEMORY_FORMAT = new DecimalFormat("#,###.00 MB");
 

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/MemoryUsageAnalysisTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/MemoryUsageAnalysisTests.java
@@ -7,7 +7,6 @@ package org.opensearch.knn.index.codec.jvector;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import lombok.extern.log4j.Log4j2;
-import org.apache.lucene.codecs.lucene101.Lucene101Codec;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.KnnFloatVectorField;
@@ -36,7 +35,7 @@ import static org.opensearch.knn.TestUtils.generateRandomVectors;
 public class MemoryUsageAnalysisTests extends LuceneTestCase {
 
     private static final int VECTOR_DIMENSION = 128;
-    private static final int TOTAL_DOCS = 100000;
+    private static final int TOTAL_DOCS = 1000;
     private static final int BATCH_SIZE = 100;
     private static final String VECTOR_FIELD_NAME = "vector_field";
     private static final DecimalFormat MEMORY_FORMAT = new DecimalFormat("#,###.00 MB");

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/MemoryUsageAnalysisTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/MemoryUsageAnalysisTests.java
@@ -7,6 +7,7 @@ package org.opensearch.knn.index.codec.jvector;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.codecs.lucene101.Lucene101Codec;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.KnnFloatVectorField;
@@ -35,7 +36,7 @@ import static org.opensearch.knn.TestUtils.generateRandomVectors;
 public class MemoryUsageAnalysisTests extends LuceneTestCase {
 
     private static final int VECTOR_DIMENSION = 128;
-    private static final int TOTAL_DOCS = 1000;
+    private static final int TOTAL_DOCS = 100000;
     private static final int BATCH_SIZE = 100;
     private static final String VECTOR_FIELD_NAME = "vector_field";
     private static final DecimalFormat MEMORY_FORMAT = new DecimalFormat("#,###.00 MB");
@@ -63,7 +64,7 @@ public class MemoryUsageAnalysisTests extends LuceneTestCase {
         Path indexPath = createTempDir("memory-test-index");
 
         // Configure the JVector codec
-        JVectorCodec codec = new JVectorCodec();
+        var codec = new JVectorCodec();
 
         // Setup index writer with the JVector codec
         IndexWriterConfig config = new IndexWriterConfig().setCodec(codec)

--- a/src/test/java/org/opensearch/knn/index/engine/JVectorEngineIT.java
+++ b/src/test/java/org/opensearch/knn/index/engine/JVectorEngineIT.java
@@ -358,9 +358,10 @@ public class JVectorEngineIT extends KNNRestTestCase {
             )).longValue()
         );
 
+        // TODO: bring back to increment when we re-enable PQ in jVector plugin
         assertTrue(
             "Reranked counter did not increase",
-            ((Number) after.get(StatNames.KNN_QUERY_RERANKED_COUNT.getName())).longValue() > ((Number) before.get(
+            ((Number) after.get(StatNames.KNN_QUERY_RERANKED_COUNT.getName())).longValue() == ((Number) before.get(
                 StatNames.KNN_QUERY_RERANKED_COUNT.getName()
             )).longValue()
         );

--- a/src/test/java/org/opensearch/knn/index/engine/JVectorEngineIT.java
+++ b/src/test/java/org/opensearch/knn/index/engine/JVectorEngineIT.java
@@ -358,10 +358,9 @@ public class JVectorEngineIT extends KNNRestTestCase {
             )).longValue()
         );
 
-        // TODO: bring back to increment when we re-enable PQ in jVector plugin
         assertTrue(
             "Reranked counter did not increase",
-            ((Number) after.get(StatNames.KNN_QUERY_RERANKED_COUNT.getName())).longValue() == ((Number) before.get(
+            ((Number) after.get(StatNames.KNN_QUERY_RERANKED_COUNT.getName())).longValue() > ((Number) before.get(
                 StatNames.KNN_QUERY_RERANKED_COUNT.getName()
             )).longValue()
         );


### PR DESCRIPTION
### Description
Use references and ord mapping to readers to avoid copying large number of floating vectors on the heap during merge.
This should allow for much larger vector mergers with much smaller heaps.

### Related Issues
Resolves #87 

### Check List
- [x ] New functionality includes testing.
- [x ] New functionality has been documented.
~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x ] Commits are signed per the DCO using `--signoff`.
~- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
