### PR TITLE
Update publishing of jVector with OS version parameter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -39,8 +39,10 @@ jobs:
           exclude-workflow-initiator-as-approver: true
       - name: Build with Gradle
         run: |
-          ./gradlew --no-daemon -Dbuild.snapshot=false publishNebulaPublicationToLocalRepoRepository
-          ./gradlew --no-daemon -Dbuild.snapshot=false publishPluginZipPublicationToLocalRepoRepository
+          OS_VERSION=`./gradlew -Dbuild.snapshot=false properties | grep -iE "^version:" | cut -d: -f2 | cut -d. -f1-3 | tr -d ' '`
+          echo "OS_VERSION $OS_VERSION"
+          ./gradlew --no-daemon -Dbuild.snapshot=false -Dopensearch.version=$OS_VERSION publishNebulaPublicationToLocalRepoRepository
+          ./gradlew --no-daemon -Dbuild.snapshot=false -Dopensearch.version=$OS_VERSION publishPluginZipPublicationToLocalRepoRepository
           tar -C build -czvf artifacts.tar.gz repository
       - name: Draft a release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
### Description
Update publishing of jVector with OS version parameter

### Related Issues
Resolves https://github.com/opensearch-project/opensearch-jvector/issues/183



### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
