### PR TITLE
fix ordering test

### DIFF
--- a/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
@@ -403,6 +403,9 @@ public class KNNJVectorTests extends LuceneTestCase {
         final String floatVectorField = "vec";
         final String expectedDocIdField = "expectedDocId";
         final Path indexPath = createTempDir();
+        final float[][] sourceVectors = TestUtils.generateRandomVectors(numDocs, 2);
+        final VectorSimilarityFunction vectorSimilarityFunction = VectorSimilarityFunction.EUCLIDEAN;
+
         try (Directory dir = newFSDirectory(indexPath)) {
             IndexWriterConfig cfg = newIndexWriterConfig();
             cfg.setCodec(getCodec());
@@ -415,7 +418,7 @@ public class KNNJVectorTests extends LuceneTestCase {
                 for (int i = 0; i < numDocs; i++) {
                     Document doc = new Document();
                     // vector whose first component encodes the future (segment-local) docID
-                    doc.add(new KnnFloatVectorField(floatVectorField, new float[] { i, 0 }, VectorSimilarityFunction.EUCLIDEAN));
+                    doc.add(new KnnFloatVectorField(floatVectorField, sourceVectors[i], vectorSimilarityFunction));
                     doc.add(new StoredField(expectedDocIdField, i));
                     w.addDocument(doc);
                 }
@@ -435,14 +438,19 @@ public class KNNJVectorTests extends LuceneTestCase {
                 for (LeafReaderContext context : reader.leaves()) {
                     FloatVectorValues vectorValues = context.reader().getFloatVectorValues("vec");
                     for (int docId = 0; docId < context.reader().maxDoc(); docId++) {
-                        int actualDocId = context.docBase + docId;
+                        final int luceneDocId = context.docBase + docId;
+                        final int globalDocId = reader.storedFields().document(luceneDocId).getField(expectedDocIdField).storedValue().getIntValue();
                         float[] vectorValue = vectorValues.vectorValue(docId);
-                        assertEquals("vector[0] should encode docId", (float) actualDocId, vectorValue[0], 0.0f);
+                        float[] expectedVectorValue = sourceVectors[globalDocId];
+                        Assert.assertArrayEquals("vectors in source and index should match", expectedVectorValue, vectorValue, 0.0f);
                     }
                 }
 
                 // (b) search with the same vector and confirm we are not exhausting the file handles with each search
                 IndexSearcher searcher = newSearcher(reader);
+                LeafReaderContext context = reader.leaves().get(0); // we only have one leaf at this point so we can use it to obtain the vector values
+                final int baseDocId = context.docBase;
+                final FloatVectorValues vectorValues = context.reader().getFloatVectorValues("vec");
                 final int k = 1;
                 for (int docId = 0; docId < reader.maxDoc(); docId++) {
                     float[] query = new float[] { docId, 0 };
@@ -464,15 +472,16 @@ public class KNNJVectorTests extends LuceneTestCase {
                             int i = 0;
 
                             try {
-                                ThreadLocalRandom random = ThreadLocalRandom.current();
                                 for (i = 0; i < queriesPerThread && !failureDetected.get(); i++) {
-                                    // Choose a random docId to search for
-                                    int randomDocId = random.nextInt(reader.maxDoc());
-                                    float[] query = new float[] { randomDocId, 0 };
+                                    float[] query = TestUtils.generateRandomVectors(1, 2)[0];
                                     try {
                                         TopDocs td = searcher.search(new KnnFloatVectorQuery("vec", query, k), k);
                                         assertEquals("Search should return correct number of results", k, td.scoreDocs.length);
-                                        assertEquals("Search should return the correct document", randomDocId, td.scoreDocs[0].doc);
+                                        final int localDocId = td.scoreDocs[0].doc;
+                                        final int globalDocId = reader.storedFields().document(localDocId).getField(expectedDocIdField).storedValue().getIntValue();
+                                        float[] vectorValue = vectorValues.vectorValue(localDocId - baseDocId);
+                                        float[] expectedVectorValue = sourceVectors[globalDocId];
+                                        Assert.assertArrayEquals("vectors in source and index should match", expectedVectorValue, vectorValue, 0.0f);
                                         totalQueries.incrementAndGet();
                                     } catch (Throwable e) {
                                         failureDetected.compareAndSet(false, true);


### PR DESCRIPTION
### Description
Ordering test was broken and was using flawed logic.
This change fixes it to leverage the global UUID, and avoid creating monotonously increasing dataset which will break PQ.

### Related Issues
Follow up fix to https://github.com/opensearch-project/opensearch-jvector/pull/142

### Check List
~- [ ] New functionality includes testing.~
~- [ ] New functionality has been documented.~
~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x ] Commits are signed per the DCO using `--signoff`.
~- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
