### PR TITLE
Fix visited docs tracking that led to assertions on AbstractKnnVectorQuery side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 ### Enhancements
 ### Bug Fixes
+* Fix visited docs tracking that led to assertions on AbstractKnnVectorQuery side [238] (https://github.com/opensearch-project/opensearch-jvector/pull/238)
 ### Infrastructure
 * Upgrade Gradle to 9.2.0 [220] (https://github.com/opensearch-project/opensearch-jvector/pull/222)
 * Add support for JDK25 [220] (https://github.com/opensearch-project/opensearch-jvector/pull/222)

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ plugins {
     id 'java-library'
     id 'java-test-fixtures'
     id 'idea'
+    id 'eclipse'
     id "com.diffplug.spotless" version "6.25.0" apply false
     id 'io.freefair.lombok' version '8.14'
     id "de.undercouch.download" version "5.3.0"

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
@@ -213,6 +213,12 @@ public class JVectorReader extends KnnVectorsReader {
                     expandedBaseLayerCount
                 );
 
+                // Apache Lucene tracks visited counter so to validate scored docs/ total hits (
+                // see AbstractKnnVectorQuery please). The counter has to be updated manually.
+                final int visitedCount = visitedNodesCount + expandedCount;
+                if (visitedCount > 0) {
+                    jvectorKnnCollector.incVisitedCount(visitedCount);
+                }
             }
         }
     }

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
@@ -28,8 +28,6 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.opensearch.knn.KNNRestTestCase.TERM_QUERY_FIELD_NAME;
-import static org.opensearch.knn.KNNRestTestCase.TERM_QUERY_FIELD_VALUE;
 import static org.opensearch.knn.common.KNNConstants.DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION;
 import static org.opensearch.knn.index.engine.CommonTestUtils.getCodec;
 
@@ -196,7 +194,6 @@ public class KNNJVectorTests extends LuceneTestCase {
                 final float[] source = new float[] { 0.0f, i };
                 doc.add(new KnnFloatVectorField("test_field", source, vectorSimilarityFunction));
                 doc.add(new IntField(TEST_ID_FIELD, i, Field.Store.YES));
-                doc.add(new StringField(TERM_QUERY_FIELD_NAME, TERM_QUERY_FIELD_VALUE, Field.Store.YES));
                 // Add the sortable field
                 doc.add(new NumericDocValuesField(sortFieldName, i));
                 w.addDocument(doc);
@@ -209,7 +206,7 @@ public class KNNJVectorTests extends LuceneTestCase {
                 Assert.assertEquals(1, reader.getContext().leaves().size());
                 Assert.assertEquals(totalNumberOfDocs, reader.numDocs());
 
-                final Query filterQuery = new TermQuery(new Term(TERM_QUERY_FIELD_NAME, TERM_QUERY_FIELD_VALUE));
+                final Query filterQuery = new MatchAllDocsQuery();
                 final IndexSearcher searcher = newSearcher(reader);
                 KnnFloatVectorQuery knnFloatVectorQuery = getJVectorKnnFloatVectorQuery("test_field", target, k, filterQuery);
                 TopDocs topDocs = searcher.search(knnFloatVectorQuery, k);
@@ -329,7 +326,6 @@ public class KNNJVectorTests extends LuceneTestCase {
                 final Document doc = new Document();
                 doc.add(new KnnFloatVectorField("test_field", source, VectorSimilarityFunction.EUCLIDEAN));
                 doc.add(new StringField("my_doc_id", Integer.toString(i, 10), Field.Store.YES));
-                doc.add(new StringField(TERM_QUERY_FIELD_NAME, TERM_QUERY_FIELD_VALUE, Field.Store.YES));
                 w.addDocument(doc);
                 w.commit(); // this creates a new segment without triggering a merge
             }
@@ -341,7 +337,7 @@ public class KNNJVectorTests extends LuceneTestCase {
                 log.info("We should now have 1 segment with 10 documents");
                 Assert.assertEquals(1, reader.getContext().leaves().size());
                 Assert.assertEquals(totalNumberOfDocs, reader.numDocs());
-                final Query filterQuery = new TermQuery(new Term(TERM_QUERY_FIELD_NAME, TERM_QUERY_FIELD_VALUE));
+                final Query filterQuery = new MatchAllDocsQuery();
                 final IndexSearcher searcher = newSearcher(reader);
                 KnnFloatVectorQuery knnFloatVectorQuery = getJVectorKnnFloatVectorQuery("test_field", target, k, filterQuery);
                 TopDocs topDocs = searcher.search(knnFloatVectorQuery, k);

--- a/src/test/java/org/opensearch/knn/index/engine/InternalKNNEngineTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/InternalKNNEngineTests.java
@@ -506,7 +506,7 @@ public class InternalKNNEngineTests extends OpenSearchIntegTestCase {
         // calculate recall
         logger.info("Calculating recall");
         float recall = ((float) results.stream().filter(r -> expectedDocIds.contains(r.getDocId())).count()) / ((float) k);
-        assertTrue("Expected recall to be at least 0.9 but got " + recall, recall >= 0.9);
+        assertTrue("Expected recall to be at least 0.9 but got " + recall, recall >= 0.9f);
     }
 
     /**

--- a/src/test/java/org/opensearch/knn/index/engine/JVectorEngineIT.java
+++ b/src/test/java/org/opensearch/knn/index/engine/JVectorEngineIT.java
@@ -18,7 +18,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
-import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.TestUtils;
@@ -350,11 +349,7 @@ public class JVectorEngineIT extends KNNRestTestCase {
 
     private List<float[]> queryResults(final float[] searchVector, final int k) throws Exception {
         final String responseBody = EntityUtils.toString(
-            searchKNNIndex(
-                INDEX_NAME,
-                new KNNQueryBuilder(FIELD_NAME, searchVector, k, new TermQueryBuilder(TERM_QUERY_FIELD_NAME, TERM_QUERY_FIELD_VALUE)),
-                k
-            ).getEntity()
+            searchKNNIndex(INDEX_NAME, new KNNQueryBuilder(FIELD_NAME, searchVector, k), k).getEntity()
         );
         final List<KNNResult> knnResults = parseSearchResponse(responseBody, FIELD_NAME);
         assertNotNull(knnResults);
@@ -425,11 +420,7 @@ public class JVectorEngineIT extends KNNRestTestCase {
 
         int k = CommonTestUtils.TEST_INDEX_VECTORS.length;
         for (float[] queryVector : TEST_QUERY_VECTORS) {
-            Response response = searchKNNIndex(
-                INDEX_NAME,
-                new KNNQueryBuilder(fieldName, queryVector, k, new TermQueryBuilder(TERM_QUERY_FIELD_NAME, TERM_QUERY_FIELD_VALUE)),
-                k
-            );
+            Response response = searchKNNIndex(INDEX_NAME, buildSearchQuery(fieldName, k, queryVector, methodParameters), k);
             String responseBody = EntityUtils.toString(response.getEntity());
             List<KNNResult> knnResults = parseSearchResponse(responseBody, fieldName);
             assertEquals(k, knnResults.size());

--- a/src/test/java/org/opensearch/knn/index/engine/LuceneEngineIT.java
+++ b/src/test/java/org/opensearch/knn/index/engine/LuceneEngineIT.java
@@ -21,7 +21,6 @@ import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
-import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.TestUtils;
@@ -842,11 +841,7 @@ public class LuceneEngineIT extends KNNRestTestCase {
 
         int k = LuceneEngineIT.TEST_INDEX_VECTORS.length;
         for (float[] queryVector : TEST_QUERY_VECTORS) {
-            Response response = searchKNNIndex(
-                INDEX_NAME,
-                new KNNQueryBuilder(fieldName, queryVector, k, new TermQueryBuilder(TERM_QUERY_FIELD_NAME, TERM_QUERY_FIELD_VALUE)),
-                k
-            );
+            Response response = searchKNNIndex(INDEX_NAME, buildSearchQuery(fieldName, k, queryVector, methodParameters), k);
             String responseBody = EntityUtils.toString(response.getEntity());
             List<KNNResult> knnResults = parseSearchResponse(responseBody, fieldName);
             assertEquals(k, knnResults.size());
@@ -863,11 +858,7 @@ public class LuceneEngineIT extends KNNRestTestCase {
 
     private List<float[]> queryResults(final float[] searchVector, final int k) throws Exception {
         final String responseBody = EntityUtils.toString(
-            searchKNNIndex(
-                INDEX_NAME,
-                new KNNQueryBuilder(FIELD_NAME, searchVector, k, new TermQueryBuilder(TERM_QUERY_FIELD_NAME, TERM_QUERY_FIELD_VALUE)),
-                k
-            ).getEntity()
+            searchKNNIndex(INDEX_NAME, new KNNQueryBuilder(FIELD_NAME, searchVector, k), k).getEntity()
         );
         final List<KNNResult> knnResults = parseSearchResponse(responseBody, FIELD_NAME);
         assertNotNull(knnResults);

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -82,7 +82,7 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
 import static org.opensearch.knn.common.KNNConstants.NAME;
-import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.DISK_ANN;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_M;
@@ -122,8 +122,6 @@ public class KNNRestTestCase extends ODFERestTestCase {
     private static final String SYSTEM_INDEX_PREFIX = ".opendistro";
     public static final int MIN_CODE_UNITS = 4;
     public static final int MAX_CODE_UNITS = 10;
-    public static final String TERM_QUERY_FIELD_NAME = "my_field";
-    public static final String TERM_QUERY_FIELD_VALUE = "1";
 
     @AfterClass
     public static void dumpCoverage() throws IOException, MalformedObjectNameException {
@@ -222,7 +220,6 @@ public class KNNRestTestCase extends ODFERestTestCase {
     protected Response searchKNNIndex(String index, String query, int resultSize) throws IOException {
         Request request = new Request("POST", "/" + index + "/_search");
         request.setJsonEntity(query);
-
         request.addParameter("size", Integer.toString(resultSize));
         request.addParameter("search_type", "query_then_fetch");
         // Nested field does not support explain parameter and the request is rejected if we set explain parameter
@@ -407,6 +404,22 @@ public class KNNRestTestCase extends ODFERestTestCase {
      * Utility to create a Knn Index Mapping
      */
     protected String createKnnIndexMapping(String fieldName, Integer dimensions) throws IOException {
+        return XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(fieldName)
+            .field("type", "knn_vector")
+            .field("dimension", dimensions.toString())
+            .startObject(KNN_METHOD)
+            .field(NAME, DISK_ANN)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+    }
+
+    protected String createKnnScriptScoreIndexMapping(String fieldName, Integer dimensions) throws IOException {
         return XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
@@ -622,11 +635,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
     protected <T> void addKnnDoc(String index, String docId, String fieldName, T vector) throws IOException {
         Request request = new Request("POST", "/" + index + "/_doc/" + docId + "?refresh=true");
 
-        XContentBuilder builder = XContentFactory.jsonBuilder()
-            .startObject()
-            .field(fieldName, vector)
-            .field(TERM_QUERY_FIELD_NAME, TERM_QUERY_FIELD_VALUE)
-            .endObject();
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().field(fieldName, vector).endObject();
         request.setJsonEntity(builder.toString());
         client().performRequest(request);
 
@@ -715,7 +724,6 @@ public class KNNRestTestCase extends ODFERestTestCase {
         for (int i = 0; i < fieldNames.size(); i++) {
             builder.field(fieldNames.get(i), vectors.get(i));
         }
-        builder.field(TERM_QUERY_FIELD_NAME, TERM_QUERY_FIELD_VALUE);
         builder.endObject();
 
         request.setJsonEntity(builder.toString());
@@ -1746,7 +1754,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
             .field(VECTOR_TYPE, KNN_VECTOR)
             .field(DIMENSION, dimensions.toString())
             .startObject(KNN_METHOD)
-            .field(NAME, METHOD_HNSW)
+            .field(NAME, DISK_ANN)
             .endObject()
             .endObject()
             .endObject()
@@ -1769,7 +1777,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
             .field(VECTOR_TYPE, KNN_VECTOR)
             .field(DIMENSION, dimensions.toString())
             .startObject(KNN_METHOD)
-            .field(NAME, METHOD_HNSW)
+            .field(NAME, DISK_ANN)
             .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
             .field(KNN_ENGINE, engine)
             .startObject(PARAMETERS)
@@ -1799,7 +1807,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
             .field(VECTOR_TYPE, KNN_VECTOR)
             .field(DIMENSION, dimensions.toString())
             .startObject(KNN_METHOD)
-            .field(NAME, METHOD_HNSW)
+            .field(NAME, DISK_ANN)
             .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
             .field(KNN_ENGINE, engine)
             .startObject(PARAMETERS)


### PR DESCRIPTION
### Description
Fi visited docs tracking that led to assertions on AbstractKnnVectorQuery side

### Related Issues

Fixes (and reverts some https://github.com/opensearch-project/opensearch-jvector/pull/201 changes):

```
» ERROR][o.o.b.OpenSearchUncaughtExceptionHandler] [knnBwcCluster-rolling-1] fatal error in thread [opensearch[knnBwcCluster-rolling-1][search][T#1]], exiting
»  java.lang.AssertionError
»  	at org.apache.lucene.search.AbstractKnnVectorQuery$ReentrantKnnCollectorManager.newCollector(AbstractKnnVectorQuery.java:379)
»  	at org.apache.lucene.search.TimeLimitingKnnCollectorManager.newCollector(TimeLimitingKnnCollectorManager.java:44)
»  	at org.opensearch.knn.index.codec.jvector.JVectorKnnFloatVectorQuery.approximateSearch(JVectorKnnFloatVectorQuery.java:68)
»  	at org.apache.lucene.search.AbstractKnnVectorQuery.getLeafResults(AbstractKnnVectorQuery.java:194)
»  	at org.apache.lucene.search.AbstractKnnVectorQuery.searchLeaf(AbstractKnnVectorQuery.java:175)
»  	at org.apache.lucene.search.AbstractKnnVectorQuery.lambda$rewrite$1(AbstractKnnVectorQuery.java:138)
»  	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
»  	at org.apache.lucene.search.TaskExecutor$Task.run(TaskExecutor.java:173)
»  	at org.apache.lucene.search.TaskExecutor.invokeAll(TaskExecutor.java:111)
»  	at org.apache.lucene.search.AbstractKnnVectorQuery.runSearchTasks(AbstractKnnVectorQuery.java:161)
»  	at org.apache.lucene.search.AbstractKnnVectorQuery.rewrite(AbstractKnnVectorQuery.java:147)
»  	at org.apache.lucene.search.KnnFloatVectorQuery.rewrite(KnnFloatVectorQuery.java:48)
»  	at org.apache.lucene.search.IndexSearcher.rewrite(IndexSearcher.java:874)
»  	at org.opensearch.search.internal.ContextIndexSearcher.rewrite(ContextIndexSearcher.java:213)
»  	at org.opensearch.search.DefaultSearchContext.preProcess(DefaultSearchContext.java:449)
»  	at org.opensearch.search.query.QueryPhase.preProcess(QueryPhase.java:128)
»  	at org.opensearch.search.SearchService.createContext(SearchService.java:1282)
»  	at org.opensearch.search.SearchService.executeQueryPhase(SearchService.java:836)
»  	at org.opensearch.search.SearchService$2.lambda$onResponse$0(SearchService.java:802)
»  	at org.opensearch.action.ActionRunnable.lambda$supply$0(ActionRunnable.java:74)
»  	at org.opensearch.action.ActionRunnable$2.doRun(ActionRunnable.java:89)
»  	at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52)
»  	at org.opensearch.threadpool.TaskAwareRunnable.doRun(TaskAwareRunnable.java:78)
»  	at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52)
»  	at org.opensearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:59)
»  	at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:975)
»  	at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52)
»  	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
»  	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
»  	at java.base/java.lang.Thread.run(Thread.java:1583)
```

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
