### PR TITLE
Include AdditionalCodecs argument to allow additional Codec registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 3.4](https://github.com/opensearch-project/opensearch-jvector/compare/3.3...HEAD)
 ### Features
 ### Enhancements
-* More tests for leading segment merge. [PR #243](https://github.com/opensearch-project/opensearch-jvector/pull/243)
+* More tests for leading segment merge. [243] (https://github.com/opensearch-project/opensearch-jvector/pull/243)
+* Include AdditionalCodecs argument to allow additional Codec registration [250] (https://github.com/opensearch-project/opensearch-jvector/pull/250)
+
 ### Bug Fixes
 * Fix visited docs tracking that led to assertions on AbstractKnnVectorQuery side [238] (https://github.com/opensearch-project/opensearch-jvector/pull/238)
 * Revert of support deletes for incremental insertion [240](https://github.com/opensearch-project/opensearch-jvector/pull/240)

--- a/src/main/java/org/opensearch/knn/index/codec/KNNCodecService.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNNCodecService.java
@@ -18,7 +18,12 @@ public class KNNCodecService extends CodecService {
     private final MapperService mapperService;
 
     public KNNCodecService(CodecServiceConfig codecServiceConfig) {
-        super(codecServiceConfig.getMapperService(), codecServiceConfig.getIndexSettings(), codecServiceConfig.getLogger());
+        super(
+            codecServiceConfig.getMapperService(),
+            codecServiceConfig.getIndexSettings(),
+            codecServiceConfig.getLogger(),
+            codecServiceConfig.getAdditionalCodecs()
+        );
         mapperService = codecServiceConfig.getMapperService();
     }
 


### PR DESCRIPTION
### Description
Include AdditionalCodecs and EnginePlugin::getAdditionalCodecs hook to allow additional Codec registration

### Related Issues
Followup on https://github.com/opensearch-project/OpenSearch/pull/20411

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
