### PR TITLE
add PQ index construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 3.0](https://github.com/opensearch-project/k-NN/compare/2.x...HEAD)
 ### Features
 ### Enhancements
+* Index construction using PQ scoring [#110](https://github.com/opensearch-project/opensearch-jvector/issues/110)
 * upgrade to the latest jVector version [#99](https://github.com/opensearch-project/opensearch-jvector/issues/99)
 ### Bug Fixes
 ### Infrastructure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 ### Enhancements
 * Index construction using PQ scoring [#110](https://github.com/opensearch-project/opensearch-jvector/issues/110)
-* upgrade to the latest jVector version [#99](https://github.com/opensearch-project/opensearch-jvector/issues/99)
 ### Bug Fixes
 ### Infrastructure
 ### Documentation

--- a/benchmark-jmh/README.md
+++ b/benchmark-jmh/README.md
@@ -11,5 +11,9 @@ To run the benchmarks, use the following command:
 Replace `<benchmark_class_name>` with the name of the benchmark class you want to run. For example, to run the `FormatBenchmarkRandomVectors` benchmark, use the following command:
 
 ```shell
-./gradlew benchmark-jmh:jmh -PjmhInclude=org.opensearch.knn.index.codec.jvector.FormatBenchmarkRandomVectors
+./gradlew benchmark-jmh:jmh -PjmhInclude=org.opensearch.knn.index.codec.jvector.FormatBenchmarkQueryWithRandomVectors
+```
+
+```shell
+./gradlew benchmark-jmh:jmh -PjmhInclude=org.opensearch.knn.index.codec.jvector.FormatBenchmarkConstructionWithRandomVectors
 ```

--- a/benchmark-jmh/build.gradle
+++ b/benchmark-jmh/build.gradle
@@ -102,7 +102,7 @@ jmh {
     iterations = 5
     warmupIterations = 2
     fork = 1
-    jvmArgs = ['-Xms2G', '-Xmx2G']
+    jvmArgs = ['-Xms20G', '-Xmx20G']
     resultFormat = 'JSON'
     resultsFile = file("${buildDir}/reports/jmh/results.json")
     humanOutputFile = file("${buildDir}/reports/jmh/human.txt")  // human readable output

--- a/benchmark-jmh/build.gradle
+++ b/benchmark-jmh/build.gradle
@@ -102,7 +102,7 @@ jmh {
     iterations = 5
     warmupIterations = 2
     fork = 1
-    jvmArgs = ['-Xms20G', '-Xmx20G']
+    jvmArgs = ['-Xms20G', '-Xmx20G', '--add-modules=jdk.incubator.vector', '-Djvector.experimental.enable_native_vectorization=true', '--enable-native-access=ALL-UNNAMED']
     resultFormat = 'JSON'
     resultsFile = file("${buildDir}/reports/jmh/results.json")
     humanOutputFile = file("${buildDir}/reports/jmh/human.txt")  // human readable output

--- a/benchmark-jmh/src/jmh/java/org/opensearch/knn/index/codec/jvector/BenchmarkCommon.java
+++ b/benchmark-jmh/src/jmh/java/org/opensearch/knn/index/codec/jvector/BenchmarkCommon.java
@@ -21,8 +21,8 @@ public class BenchmarkCommon {
 
     public static Codec getCodec(String codecType) {
         return switch (codecType) {
-            case JVECTOR_NOT_QUANTIZED -> new JVectorCodec(Integer.MAX_VALUE, false);
-            case JVECTOR_QUANTIZED -> new JVectorCodec(DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION, false);
+            case JVECTOR_NOT_QUANTIZED -> new JVectorCodec(Integer.MAX_VALUE, true);
+            case JVECTOR_QUANTIZED -> new JVectorCodec(DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION, true);
             case LUCENE101 -> new Lucene101Codec();
             default -> throw new IllegalStateException("Unexpected codec type: " + codecType);
         };

--- a/benchmark-jmh/src/jmh/java/org/opensearch/knn/index/codec/jvector/CachelessFormatBenchmarkRandomVectors.java
+++ b/benchmark-jmh/src/jmh/java/org/opensearch/knn/index/codec/jvector/CachelessFormatBenchmarkRandomVectors.java
@@ -30,7 +30,7 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Benchmark to compare the performance of JVector and Lucene codecs with random vectors similar to {@link FormatBenchmarkRandomVectors}.
+ * Benchmark to compare the performance of JVector and Lucene codecs with random vectors similar to {@link FormatBenchmarkQueryWithRandomVectors}.
  * The difference is that this benchmark is a single shot time benchmark and cleans the filesystem cache between each iteration to measure the impact of operating system cache misses.
  * Note: this benchmark is only for qualitative analysis and not meant to reproduce the already existing benchmarks of either Lucene or JVector.
  */

--- a/benchmark-jmh/src/jmh/java/org/opensearch/knn/index/codec/jvector/FormatBenchmarkConstructionWithRandomVectors.java
+++ b/benchmark-jmh/src/jmh/java/org/opensearch/knn/index/codec/jvector/FormatBenchmarkConstructionWithRandomVectors.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.jvector;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmark to compare the graph index construction performance with jVector in various configurations and Lucene
+ * The benchmark generates random vectors and indexes them using JVector and Lucene codecs.
+ * Note: This benchmark is not meant to reproduce the already existing benchmarks of either Lucene or JVector.
+ * But rather it is more meant as a qualitative analysis of the relative performance of the codecs in the plugin for certain scenarios.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 2)
+@Measurement(iterations = 5)
+@Fork(1)
+public class FormatBenchmarkConstructionWithRandomVectors {
+    private static final Logger log = LogManager.getLogger(FormatBenchmarkConstructionWithRandomVectors.class);
+    private static final String JVECTOR_NOT_QUANTIZED = "jvector_not_quantized";
+    private static final String JVECTOR_QUANTIZED = "jvector_quantized";
+    private static final String LUCENE101 = "Lucene101";
+    private static final String FIELD_NAME = "vector_field";
+    private static final VectorSimilarityFunction SIMILARITY_FUNCTION = VectorSimilarityFunction.EUCLIDEAN;
+    @Param({ JVECTOR_NOT_QUANTIZED, JVECTOR_QUANTIZED, LUCENE101 })  // This will run the benchmark each codec type
+    private String codecType;
+    @Param({ /*"1000", "10000",*/ "100000" })
+    private int numDocs;
+    @Param({ /*"128", "256",*/ "768", /*"1024"*/ })
+    private int dimension;
+
+    private float[][] vectors;
+    private Directory directory;
+    private Path indexDirectoryPath;
+    private List<Document> documents;
+
+    @Setup(Level.Invocation)
+    public void setup() throws IOException {
+        documents = new ArrayList<>(numDocs);
+        vectors = new float[numDocs][dimension];
+        log.info("Generating {} random vectors of dimension {}", numDocs, dimension);
+        // Generate random vectors
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        for (int i = 0; i < numDocs; i++) {
+            for (int j = 0; j < dimension; j++) {
+                vectors[i][j] = random.nextFloat();
+            }
+        }
+
+        indexDirectoryPath = Files.createTempDirectory("jvector-benchmark");
+        log.info("Index path: {}", indexDirectoryPath);
+        directory = FSDirectory.open(indexDirectoryPath);
+
+        for (int i = 0; i < numDocs; i++) {
+            Document doc = new Document();
+            doc.add(new KnnFloatVectorField(FIELD_NAME, vectors[i], SIMILARITY_FUNCTION));
+            documents.add(doc);
+        }
+    }
+
+    @TearDown(Level.Invocation)
+    public void tearDown() throws IOException {
+        directory.close();
+        // Cleanup previously created index directory
+        Files.walk(indexDirectoryPath)
+            .sorted((path1, path2) -> path2.compareTo(path1)) // Reverse order to delete files before directories
+            .forEach(path -> {
+                try {
+                    Files.delete(path);
+                } catch (IOException e) {
+                    throw new UncheckedIOException("Failed to delete " + path, e);
+                }
+            });
+        documents.clear();
+    }
+
+    @Benchmark
+    public void benchmarkSearch(Blackhole blackhole) throws IOException {
+        IndexWriterConfig indexWriterConfig = new IndexWriterConfig();
+        indexWriterConfig.setCodec(BenchmarkCommon.getCodec(codecType));
+        indexWriterConfig.setUseCompoundFile(true);
+        indexWriterConfig.setMergePolicy(new ForceMergesOnlyMergePolicy(true));
+        try (IndexWriter writer = new IndexWriter(directory, indexWriterConfig)) {
+            writer.addDocuments(documents);
+            writer.commit();
+            log.info("Flushing docs to make them discoverable on the file system and force merging all segments to get a single segment");
+            writer.forceMerge(1);
+        }
+        blackhole.consume(documents);
+    }
+}

--- a/benchmark-jmh/src/jmh/java/org/opensearch/knn/index/codec/jvector/FormatBenchmarkQueryWithKnownDatasets.java
+++ b/benchmark-jmh/src/jmh/java/org/opensearch/knn/index/codec/jvector/FormatBenchmarkQueryWithKnownDatasets.java
@@ -42,8 +42,8 @@ import static org.opensearch.knn.index.codec.jvector.BenchmarkCommon.*;
 @Warmup(iterations = 2)
 @Measurement(iterations = 5)
 @Fork(1)
-public class FormatBenchmarkWithKnownDatasets {
-    Logger log = LogManager.getLogger(FormatBenchmarkWithKnownDatasets.class);
+public class FormatBenchmarkQueryWithKnownDatasets {
+    Logger log = LogManager.getLogger(FormatBenchmarkQueryWithKnownDatasets.class);
     // large embeddings calculated by Neighborhood Watch. 100k files by default; 1M also available
     private static final List<String> LARGE_DATASETS = List.of(
         "ada002-100k",

--- a/benchmark-jmh/src/jmh/java/org/opensearch/knn/index/codec/jvector/FormatBenchmarkQueryWithRandomVectors.java
+++ b/benchmark-jmh/src/jmh/java/org/opensearch/knn/index/codec/jvector/FormatBenchmarkQueryWithRandomVectors.java
@@ -38,11 +38,11 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Thread)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Warmup(iterations = 1)
-@Measurement(iterations = 3)
+@Warmup(iterations = 2)
+@Measurement(iterations = 5)
 @Fork(1)
-public class FormatBenchmarkRandomVectors {
-    private static final Logger log = LogManager.getLogger(FormatBenchmarkRandomVectors.class);
+public class FormatBenchmarkQueryWithRandomVectors {
+    private static final Logger log = LogManager.getLogger(FormatBenchmarkQueryWithRandomVectors.class);
     private static final String JVECTOR_NOT_QUANTIZED = "jvector_not_quantized";
     private static final String JVECTOR_QUANTIZED = "jvector_quantized";
     private static final String LUCENE101 = "Lucene101";
@@ -51,9 +51,9 @@ public class FormatBenchmarkRandomVectors {
     private static final VectorSimilarityFunction SIMILARITY_FUNCTION = VectorSimilarityFunction.EUCLIDEAN;
     @Param({ JVECTOR_NOT_QUANTIZED, JVECTOR_QUANTIZED, LUCENE101 })  // This will run the benchmark each codec type
     private String codecType;
-    @Param({ "1000", "10000", "100000" })
+    @Param({ /*"1000", "10000",*/ "100000" })
     private int numDocs;
-    @Param({ "128", /*"256", "512", "1024"*/ })
+    @Param({ /*"128", "256",*/ "768", /*"1024"*/ })
     private int dimension;
 
     private float[][] vectors;

--- a/build.gradle
+++ b/build.gradle
@@ -351,6 +351,7 @@ test {
             '--add-opens', 'java.base/java.nio=ALL-UNNAMED',
             '--add-opens', 'java.base/sun.nio.ch=ALL-UNNAMED',
             '-Djdk.incubator.foreign.restricted=permit',
+            '-Djdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK=0',
             '--enable-native-access=ALL-UNNAMED',
             '-Dio.netty.tryReflectionSetAccessible=true',
             '--enable-preview'
@@ -396,6 +397,19 @@ integTest {
         systemProperty 'cluster.debug', isDebuggingCluster
         // Set number of nodes system property to be used in tests
         systemProperty 'cluster.number_of_nodes', "${_numNodes}"
+
+        systemProperty 'jdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK', "0"
+        jvmArgs = [
+                '--add-modules', 'jdk.incubator.vector',
+                '--add-opens', 'java.base/java.nio=ALL-UNNAMED',
+                '--add-opens', 'java.base/sun.nio.ch=ALL-UNNAMED',
+                '-Djdk.incubator.foreign.restricted=permit',
+                '-Djdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK=0',
+                '--enable-native-access=ALL-UNNAMED',
+                '-Dio.netty.tryReflectionSetAccessible=true',
+                '--enable-preview'
+        ]
+
         // There seems to be an issue when running multi node run or integ tasks with unicast_hosts
         // not being written, the waitForAllConditions ensures it's written
         getClusters().forEach { cluster ->
@@ -414,6 +428,7 @@ testClusters.integTest {
     testDistribution = "ARCHIVE"
     systemProperty "java.security.policy", "file://${project.rootDir}/src/main/plugin-metadata/plugin-security.policy"
     systemProperty 'log4j.configurationFile', "${project.rootDir}/src/test/resources/log4j2.properties"
+
     // Optionally install security
     if (System.getProperty("security.enabled") != null) {
         configureSecurityPlugin(testClusters.integTest)
@@ -435,6 +450,7 @@ testClusters.integTest {
         }
     }
     systemProperty propertyKeys.breaker.useRealMemory, getBreakerSetting()
+    systemProperty 'jdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK', "0"
 }
 
 task integTestRemote(type: RestIntegTestTask) {
@@ -466,7 +482,9 @@ run {
     testClusters.integTest.nodes.each { node ->
         node.jvmArgs(
                 '-Xms2g',  // Initial heap size
-                '-Xmx2g'   // Maximum heap size
+                '-Xmx2g',   // Maximum heap size
+                '-XX:+UnlockDiagnosticVMOptions',
+                "-XX:CompilerDirectivesFile=${project.rootDir}/src/main/resources/hotspot_compiler"
         )
     }
 

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/RecallIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/RecallIT.java
@@ -78,6 +78,6 @@ public class RecallIT extends AbstractRestartUpgradeTestCase {
         // Updating index thread qty to 2 to speed up data ingestion
         updateClusterSettings(KNN_ALGO_PARAM_INDEX_THREAD_QTY, INDEX_THREAD_QTY);
 
-        bulkAddKnnDocs(testIndex, testField, TestUtils.getIndexVectors(docCount, dimensions, isStandard), docCount);
+        bulkAddKnnDocs(testIndex, testField, TestUtils.getIndexVectors(docCount, dimensions, isStandard), docCount, true);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFormat.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index.codec.jvector;
 
+import io.github.jbellis.jvector.util.PhysicalCoreExecutor;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.KnnVectorsWriter;
@@ -13,6 +14,7 @@ import org.apache.lucene.index.SegmentWriteState;
 import org.opensearch.knn.common.KNNConstants;
 
 import java.io.IOException;
+import java.util.concurrent.ForkJoinPool;
 import java.util.function.Function;
 
 public class JVectorFormat extends KnnVectorsFormat {
@@ -26,9 +28,11 @@ public class JVectorFormat extends KnnVectorsFormat {
                                                                                 // quantization
     public static final int VERSION_START = 0;
     public static final int VERSION_CURRENT = VERSION_START;
-    private static final int DEFAULT_MAX_CONN = 32;
-    private static final int DEFAULT_BEAM_WIDTH = 100;
+    public static final int DEFAULT_MAX_CONN = 32;
+    public static final int DEFAULT_BEAM_WIDTH = 100;
     public static final boolean DEFAULT_MERGE_ON_DISK = true;
+    // Unfortunately, this can't be managed yet by the OpenSearch ThreadPool because it's not supporting {@link ForkJoinPool} types
+    public static final ForkJoinPool SIMD_POOL = PhysicalCoreExecutor.pool();
 
     private final int maxConn;
     private final int beamWidth;

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFormat.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.knn.index.codec.jvector;
 
-import io.github.jbellis.jvector.util.PhysicalCoreExecutor;
+import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.KnnVectorsWriter;
@@ -15,8 +15,10 @@ import org.opensearch.knn.common.KNNConstants;
 
 import java.io.IOException;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinWorkerThread;
 import java.util.function.Function;
 
+@Log4j2
 public class JVectorFormat extends KnnVectorsFormat {
     public static final String NAME = "JVectorFormat";
     public static final String META_CODEC_NAME = "JVectorVectorsFormatMeta";
@@ -32,7 +34,7 @@ public class JVectorFormat extends KnnVectorsFormat {
     public static final int DEFAULT_BEAM_WIDTH = 100;
     public static final boolean DEFAULT_MERGE_ON_DISK = true;
     // Unfortunately, this can't be managed yet by the OpenSearch ThreadPool because it's not supporting {@link ForkJoinPool} types
-    public static final ForkJoinPool SIMD_POOL = PhysicalCoreExecutor.pool();
+    public static final ForkJoinPool SIMD_POOL = getPhysicalCoreExecutor();
 
     private final int maxConn;
     private final int beamWidth;
@@ -171,5 +173,22 @@ public class JVectorFormat extends KnnVectorsFormat {
             compressedBytes = (int) (originalDimension * 0.125);
         }
         return compressedBytes;
+    }
+
+    public static ForkJoinPool getPhysicalCoreExecutor() {
+        final int estimatedPhysicalCoreCount = Integer.getInteger(
+            "jvector.physical_core_count",
+            Math.max(1, Runtime.getRuntime().availableProcessors() / 2)
+        );
+        assert estimatedPhysicalCoreCount > 0 && estimatedPhysicalCoreCount <= Runtime.getRuntime().availableProcessors()
+            : "Invalid core count: " + estimatedPhysicalCoreCount;
+        final ForkJoinPool.ForkJoinWorkerThreadFactory factory = pool -> {
+            ForkJoinWorkerThread thread = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool);
+            thread.setPriority(Thread.NORM_PRIORITY - 2);
+            return thread;
+        };
+
+        log.info("Creating SIMD ForkJoinPool with {} physical cores for JVector SIMD operations", estimatedPhysicalCoreCount);
+        return new ForkJoinPool(estimatedPhysicalCoreCount, factory, null, true);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
@@ -171,7 +171,13 @@ public class JVectorReader extends KnnVectorsReader {
                 KNNCounter.KNN_QUERY_RERANKED_COUNT.add(rerankedCount);
                 KNNCounter.KNN_QUERY_EXPANDED_NODES.add(expandedCount);
                 KNNCounter.KNN_QUERY_EXPANDED_BASE_LAYER_NODES.add(expandedBaseLayerCount);
-                log.debug("rerankedCount: {}, visitedNodesCount: {}, expandedCount: {}, expandedBaseLayerCount: {}", rerankedCount, visitedNodesCount, expandedCount, expandedBaseLayerCount);
+                log.debug(
+                    "rerankedCount: {}, visitedNodesCount: {}, expandedCount: {}, expandedBaseLayerCount: {}",
+                    rerankedCount,
+                    visitedNodesCount,
+                    expandedCount,
+                    expandedBaseLayerCount
+                );
 
             }
         }

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
@@ -171,6 +171,7 @@ public class JVectorReader extends KnnVectorsReader {
                 KNNCounter.KNN_QUERY_RERANKED_COUNT.add(rerankedCount);
                 KNNCounter.KNN_QUERY_EXPANDED_NODES.add(expandedCount);
                 KNNCounter.KNN_QUERY_EXPANDED_BASE_LAYER_NODES.add(expandedBaseLayerCount);
+                log.debug("rerankedCount: {}, visitedNodesCount: {}, expandedCount: {}, expandedBaseLayerCount: {}", rerankedCount, visitedNodesCount, expandedCount, expandedBaseLayerCount);
 
             }
         }

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -13,6 +13,7 @@ import io.github.jbellis.jvector.graph.disk.feature.Feature;
 import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
 import io.github.jbellis.jvector.graph.disk.feature.InlineVectors;
 import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
+import io.github.jbellis.jvector.quantization.PQVectors;
 import io.github.jbellis.jvector.quantization.ProductQuantization;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
@@ -38,9 +39,9 @@ import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.hnsw.CloseableRandomVectorScorerSupplier;
 
-import java.io.DataOutput;
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.ForkJoinPool;
 import java.util.function.Function;
 
 import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsReader.readVectorEncoding;
@@ -208,9 +209,9 @@ public class JVectorWriter extends KnnVectorsWriter {
     public void flush(int maxDoc, Sorter.DocMap sortMap) throws IOException {
         log.info("Flushing {} fields", fields.size());
 
-        log.info("Writing flat vectors");
+        log.info("Flushing flat vectors");
         flatVectorWriter.flush(maxDoc, sortMap);
-        log.info("Writing jVector graph index");
+        log.info("Flushing jVector graph index");
         for (FieldWriter<?> field : fields) {
             if (sortMap == null) {
                 writeField(field);
@@ -222,20 +223,41 @@ public class JVectorWriter extends KnnVectorsWriter {
     }
 
     private void writeField(FieldWriter<?> fieldData) throws IOException {
-        OnHeapGraphIndex graph = fieldData.getGraph();
-        final var vectorIndexFieldMetadata = writeGraph(graph, fieldData);
+        log.info("Writing field {}", fieldData.fieldInfo.name);
+        final PQVectors pqVectors;
+        final BuildScoreProvider buildScoreProvider;
+        if (fieldData.randomAccessVectorValues.size() >= minimumBatchSizeForQuantization) {
+            log.info("Calculating codebooks and compressed vectors for field {}", fieldData.fieldInfo.name);
+            pqVectors = getPQVectors(fieldData);
+            buildScoreProvider = BuildScoreProvider.pqBuildScoreProvider(getVectorSimilarityFunction(fieldData.fieldInfo), pqVectors);
+            // buildScoreProvider = BuildScoreProvider.randomAccessScoreProvider(fieldData.randomAccessVectorValues,
+            // getVectorSimilarityFunction(fieldData.fieldInfo));
+        } else {
+            log.info(
+                "Not enough vectors to trigger PQ quantization for field {}, will use full precision vectors instead.",
+                fieldData.fieldInfo.name
+            );
+            pqVectors = null;
+            buildScoreProvider = BuildScoreProvider.randomAccessScoreProvider(
+                fieldData.randomAccessVectorValues,
+                getVectorSimilarityFunction(fieldData.fieldInfo)
+            );
+        }
+
+        OnHeapGraphIndex graph = fieldData.getGraph(buildScoreProvider);
+        final var vectorIndexFieldMetadata = writeGraph(graph, fieldData, pqVectors);
         meta.writeInt(fieldData.fieldInfo.number);
         vectorIndexFieldMetadata.toOutput(meta);
     }
 
     /**
-     * Writes the graph to the vector index file
+     * Writes the graph and PQ codebooks and compressed vectors to the vector index file
      * @param graph graph
      * @param fieldData fieldData
      * @return Tuple of start offset and length of the graph
      * @throws IOException IOException
      */
-    private VectorIndexFieldMetadata writeGraph(OnHeapGraphIndex graph, FieldWriter<?> fieldData) throws IOException {
+    private VectorIndexFieldMetadata writeGraph(OnHeapGraphIndex graph, FieldWriter<?> fieldData, PQVectors pqVectors) throws IOException {
         // field data file, which contains the graph
         final String vectorIndexFieldFileName = baseDataFileName
             + "_"
@@ -279,7 +301,7 @@ public class JVectorWriter extends KnnVectorsWriter {
                 resultBuilder.vectorIndexLength(endGraphOffset - startOffset);
 
                 // If PQ is enabled and we have enough vectors, write the PQ codebooks and compressed vectors
-                if (fieldData.randomAccessVectorValues.size() >= minimumBatchSizeForQuantization) {
+                if (pqVectors != null) {
                     log.info(
                         "Writing PQ codebooks and vectors for field {} since the size is {} >= {}",
                         fieldData.fieldInfo.name,
@@ -287,7 +309,8 @@ public class JVectorWriter extends KnnVectorsWriter {
                         minimumBatchSizeForQuantization
                     );
                     resultBuilder.pqCodebooksAndVectorsOffset(endGraphOffset);
-                    writePQCodebooksAndVectors(jVectorIndexWriter, fieldData);
+                    // write the compressed vectors and codebooks to disk
+                    pqVectors.write(jVectorIndexWriter);
                     resultBuilder.pqCodebooksAndVectorsLength(jVectorIndexWriter.position() - endGraphOffset);
                 } else {
                     resultBuilder.pqCodebooksAndVectorsOffset(0);
@@ -300,28 +323,36 @@ public class JVectorWriter extends KnnVectorsWriter {
         }
     }
 
-    /**
-     * Writes the product quantization (PQ) codebooks and encoded vectors to a DataOutput stream.
-     * This method compresses the original vector data using product quantization and encodes
-     * all vector values into a smaller, compressed form for storage or transfer.
-     *
-     * @param out The DataOutput stream where the compressed PQ codebooks and encoded vectors will be written.
-     * @param fieldData The field writer object providing access to the vector data to be compressed.
-     * @throws IOException If an I/O error occurs during writing.
-     */
-    private void writePQCodebooksAndVectors(DataOutput out, FieldWriter<?> fieldData) throws IOException {
+    private PQVectors getPQVectors(FieldWriter<?> fieldData) throws IOException {
+        log.info("Computing PQ codebooks for field {}", fieldData.fieldInfo.name);
         final var M = numberOfSubspacesPerVectorSupplier.apply(fieldData.randomAccessVectorValues.dimension());
         final var numberOfClustersPerSubspace = Math.min(256, fieldData.randomAccessVectorValues.size()); // number of centroids per
-                                                                                                          // subspace
+        // subspace
         ProductQuantization pq = ProductQuantization.compute(
             fieldData.randomAccessVectorValues,
             M, // number of subspaces
             numberOfClustersPerSubspace, // number of centroids per subspace
-            fieldData.fieldInfo.getVectorSimilarityFunction() == VectorSimilarityFunction.EUCLIDEAN
-        ); // center the dataset
-        var pqv = pq.encodeAll(fieldData.randomAccessVectorValues);
-        // write the compressed vectors to disk
-        pqv.write(out);
+            fieldData.fieldInfo.getVectorSimilarityFunction() == VectorSimilarityFunction.EUCLIDEAN // center the dataset
+        );
+        log.info("Computed PQ codebooks for field {}", fieldData.fieldInfo.name);
+        log.info(
+            "Encoding and building PQ vectors for field {} for {} vectors",
+            fieldData.fieldInfo.name,
+            fieldData.randomAccessVectorValues.size()
+        );
+        var pqVectors = PQVectors.encodeAndBuild(
+            pq,
+            fieldData.randomAccessVectorValues.size(),
+            fieldData.randomAccessVectorValues,
+            ForkJoinPool.commonPool()
+        );
+        log.info(
+            "Encoded and built PQ vectors for field {}, original size: {} bytes, compressed size: {} bytes",
+            fieldData.fieldInfo.name,
+            pqVectors.getOriginalSize(),
+            pqVectors.getCompressedSize()
+        );
+        return pqVectors;
     }
 
     @Value
@@ -410,12 +441,10 @@ public class JVectorWriter extends KnnVectorsWriter {
         @Getter
         private final FieldInfo fieldInfo;
         private int lastDocID = -1;
-        private final GraphIndexBuilder graphIndexBuilder;
         private final String segmentName;
         private final RandomAccessVectorValues randomAccessVectorValues;
         private final FloatVectorValues mergedFloatVector;
         private final FlatFieldVectorsWriter<T> flatFieldVectorsWriter;
-        private final BuildScoreProvider buildScoreProvider;
 
         // For merge fields only
         FieldWriter(FieldInfo fieldInfo, String segmentName, FloatVectorValues mergedFloatVector, RandomAccessVectorValues ravv) {
@@ -425,19 +454,6 @@ public class JVectorWriter extends KnnVectorsWriter {
             // This unmodifiable list makes sure that the addition of values outside what's already in ravv will fail.
             this.fieldInfo = fieldInfo;
             this.segmentName = segmentName;
-            this.buildScoreProvider = BuildScoreProvider.randomAccessScoreProvider(
-                randomAccessVectorValues,
-                getVectorSimilarityFunction(fieldInfo)
-            );
-            this.graphIndexBuilder = new GraphIndexBuilder(
-                buildScoreProvider,
-                fieldInfo.getVectorDimension(),
-                maxConn,
-                beamWidth,
-                degreeOverflow,
-                alpha,
-                true
-            );
         }
 
         FieldWriter(FieldInfo fieldInfo, String segmentName, FlatFieldVectorsWriter<T> flatFieldVectorsWriter) {
@@ -449,19 +465,6 @@ public class JVectorWriter extends KnnVectorsWriter {
             this.mergedFloatVector = null;
             this.fieldInfo = fieldInfo;
             this.segmentName = segmentName;
-            this.buildScoreProvider = BuildScoreProvider.randomAccessScoreProvider(
-                randomAccessVectorValues,
-                getVectorSimilarityFunction(fieldInfo)
-            );
-            this.graphIndexBuilder = new GraphIndexBuilder(
-                buildScoreProvider,
-                randomAccessVectorValues.dimension(),
-                maxConn,
-                beamWidth,
-                degreeOverflow,
-                alpha,
-                true
-            );
         }
 
         @Override
@@ -499,26 +502,22 @@ public class JVectorWriter extends KnnVectorsWriter {
             return SHALLOW_SIZE + flatFieldVectorsWriter.ramBytesUsed();
         }
 
-        io.github.jbellis.jvector.vector.VectorSimilarityFunction getVectorSimilarityFunction(FieldInfo fieldInfo) {
-            log.info("Matching vector similarity function {} for field {}", fieldInfo.getVectorSimilarityFunction(), fieldInfo.name);
-            switch (fieldInfo.getVectorSimilarityFunction()) {
-                case EUCLIDEAN:
-                    return io.github.jbellis.jvector.vector.VectorSimilarityFunction.EUCLIDEAN;
-                case COSINE:
-                    return io.github.jbellis.jvector.vector.VectorSimilarityFunction.COSINE;
-                case DOT_PRODUCT:
-                    return io.github.jbellis.jvector.vector.VectorSimilarityFunction.DOT_PRODUCT;
-                default:
-                    throw new IllegalArgumentException("Unsupported similarity function: " + fieldInfo.getVectorSimilarityFunction());
-            }
-        }
-
         /**
          * This method will return the graph index for the field
          * @return OnHeapGraphIndex
          * @throws IOException IOException
          */
-        public OnHeapGraphIndex getGraph() throws IOException {
+        public OnHeapGraphIndex getGraph(BuildScoreProvider buildScoreProvider) throws IOException {
+            final GraphIndexBuilder graphIndexBuilder = new GraphIndexBuilder(
+                buildScoreProvider,
+                fieldInfo.getVectorDimension(),
+                maxConn,
+                beamWidth,
+                degreeOverflow,
+                alpha,
+                true
+            );
+
             /*
              * We cannot always use randomAccessVectorValues for the graph building
              * because it's size will not always correspond to the document count.
@@ -541,6 +540,16 @@ public class JVectorWriter extends KnnVectorsWriter {
             graphIndexBuilder.cleanup();
             return graphIndexBuilder.getGraph();
         }
+    }
+
+    static io.github.jbellis.jvector.vector.VectorSimilarityFunction getVectorSimilarityFunction(FieldInfo fieldInfo) {
+        log.info("Matching vector similarity function {} for field {}", fieldInfo.getVectorSimilarityFunction(), fieldInfo.name);
+        return switch (fieldInfo.getVectorSimilarityFunction()) {
+            case EUCLIDEAN -> io.github.jbellis.jvector.vector.VectorSimilarityFunction.EUCLIDEAN;
+            case COSINE -> io.github.jbellis.jvector.vector.VectorSimilarityFunction.COSINE;
+            case DOT_PRODUCT -> io.github.jbellis.jvector.vector.VectorSimilarityFunction.DOT_PRODUCT;
+            default -> throw new IllegalArgumentException("Unsupported similarity function: " + fieldInfo.getVectorSimilarityFunction());
+        };
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -230,8 +230,6 @@ public class JVectorWriter extends KnnVectorsWriter {
             log.info("Calculating codebooks and compressed vectors for field {}", fieldData.fieldInfo.name);
             pqVectors = getPQVectors(fieldData);
             buildScoreProvider = BuildScoreProvider.pqBuildScoreProvider(getVectorSimilarityFunction(fieldData.fieldInfo), pqVectors);
-            // buildScoreProvider = BuildScoreProvider.randomAccessScoreProvider(fieldData.randomAccessVectorValues,
-            // getVectorSimilarityFunction(fieldData.fieldInfo));
         } else {
             log.info(
                 "Not enough vectors to trigger PQ quantization for field {}, will use full precision vectors instead.",

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -41,7 +41,6 @@ import org.apache.lucene.util.hnsw.CloseableRandomVectorScorerSupplier;
 
 import java.io.IOException;
 import java.util.*;
-import java.util.concurrent.ForkJoinPool;
 import java.util.function.Function;
 
 import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsReader.readVectorEncoding;

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -338,12 +338,7 @@ public class JVectorWriter extends KnnVectorsWriter {
             fieldData.fieldInfo.name,
             fieldData.randomAccessVectorValues.size()
         );
-        var pqVectors = PQVectors.encodeAndBuild(
-            pq,
-            fieldData.randomAccessVectorValues.size(),
-            fieldData.randomAccessVectorValues,
-            ForkJoinPool.commonPool()
-        );
+        PQVectors pqVectors = (PQVectors) pq.encodeAll(fieldData.randomAccessVectorValues);
         log.info(
             "Encoded and built PQ vectors for field {}, original size: {} bytes, compressed size: {} bytes",
             fieldData.fieldInfo.name,

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -42,9 +42,11 @@ import org.apache.lucene.util.hnsw.CloseableRandomVectorScorerSupplier;
 import java.io.IOException;
 import java.time.Clock;
 import java.util.*;
+import java.util.concurrent.ForkJoinPool;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 
+import static io.github.jbellis.jvector.quantization.KMeansPlusPlusClusterer.UNWEIGHTED;
 import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsReader.readVectorEncoding;
 import static org.opensearch.knn.index.codec.jvector.JVectorFormat.SIMD_POOL;
 
@@ -340,8 +342,12 @@ public class JVectorWriter extends KnnVectorsWriter {
             fieldData.randomAccessVectorValues,
             M, // number of subspaces
             numberOfClustersPerSubspace, // number of centroids per subspace
-            fieldData.fieldInfo.getVectorSimilarityFunction() == VectorSimilarityFunction.EUCLIDEAN // center the dataset
+            fieldData.fieldInfo.getVectorSimilarityFunction() == VectorSimilarityFunction.EUCLIDEAN, // center the dataset
+            UNWEIGHTED,
+            SIMD_POOL,
+            ForkJoinPool.commonPool()
         );
+
         final long end = Clock.systemDefaultZone().millis();
         log.info("Computed PQ codebooks for field {}, in {} millis", fieldData.fieldInfo.name, end - start);
         log.info(

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -321,7 +321,7 @@ public class JVectorWriter extends KnnVectorsWriter {
     }
 
     private PQVectors getPQVectors(FieldWriter<?> fieldData) throws IOException {
-        log.info("Computing PQ codebooks for field {}", fieldData.fieldInfo.name);
+        log.info("Computing PQ codebooks for field {} for {} vectors", fieldData.fieldInfo.name, fieldData.randomAccessVectorValues.size());
         final var M = numberOfSubspacesPerVectorSupplier.apply(fieldData.randomAccessVectorValues.dimension());
         final var numberOfClustersPerSubspace = Math.min(256, fieldData.randomAccessVectorValues.size()); // number of centroids per
         // subspace

--- a/src/main/resources/hotspot_compiler
+++ b/src/main/resources/hotspot_compiler
@@ -1,0 +1,9 @@
+[
+  {
+    match: ["*.*"],
+    "inline": [
+// Third party library used for Vector Search https://github.com/jbellis/jvector
+      "+io.github.jbellis.jvector.vector.VectorUtil::*"
+    ]
+  }
+]

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
@@ -1235,30 +1235,4 @@ public class KNNJVectorTests extends LuceneTestCase {
         vector[vectorDimension - 1] = lastValue;
         return vector;
     }
-
-    private static float[][] generateRandomVectors(int numVectors, int vectorDimension) {
-        float[][] vectors = new float[numVectors][vectorDimension];
-        for (int i = 0; i < numVectors; i++) {
-            vectors[i] = generateRandomVector(vectorDimension);
-        }
-        return vectors;
-    }
-
-    private static float[] generateRandomVector(int vectorDimension) {
-        float[] vector = new float[vectorDimension];
-        for (int i = 0; i < vectorDimension; i++) {
-            vector[i] = random().nextFloat();
-        }
-        return vector;
-    }
-
-    private static float calculateRecall(TopDocs topDocs, float[] target, float[][] vectors, int k) {
-        int totalRelevantDocs = 0;
-        for (int i = 0; i < topDocs.scoreDocs.length; i++) {
-            if (VectorSimilarityFunction.EUCLIDEAN.compare(target, vectors[topDocs.scoreDocs[i].doc]) >= topDocs.scoreDocs[i].score) {
-                totalRelevantDocs++;
-            }
-        }
-        return ((float) totalRelevantDocs) / ((float) k);
-    }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
@@ -6,8 +6,6 @@
 package org.opensearch.knn.index.codec.jvector;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
-import io.github.jbellis.jvector.vector.VectorizationProvider;
-import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.document.*;
 import org.apache.lucene.index.*;
@@ -28,7 +26,6 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.ToDoubleFunction;
 
 import static org.opensearch.knn.index.codec.jvector.JVectorFormat.DEFAULT_MERGE_ON_DISK;
 import static org.opensearch.knn.index.codec.jvector.JVectorFormat.DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION;
@@ -1210,7 +1207,8 @@ public class KNNJVectorTests extends LuceneTestCase {
         return vector;
     }
 
-    private static float calculateRecall(IndexReader reader, Set<Integer> groundTruthVectorsIds, TopDocs topDocs, int k) throws IOException {
+    private static float calculateRecall(IndexReader reader, Set<Integer> groundTruthVectorsIds, TopDocs topDocs, int k)
+        throws IOException {
         final ScoreDoc[] scoreDocs = topDocs.scoreDocs;
         Assert.assertEquals(groundTruthVectorsIds.size(), scoreDocs.length);
         int totalRelevantDocs = 0;
@@ -1230,7 +1228,12 @@ public class KNNJVectorTests extends LuceneTestCase {
      * @param k the number of expected results
      * @return the IDs of the ground truth vectors in the dataset
      */
-    private static Set<Integer> calculateGroundTruthVectorsIds(float[] query, final float[][] dataset, int k, VectorSimilarityFunction vectorSimilarityFunction) {
+    private static Set<Integer> calculateGroundTruthVectorsIds(
+        float[] query,
+        final float[][] dataset,
+        int k,
+        VectorSimilarityFunction vectorSimilarityFunction
+    ) {
         final Set<Integer> groundTruthVectorsIds = new HashSet<>();
         final PriorityQueue<ScoreDoc> priorityQueue = new PriorityQueue<>(k, (o1, o2) -> Float.compare(o1.score, o2.score));
         for (int i = 0; i < dataset.length; i++) {
@@ -1252,6 +1255,5 @@ public class KNNJVectorTests extends LuceneTestCase {
 
         return groundTruthVectorsIds;
     }
-
 
 }

--- a/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
+++ b/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
@@ -50,7 +50,8 @@ public class RecallTestsIT extends KNNRestTestCase {
     private static final String PROPERTIES_FIELD = "properties";
     private final static String TEST_INDEX_PREFIX_NAME = "test_index";
     private final static String TEST_FIELD_NAME = "test_field";
-    private final static int TEST_DIMENSION = 128;
+    // For more extensive real world scenarios increase the vector dimensions
+    private final static int TEST_DIMENSION = 32;
     private final static int DOC_COUNT = 10000;
     private final static int BATCH_SIZE = 1000;
     private final static int QUERY_COUNT = 100;

--- a/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
+++ b/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
@@ -52,6 +52,7 @@ public class RecallTestsIT extends KNNRestTestCase {
     private final static String TEST_FIELD_NAME = "test_field";
     private final static int TEST_DIMENSION = 32;
     private final static int DOC_COUNT = 10000;
+    private final static int BATCH_SIZE = 1000;
     private final static int QUERY_COUNT = 100;
     private final static int TEST_K = 100;
     private final static double PERFECT_RECALL = 1.0;
@@ -185,7 +186,12 @@ public class RecallTestsIT extends KNNRestTestCase {
     @SneakyThrows
     private void createIndexAndIngestDocs(String indexName, String fieldName, Settings settings, String mapping) {
         createKnnIndex(indexName, settings, mapping);
-        bulkAddKnnDocs(indexName, fieldName, INDEX_VECTORS, DOC_COUNT);
+        for (int i = 0; i < DOC_COUNT; i+=BATCH_SIZE) {
+            logger.info("Ingesting batch {}/{}", i, DOC_COUNT);
+            final float[][] indexVectors = new float[BATCH_SIZE][TEST_DIMENSION];
+            System.arraycopy(INDEX_VECTORS, i, indexVectors, 0, BATCH_SIZE);
+            bulkAddKnnDocs(indexName, fieldName, indexVectors, i, BATCH_SIZE);
+        }
         forceMergeKnnIndex(indexName, MAX_SEGMENT_COUNT);
     }
 

--- a/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
+++ b/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
@@ -186,7 +186,7 @@ public class RecallTestsIT extends KNNRestTestCase {
     @SneakyThrows
     private void createIndexAndIngestDocs(String indexName, String fieldName, Settings settings, String mapping) {
         createKnnIndex(indexName, settings, mapping);
-        for (int i = 0; i < DOC_COUNT; i+=BATCH_SIZE) {
+        for (int i = 0; i < DOC_COUNT; i += BATCH_SIZE) {
             logger.info("Ingesting batch {}/{}", i, DOC_COUNT);
             final float[][] indexVectors = new float[BATCH_SIZE][TEST_DIMENSION];
             System.arraycopy(INDEX_VECTORS, i, indexVectors, 0, BATCH_SIZE);

--- a/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
+++ b/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
@@ -51,7 +51,7 @@ public class RecallTestsIT extends KNNRestTestCase {
     private final static String TEST_INDEX_PREFIX_NAME = "test_index";
     private final static String TEST_FIELD_NAME = "test_field";
     // For more extensive real world scenarios increase the vector dimensions
-    private final static int TEST_DIMENSION = 32;
+    private final static int TEST_DIMENSION = 16;
     private final static int DOC_COUNT = 10000;
     private final static int BATCH_SIZE = 1000;
     private final static int QUERY_COUNT = 100;

--- a/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
+++ b/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
@@ -75,6 +75,7 @@ public class RecallTestsIT extends KNNRestTestCase {
         SpaceType.INNER_PRODUCT,
         TestUtils.computeGroundTruthValues(INDEX_VECTORS, QUERY_VECTORS, SpaceType.INNER_PRODUCT, TEST_K)
     );
+    private static final List<SpaceType> SPACE_TYPE_LIST = List.of(SpaceType.L2, SpaceType.COSINESIMIL);
 
     /**
      * {
@@ -97,8 +98,7 @@ public class RecallTestsIT extends KNNRestTestCase {
      */
     @SneakyThrows
     public void testRecall_whenLuceneHnswFP32_thenRecallAbove75percent() {
-        List<SpaceType> spaceTypes = List.of(SpaceType.L2, SpaceType.COSINESIMIL);
-        for (SpaceType spaceType : spaceTypes) {
+        for (SpaceType spaceType : SPACE_TYPE_LIST) {
             String indexName = createIndexName(KNNEngine.LUCENE, spaceType);
             XContentBuilder builder = XContentFactory.jsonBuilder()
                 .startObject()
@@ -147,8 +147,7 @@ public class RecallTestsIT extends KNNRestTestCase {
      */
     @SneakyThrows
     public void testRecall_whenJVectorDiskANN_thenRecallAbove75percent() {
-        List<SpaceType> spaceTypes = List.of(SpaceType.L2, SpaceType.COSINESIMIL);
-        for (SpaceType spaceType : spaceTypes) {
+        for (SpaceType spaceType : SPACE_TYPE_LIST) {
             String indexName = createIndexName(KNNEngine.JVECTOR, spaceType);
             XContentBuilder builder = XContentFactory.jsonBuilder()
                 .startObject()

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -1589,15 +1589,16 @@ public class KNNRestTestCase extends ODFERestTestCase {
     }
 
     // Method that adds multiple documents into the index using Bulk API
-    public void bulkAddKnnDocs(String index, String fieldName, float[][] indexVectors, int docCount) throws IOException {
-        bulkAddKnnDocs(index, fieldName, indexVectors, 0, docCount);
+    public void bulkAddKnnDocs(String index, String fieldName, float[][] indexVectors, int docCount, boolean refresh) throws IOException {
+        bulkAddKnnDocs(index, fieldName, indexVectors, 0, docCount, refresh);
     }
 
     // Method that adds multiple documents into the index using Bulk API
-    public void bulkAddKnnDocs(String index, String fieldName, float[][] indexVectors, int baseDocId, int docCount) throws IOException {
+    public void bulkAddKnnDocs(String index, String fieldName, float[][] indexVectors, int baseDocId, int docCount, boolean refresh)
+        throws IOException {
         Request request = new Request("POST", "/_bulk");
 
-        request.addParameter("refresh", "true");
+        request.addParameter("refresh", Boolean.toString(refresh));
         StringBuilder sb = new StringBuilder();
 
         for (int i = 0; i < docCount; i++) {

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -1602,15 +1602,15 @@ public class KNNRestTestCase extends ODFERestTestCase {
 
         for (int i = 0; i < docCount; i++) {
             sb.append("{ \"index\" : { \"_index\" : \"")
-                    .append(index)
-                    .append("\", \"_id\" : \"")
-                    .append(baseDocId + i)
-                    .append("\" } }\n")
-                    .append("{ \"")
-                    .append(fieldName)
-                    .append("\" : ")
-                    .append(Arrays.toString(indexVectors[i]))
-                    .append(" }\n");
+                .append(index)
+                .append("\", \"_id\" : \"")
+                .append(baseDocId + i)
+                .append("\" } }\n")
+                .append("{ \"")
+                .append(fieldName)
+                .append("\" : ")
+                .append(Arrays.toString(indexVectors[i]))
+                .append(" }\n");
         }
 
         request.setJsonEntity(sb.toString());

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -1590,6 +1590,11 @@ public class KNNRestTestCase extends ODFERestTestCase {
 
     // Method that adds multiple documents into the index using Bulk API
     public void bulkAddKnnDocs(String index, String fieldName, float[][] indexVectors, int docCount) throws IOException {
+        bulkAddKnnDocs(index, fieldName, indexVectors, 0, docCount);
+    }
+
+    // Method that adds multiple documents into the index using Bulk API
+    public void bulkAddKnnDocs(String index, String fieldName, float[][] indexVectors, int baseDocId, int docCount) throws IOException {
         Request request = new Request("POST", "/_bulk");
 
         request.addParameter("refresh", "true");
@@ -1597,15 +1602,15 @@ public class KNNRestTestCase extends ODFERestTestCase {
 
         for (int i = 0; i < docCount; i++) {
             sb.append("{ \"index\" : { \"_index\" : \"")
-                .append(index)
-                .append("\", \"_id\" : \"")
-                .append(i)
-                .append("\" } }\n")
-                .append("{ \"")
-                .append(fieldName)
-                .append("\" : ")
-                .append(Arrays.toString(indexVectors[i]))
-                .append(" }\n");
+                    .append(index)
+                    .append("\", \"_id\" : \"")
+                    .append(baseDocId + i)
+                    .append("\" } }\n")
+                    .append("{ \"")
+                    .append(fieldName)
+                    .append("\" : ")
+                    .append(Arrays.toString(indexVectors[i]))
+                    .append(" }\n");
         }
 
         request.setJsonEntity(sb.toString());


### PR DESCRIPTION
### Description
At the moment the exact scoring function is used during index construction. However, index construction can leverage the approximate PQ score for faster index build times.

### Changes
In this change we will use the approximate PQ construction function going forward.

### Related Issues
Resolves #110 

### Check List
- [x ] New functionality includes testing.
- [x ] New functionality has been documented.
~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x ] Commits are signed per the DCO using `--signoff`.
~- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
