### PR TITLE
Fix merge for deleted sorted index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Bug Fixes
 * Fix the limitation of the 2 GB segment with backwards compatibility to JDK21 and move default build to 21 target
 * Fix file handle leak during queries
+* Fix edge case for deleted docs or out of order readers with off heap merges
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/build.gradle
+++ b/build.gradle
@@ -465,8 +465,8 @@ run {
     // Set JVM arguments for memory
     testClusters.integTest.nodes.each { node ->
         node.jvmArgs(
-                '-Xms4g',  // Initial heap size
-                '-Xmx4g'   // Maximum heap size
+                '-Xms2g',  // Initial heap size
+                '-Xmx2g'   // Maximum heap size
         )
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -139,7 +139,8 @@ public class JVectorWriter extends KnnVectorsWriter {
         return newField;
     }
 
-    public KnnFieldVectorsWriter<?> addMergeField(FieldInfo fieldInfo, RandomAccessVectorValues ravv) throws IOException {
+    public KnnFieldVectorsWriter<?> addMergeField(FieldInfo fieldInfo, FloatVectorValues mergeFloatVector, RandomAccessVectorValues ravv)
+        throws IOException {
         log.info("Adding merge field {} in segment {}", fieldInfo.name, segmentWriteState.segmentInfo.name);
         if (fieldInfo.getVectorEncoding() == VectorEncoding.BYTE) {
             final String errorMessage = "byte[] vectors are not supported in JVector. "
@@ -148,7 +149,7 @@ public class JVectorWriter extends KnnVectorsWriter {
             log.error(errorMessage);
             throw new UnsupportedOperationException(errorMessage);
         }
-        return new FieldWriter<>(fieldInfo, segmentWriteState.segmentInfo.name, ravv);
+        return new FieldWriter<>(fieldInfo, segmentWriteState.segmentInfo.name, mergeFloatVector, ravv);
     }
 
     @Override
@@ -169,12 +170,12 @@ public class JVectorWriter extends KnnVectorsWriter {
                     break;
                 case FLOAT32:
                     final FieldWriter<float[]> floatVectorFieldWriter;
+                    FloatVectorValues mergeFloatVector = MergedVectorValues.mergeFloatVectorValues(fieldInfo, mergeState);
                     if (mergeOnDisk) {
                         final var ravv = new RandomAccessMergedFloatVectorValues(fieldInfo, mergeState, scorerSupplier);
-                        floatVectorFieldWriter = (FieldWriter<float[]>) addMergeField(fieldInfo, ravv);
+                        floatVectorFieldWriter = (FieldWriter<float[]>) addMergeField(fieldInfo, mergeFloatVector, ravv);
                     } else {
                         floatVectorFieldWriter = (FieldWriter<float[]>) addField(fieldInfo);
-                        FloatVectorValues mergeFloatVector = MergedVectorValues.mergeFloatVectorValues(fieldInfo, mergeState);
                         var itr = mergeFloatVector.iterator();
                         for (int doc = itr.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = itr.nextDoc()) {
                             floatVectorFieldWriter.addValue(doc, mergeFloatVector.vectorValue(doc));
@@ -404,13 +405,15 @@ public class JVectorWriter extends KnnVectorsWriter {
         private final GraphIndexBuilder graphIndexBuilder;
         private final String segmentName;
         private final RandomAccessVectorValues randomAccessVectorValues;
+        private final FloatVectorValues mergedFloatVector;
         private final FlatFieldVectorsWriter<T> flatFieldVectorsWriter;
         private final BuildScoreProvider buildScoreProvider;
 
         // For merge fields only
-        FieldWriter(FieldInfo fieldInfo, String segmentName, RandomAccessVectorValues ravv) {
+        FieldWriter(FieldInfo fieldInfo, String segmentName, FloatVectorValues mergedFloatVector, RandomAccessVectorValues ravv) {
             this.flatFieldVectorsWriter = null;
             this.randomAccessVectorValues = ravv;
+            this.mergedFloatVector = mergedFloatVector;
             // This unmodifiable list makes sure that the addition of values outside what's already in ravv will fail.
             this.fieldInfo = fieldInfo;
             this.segmentName = segmentName;
@@ -434,6 +437,7 @@ public class JVectorWriter extends KnnVectorsWriter {
              */
             this.flatFieldVectorsWriter = flatFieldVectorsWriter;
             this.randomAccessVectorValues = new RandomAccessVectorValuesOverFlatFields(flatFieldVectorsWriter, fieldInfo);
+            this.mergedFloatVector = null;
             this.fieldInfo = fieldInfo;
             this.segmentName = segmentName;
             this.buildScoreProvider = BuildScoreProvider.randomAccessScoreProvider(
@@ -505,9 +509,25 @@ public class JVectorWriter extends KnnVectorsWriter {
          * @throws IOException IOException
          */
         public OnHeapGraphIndex getGraph() throws IOException {
-            for (int i = 0; i < randomAccessVectorValues.size(); i++) {
-                graphIndexBuilder.addGraphNode(i, randomAccessVectorValues.getVector(i));
+            /*
+             * We cannot always use randomAccessVectorValues for the graph building
+             * because it's size will not always correspond to the document count.
+             * To have the right mapping from docId to vector ordinal we need to use the mergedFloatVector.
+             * This is the case when we are merging segments and we might have more documents than vectors.
+             */
+            if (mergedFloatVector != null) {
+                log.info("Building graph from merged float vector");
+                var itr = mergedFloatVector.iterator();
+                for (int doc = itr.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = itr.nextDoc()) {
+                    graphIndexBuilder.addGraphNode(doc, randomAccessVectorValues.getVector(doc));
+                }
+            } else {
+                log.info("Building graph from random access vector values");
+                for (int i = 0; i < randomAccessVectorValues.size(); i++) {
+                    graphIndexBuilder.addGraphNode(i, randomAccessVectorValues.getVector(i));
+                }
             }
+
             graphIndexBuilder.cleanup();
             return graphIndexBuilder.getGraph();
         }
@@ -529,6 +549,8 @@ public class JVectorWriter extends KnnVectorsWriter {
 
         // Total number of vectors
         private final int size;
+        // Total number of documents including those without values
+        private final int totalDocsCount;
 
         // Vector dimension
         private final int dimension;
@@ -549,8 +571,9 @@ public class JVectorWriter extends KnnVectorsWriter {
         ) throws IOException {
             this.fieldName = fieldInfo.name;
             this.scorerSupplier = scorerSupplier;
+            this.totalDocsCount = Math.toIntExact(Arrays.stream(mergeState.maxDocs).asLongStream().sum());
             // Count total vectors and collect readers
-            int totalSize = 0;
+            int totalVectorsCount = 0;
             int dimension = 0;
             // We explicitly show that the readers are of JVectorFloatVectorValues that are capable of random access
             List<KnnVectorsReader> allReaders = new ArrayList<>();
@@ -563,18 +586,17 @@ public class JVectorWriter extends KnnVectorsWriter {
                         FloatVectorValues values = reader.getFloatVectorValues(fieldName);
                         if (values != null) {
                             allReaders.add(reader);
-                            totalSize += values.size();
+                            totalVectorsCount += values.size();
                             dimension = Math.max(dimension, values.dimension());
                         }
                     }
                 }
             }
 
-            assert (totalSize <= Arrays.stream(mergeState.maxDocs).asLongStream().sum())
-                : "Total number of vectors exceeds the total number of documents";
+            assert (totalVectorsCount <= totalDocsCount) : "Total number of vectors exceeds the total number of documents";
             assert (dimension > 0) : "No vectors found for field " + fieldName;
 
-            this.size = totalSize;
+            this.size = totalVectorsCount;
             this.readers = new KnnVectorsReader[allReaders.size()];
             for (int i = 0; i < readers.length; i++) {
                 readers[i] = allReaders.get(i);
@@ -583,7 +605,7 @@ public class JVectorWriter extends KnnVectorsWriter {
             this.dimension = dimension;
 
             // Build mapping from global ordinal to [readerIndex, readerOrd]
-            this.ordMapping = new int[totalSize][2];
+            this.ordMapping = new int[totalDocsCount][2];
 
             int documentsIterated = 0;
 
@@ -597,15 +619,32 @@ public class JVectorWriter extends KnnVectorsWriter {
                 // For each vector in this reader
                 KnnVectorValues.DocIndexIterator it = values.iterator();
                 for (int docId = it.nextDoc(); docId != DocIdSetIterator.NO_MORE_DOCS; docId = it.nextDoc()) {
-                    final int globalOrd = docMaps[readerIdx].get(docId);
-                    ordMapping[globalOrd][0] = readerIdx; // Reader index
-                    ordMapping[globalOrd][1] = docId; // Ordinal in reader
+                    if (docMaps[readerIdx].get(docId) == -1) {
+                        log.warn(
+                            "Document {} in reader {} is not mapped to a global ordinal from the merge docMaps. Will skip this document for now",
+                            docId,
+                            readerIdx
+                        );
+                    } else {
+                        // Mapping from global ordinal to [readerIndex, readerOrd]
+                        final int globalOrd = docMaps[readerIdx].get(docId);
+                        ordMapping[globalOrd][0] = readerIdx; // Reader index
+                        ordMapping[globalOrd][1] = docId; // Ordinal in reader
+                    }
+
                     documentsIterated++;
                 }
             }
 
-            if (documentsIterated != totalSize) {
-                throw new IllegalStateException("Built mapping for " + documentsIterated + " vectors but expected " + totalSize);
+            if (documentsIterated < totalVectorsCount) {
+                throw new IllegalStateException(
+                    "More documents were expected than what was found in the readers."
+                        + "Expected at least number of total vectors: "
+                        + totalVectorsCount
+                        + " but found only: "
+                        + documentsIterated
+                        + " documents."
+                );
             }
 
             log.debug("Created RandomAccessMergedFloatVectorValues with {} total vectors from {} readers", size, readers.length);
@@ -623,7 +662,7 @@ public class JVectorWriter extends KnnVectorsWriter {
 
         @Override
         public VectorFloat<?> getVector(int ord) {
-            if (ord < 0 || ord >= size) {
+            if (ord < 0 || ord >= totalDocsCount) {
                 throw new IllegalArgumentException("Ordinal out of bounds: " + ord);
             }
 

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -538,6 +538,9 @@ public class JVectorWriter extends KnnVectorsWriter {
      * FloatVectorValues from multiple segments without copying the vectors.
      */
     static class RandomAccessMergedFloatVectorValues implements RandomAccessVectorValues {
+        private static final int READER_ID = 0;
+        private static final int READER_ORD = 1;
+
         private final VectorTypeSupport VECTOR_TYPE_SUPPORT = VectorizationProvider.getInstance().getVectorTypeSupport();
 
         // Array of sub-readers
@@ -628,8 +631,8 @@ public class JVectorWriter extends KnnVectorsWriter {
                     } else {
                         // Mapping from global ordinal to [readerIndex, readerOrd]
                         final int globalOrd = docMaps[readerIdx].get(docId);
-                        ordMapping[globalOrd][0] = readerIdx; // Reader index
-                        ordMapping[globalOrd][1] = docId; // Ordinal in reader
+                        ordMapping[globalOrd][READER_ID] = readerIdx; // Reader index
+                        ordMapping[globalOrd][READER_ORD] = docId; // Ordinal in reader
                     }
 
                     documentsIterated++;
@@ -668,8 +671,8 @@ public class JVectorWriter extends KnnVectorsWriter {
 
             try {
 
-                final int readerIdx = ordMapping[ord][0];
-                final int readerOrd = ordMapping[ord][1];
+                final int readerIdx = ordMapping[ord][READER_ID];
+                final int readerOrd = ordMapping[ord][READER_ORD];
 
                 // Access to float values is not thread safe
                 synchronized (this) {

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
@@ -501,7 +501,10 @@ public class KNNJVectorTests extends LuceneTestCase {
      */
     @Test
     public void testJVectorKnnIndex_deletedDocs() throws IOException {
-        final int k = 3;
+        final int totalNumberOfDocs = 100;
+        final int batchSize = 10;
+        final int k = batchSize - 1;
+        final int docToDeleteInEachBatch = 5;
         final Path indexPath = createTempDir();
         final IndexWriterConfig iwc = newIndexWriterConfig();
         // JVector codec requires compound files to be disabled at the moment
@@ -510,51 +513,50 @@ public class KNNJVectorTests extends LuceneTestCase {
         iwc.setMergePolicy(new ForceMergesOnlyMergePolicy(false));
 
         try (FSDirectory dir = FSDirectory.open(indexPath); IndexWriter writer = new IndexWriter(dir, iwc)) {
-            /* ---------------------------
-             * 1.  Index three simple docs
-             * --------------------------- */
-            float[][] vectors = {
-                { 0.0f, 0.2f }, // doc "1" – nearest to target
-                { 0.0f, 0.4f }, // doc "2"
-                { 0.0f, 0.6f }  // doc "3"
-            };
 
-            for (int i = 0; i < vectors.length; i++) {
+            /*
+             * 1.  Index 100 docs, in batches of 10.  Delete the 5th doc in each batch.
+             *     will leave us with 10 segments, each with 9 live docs.
+             */
+            int batchNumber = 0;
+            for (int i = 1; i <= totalNumberOfDocs; i++) {
                 Document doc = new Document();
+                final float[] vector = { 0.0f, 1.0f * (i + batchNumber) };
                 doc.add(new StringField("docId", Integer.toString(i + 1), Field.Store.YES));
-                doc.add(new KnnFloatVectorField("test_field", vectors[i], VectorSimilarityFunction.EUCLIDEAN));
+                doc.add(new KnnFloatVectorField("test_field", vector, VectorSimilarityFunction.EUCLIDEAN));
                 writer.addDocument(doc);
-                writer.commit(); // keep every doc in its own segment
+                if (i % batchSize == 0) {
+                    writer.flush();
+                    writer.deleteDocuments(new TermQuery(new Term("docId", Integer.toString(i - docToDeleteInEachBatch))));
+                    batchNumber++;
+                }
             }
+            writer.commit();
 
-            /* --------------------
-             * 2.  Delete doc "1"
-             * -------------------- */
-            writer.deleteDocuments(new Term("docId", "1"));
-            writer.commit(); // commit the delete but keep segments as-is
+            /* ----------------------------------------
+             * 2.  Merge all segments into one
+             * ---------------------------------------- */
             writer.forceMerge(1);
 
             /* ----------------------------------------
              * 3.  Search – the deleted doc must be gone
              * ---------------------------------------- */
             try (IndexReader reader = DirectoryReader.open(writer)) {
-                assertEquals("All documents except the deleted one should be live", 2, reader.numDocs());
+                assertEquals("All documents except the deleted ones should be live", totalNumberOfDocs - (totalNumberOfDocs / batchSize), reader.numDocs());
+                // For each batch we will verify that the deleted document doesn't come up in search and only it's neighbours are returned
 
-                IndexSearcher searcher = newSearcher(reader);
-                float[] target = { 0.0f, 0.0f }; // closest to doc "1", which is deleted
-
-                TopDocs results = searcher.search(new KnnFloatVectorQuery("test_field", target, k), k);
-
-                // We expect only 2 hits because one document was deleted
-                assertEquals(2, results.totalHits.value());
-
-                // Retrieve the first returned document and verify that it is *not* "1"
-                Document document = reader.storedFields().document(results.scoreDocs[0].doc);
-                String docId = document.get("docId");
-                assertNotEquals("1", docId);
-
-                // The first hit should now be the former 2nd-nearest neighbour – "2"
-                assertEquals("2", docId);
+                for (int i = 0; i < totalNumberOfDocs; i += batchSize) {
+                    final float[] target = { 0.0f, 1.0f * (i + docToDeleteInEachBatch) };
+                    final IndexSearcher searcher = newSearcher(reader);
+                    final KnnFloatVectorQuery knnFloatVectorQuery = new KnnFloatVectorQuery("test_field", target, k, new MatchAllDocsQuery());
+                    TopDocs topDocs = searcher.search(knnFloatVectorQuery, k);
+                    assertEquals(k, topDocs.totalHits.value());
+                    for (int j = 0; j < k; j++) {
+                        Document doc = reader.storedFields().document(topDocs.scoreDocs[j].doc);
+                        int docId = Integer.parseInt(doc.get("docId"));
+                        assertNotEquals("Deleted doc should not be returned in search results", i + docToDeleteInEachBatch, docId);
+                    }
+                }
             }
         }
     }

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
@@ -542,13 +542,22 @@ public class KNNJVectorTests extends LuceneTestCase {
              * 3.  Search – the deleted doc must be gone
              * ---------------------------------------- */
             try (IndexReader reader = DirectoryReader.open(writer)) {
-                assertEquals("All documents except the deleted ones should be live", totalNumberOfDocs - (totalNumberOfDocs / batchSize), reader.numDocs());
+                assertEquals(
+                    "All documents except the deleted ones should be live",
+                    totalNumberOfDocs - (totalNumberOfDocs / batchSize),
+                    reader.numDocs()
+                );
                 // For each batch we will verify that the deleted document doesn't come up in search and only it's neighbours are returned
 
                 for (int i = 0; i < totalNumberOfDocs; i += batchSize) {
                     final float[] target = { 0.0f, 1.0f * (i + docToDeleteInEachBatch) };
                     final IndexSearcher searcher = newSearcher(reader);
-                    final KnnFloatVectorQuery knnFloatVectorQuery = new KnnFloatVectorQuery("test_field", target, k, new MatchAllDocsQuery());
+                    final KnnFloatVectorQuery knnFloatVectorQuery = new KnnFloatVectorQuery(
+                        "test_field",
+                        target,
+                        k,
+                        new MatchAllDocsQuery()
+                    );
                     TopDocs topDocs = searcher.search(knnFloatVectorQuery, k);
                     assertEquals(k, topDocs.totalHits.value());
                     for (int j = 0; j < k; j++) {


### PR DESCRIPTION
### Description
New off heap merge that was introduced in #87 was missing an edge case for graceful handling of deleted documents and out of order merges.
- Created a test that properly reproduced the scenario
- Issue was detected in OSB as well

### Check List
- [x ] New functionality includes testing.
- [x ] New functionality has been documented.
~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [ x] Commits are signed per the DCO using `--signoff`.
~- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
