### PR TITLE
Fix racy ThreadGroup NPE when threads stop as check runs

### DIFF
--- a/src/test/java/org/opensearch/knn/index/ThreadLeakFiltersForTests.java
+++ b/src/test/java/org/opensearch/knn/index/ThreadLeakFiltersForTests.java
@@ -14,10 +14,11 @@ import com.carrotsearch.randomizedtesting.ThreadFilter;
 public class ThreadLeakFiltersForTests implements ThreadFilter {
     @Override
     public boolean reject(Thread thread) {
-        return thread.getName().startsWith("ForkJoinPool")
-            && (thread.getThreadGroup().getName().contains("InternalKNNEngineTests")
-                || thread.getThreadGroup().getName().startsWith("TGRP-KNNJVectorTests")
-                || thread.getThreadGroup().getName().startsWith("TGRP-JVectorConcurrentQueryTests")
-                || thread.getThreadGroup().getName().startsWith("TGRP-MemoryUsageAnalysisTests"));
+        ThreadGroup threadGroup = thread.getThreadGroup();
+        return thread.getName().startsWith("ForkJoinPool") && threadGroup != null
+                && (threadGroup.getName().contains("InternalKNNEngineTests")
+                || threadGroup.getName().startsWith("TGRP-KNNJVectorTests")
+                || threadGroup.getName().startsWith("TGRP-JVectorConcurrentQueryTests")
+                || threadGroup.getName().startsWith("TGRP-MemoryUsageAnalysisTests"));
     }
 }

--- a/src/test/java/org/opensearch/knn/index/ThreadLeakFiltersForTests.java
+++ b/src/test/java/org/opensearch/knn/index/ThreadLeakFiltersForTests.java
@@ -15,8 +15,9 @@ public class ThreadLeakFiltersForTests implements ThreadFilter {
     @Override
     public boolean reject(Thread thread) {
         ThreadGroup threadGroup = thread.getThreadGroup();
-        return thread.getName().startsWith("ForkJoinPool") && threadGroup != null
-                && (threadGroup.getName().contains("InternalKNNEngineTests")
+        return thread.getName().startsWith("ForkJoinPool")
+            && threadGroup != null
+            && (threadGroup.getName().contains("InternalKNNEngineTests")
                 || threadGroup.getName().startsWith("TGRP-KNNJVectorTests")
                 || threadGroup.getName().startsWith("TGRP-JVectorConcurrentQueryTests")
                 || threadGroup.getName().startsWith("TGRP-MemoryUsageAnalysisTests"));


### PR DESCRIPTION
### Description
CI has random failures related to `ThreadLeakFiltersForTest`.  What's happening is the check runs as a thread group shuts down causing a NPE since getThreadGroup is null for stopped threads.  See https://docs.oracle.com/javase/8/docs/api/java/lang/Thread.html#getThreadGroup--



### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
