### PR TITLE
Expose merge bug as test was swallowing it

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
@@ -216,6 +216,7 @@ public class JVectorReader extends KnnVectorsReader {
         for (FieldEntry fieldEntry : fieldEntryMap.values()) {
             IOUtils.close(fieldEntry);
         }
+        fieldEntryMap.clear();
     }
 
     private void readFields(ChecksumIndexInput meta) throws IOException {

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
@@ -482,7 +482,7 @@ public class KNNJVectorTests extends LuceneTestCase {
                                 }
                             } finally {
                                 latch.countDown();
-                                log.warn("Ran " + i + " queries");
+                                log.warn("Ran {} queries", i);
                             }
                         });
                     }

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
@@ -461,9 +461,11 @@ public class KNNJVectorTests extends LuceneTestCase {
                 try {
                     for (int t = 0; t < numThreads; t++) {
                         executor.submit(() -> {
+                            int i = 0;
+
                             try {
                                 ThreadLocalRandom random = ThreadLocalRandom.current();
-                                for (int i = 0; i < queriesPerThread && !failureDetected.get(); i++) {
+                                for (i = 0; i < queriesPerThread && !failureDetected.get(); i++) {
                                     // Choose a random docId to search for
                                     int randomDocId = random.nextInt(reader.maxDoc());
                                     float[] query = new float[] { randomDocId, 0 };
@@ -472,13 +474,15 @@ public class KNNJVectorTests extends LuceneTestCase {
                                         assertEquals("Search should return correct number of results", k, td.scoreDocs.length);
                                         assertEquals("Search should return the correct document", randomDocId, td.scoreDocs[0].doc);
                                         totalQueries.incrementAndGet();
-                                    } catch (Exception e) {
-                                        failureDetected.set(true);
+                                    } catch (Throwable e) {
+                                        failureDetected.compareAndSet(false, true);
+                                        log.error("Exception encountered", e);
                                         fail("Exception during concurrent search: " + e.getMessage());
                                     }
                                 }
                             } finally {
                                 latch.countDown();
+                                log.warn("Ran " + i + " queries");
                             }
                         });
                     }
@@ -487,9 +491,10 @@ public class KNNJVectorTests extends LuceneTestCase {
                     boolean completed = latch.await(30, TimeUnit.SECONDS);
                     assertTrue("Test timed out while waiting for concurrent searches", completed);
                     assertFalse("Test encountered failures during concurrent searches", failureDetected.get());
+                    assertEquals("Incorrect number of queries executed", numThreads * queriesPerThread, totalQueries.get());
 
                     // Log the number of successful queries
-                    log.info("Successfully completed {} concurrent kNN search queries", totalQueries.get());
+                    log.info("Successfully completed {} concurrent kNN search queries!", totalQueries.get());
 
                 } finally {
                     executor.shutdownNow();


### PR DESCRIPTION
This pull request improves resource management and enhances the robustness and logging of concurrent kNN search tests in the `JVectorReader` and `KNNJVectorTests` classes.

It was silently failing!

Test Robustness and Logging Improvements:

* Improved exception handling in the concurrent search test by catching `Throwable` instead of `Exception`, using `compareAndSet` for atomic failure flag updates, and logging encountered exceptions.
* Added per-thread logging of the number of queries executed for better visibility during test runs.
* Added an assertion to verify the total number of queries executed matches expectations, and updated the success log message for clarity.

Code Clarity:

* Refactored the query counter in the concurrent search test for clearer tracking of queries executed per thread.### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
