### PR TITLE
speed up merge by ensuring sequential reads are used

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
@@ -94,7 +94,7 @@ public class JVectorReader extends KnnVectorsReader {
     public void checkIntegrity() throws IOException {
         flatVectorsReader.checkIntegrity();
         for (FieldEntry fieldEntry : fieldEntryMap.values()) {
-            try (var indexInput = state.directory.openInput(fieldEntry.vectorIndexFieldDataFileName, state.context)) {
+            try (var indexInput = state.directory.openInput(fieldEntry.vectorIndexFieldDataFileName, IOContext.READONCE)) {
                 CodecUtil.checksumEntireFile(indexInput);
             }
         }
@@ -278,7 +278,7 @@ public class JVectorReader extends KnnVectorsReader {
                     throw new IllegalArgumentException("pqCodebooksAndVectorsOffset must be greater than vectorIndexOffset");
                 }
                 this.pqCodebooksReaderSupplier = new JVectorRandomAccessReader.Supplier(
-                    directory.openInput(vectorIndexFieldDataFileName, state.context),
+                    directory.openInput(vectorIndexFieldDataFileName, IOContext.READONCE),
                     pqCodebooksAndVectorsOffset,
                     pqCodebooksAndVectorsLength
                 );

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -157,7 +157,7 @@ public class JVectorWriter extends KnnVectorsWriter {
     @Override
     public void mergeOneField(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
         log.info("Merging field {} into segment {}", fieldInfo.name, segmentWriteState.segmentInfo.name);
-        CloseableRandomVectorScorerSupplier scorerSupplier = flatVectorWriter.mergeOneFieldToIndex(fieldInfo, mergeState);
+        flatVectorWriter.mergeOneField(fieldInfo, mergeState);
         var success = false;
         try {
             final long mergeStart = Clock.systemDefaultZone().millis();
@@ -190,12 +190,7 @@ public class JVectorWriter extends KnnVectorsWriter {
             success = true;
             log.info("Completed Merge field {} into segment {}", fieldInfo.name, segmentWriteState.segmentInfo.name);
         } finally {
-            IOUtils.close(scorerSupplier);
-            if (success) {
-                // IOUtils.close(scorerSupplier);
-            } else {
-                // IOUtils.closeWhileHandlingException(scorerSupplier);
-            }
+
         }
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -38,7 +38,6 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.store.*;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.RamUsageEstimator;
-import org.apache.lucene.util.hnsw.CloseableRandomVectorScorerSupplier;
 import org.opensearch.knn.plugin.stats.KNNCounter;
 
 import java.io.IOException;


### PR DESCRIPTION
### Description

This pull request makes small but important changes to how file input contexts are handled in the `JVectorReader` class. The changes ensure that file reads for integrity checks and PQ codebooks access use the `IOContext.READONCE` context instead of the previous `state.context`, which is more appropriate for single-use, read-only operations.

* File Input Context Updates:
  * Updated the file input context to use `IOContext.READONCE` in the `checkIntegrity` method when opening vector index files for checksum verification.
  * Changed the file input context to `IOContext.READONCE` when creating the `pqCodebooksReaderSupplier` in the `FieldEntry` constructor for reading PQ codebooks and vectors.


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
