### PR TITLE
Increment opensearch-jvector version to 3.3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See the [CONTRIBUTING guide](./CONTRIBUTING.md#Changelog) for instructions on how to add changelog entries.
 
-## [Unreleased 3.4](https://github.com/opensearch-project/opensearch-jvector/compare/3.3...HEAD)
+## [Unreleased 3.3](https://github.com/opensearch-project/opensearch-jvector/compare/3.3...HEAD)
 ### Features
 ### Enhancements
 * More tests for leading segment merge. [PR #243](https://github.com/opensearch-project/opensearch-jvector/pull/243)

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
         isSnapshot = "true" == System.getProperty("build.snapshot", "false")
 
         version_tokens = opensearch_version.tokenize('-')
-        opensearch_build = version_tokens[0] + '.0'
+        opensearch_build = version_tokens[0] + '.1'
         plugin_no_snapshot = opensearch_build
         if (version_qualifier) {
             opensearch_build += "-${version_qualifier}"


### PR DESCRIPTION
### Description
Increment opensearch-jvector version to 3.3.2.1

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
