### PR TITLE
Merge Flaky Test Partial Progress

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/jvector/GraphNodeIdToDocMap.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/GraphNodeIdToDocMap.java
@@ -158,4 +158,13 @@ public class GraphNodeIdToDocMap {
             out.writeVInt(graphNodeIdsToDocIds[ord]);
         }
     }
+
+    public int size() {
+        return docIdsToGraphNodeIds.length;
+    }
+
+    @Override
+    public String toString() {
+        return "GraphNodeIdToDocMap{" + "graphNodeIdsToDocIds=" + Arrays.toString(graphNodeIdsToDocIds) + ", docIdsToGraphNodeIds=" + Arrays.toString(docIdsToGraphNodeIds) + '}';
+    }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -624,6 +624,7 @@ public class JVectorWriter extends KnnVectorsWriter {
          * @param mergeState Merge state containing readers and doc maps
          */
         public RandomAccessMergedFloatVectorValues(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
+            log.info("Start initializing RandomAccessMergedFloatVectorValues for field {} in segment {}", fieldInfo.name, segmentWriteState.segmentInfo.name);
             this.totalDocsCount = Math.toIntExact(Arrays.stream(mergeState.maxDocs).asLongStream().sum());
             this.fieldInfo = fieldInfo;
             this.mergeState = mergeState;
@@ -688,6 +689,10 @@ public class JVectorWriter extends KnnVectorsWriter {
                     }
                 }
             }
+
+            log.info("Total vectors count across all segments for field {}: {}", fieldName, totalVectorsCount);
+            log.info("Total live vectors count across all segments for field {}: {}", fieldName, totalLiveVectorsCount);
+            log.info("Base ordinals for each reader: {}", Arrays.toString(baseOrds));
 
             assert (totalVectorsCount <= totalDocsCount) : "Total number of vectors exceeds the total number of documents";
             assert (totalLiveVectorsCount <= totalVectorsCount) : "Total number of live vectors exceeds the total number of vectors";
@@ -840,6 +845,8 @@ public class JVectorWriter extends KnnVectorsWriter {
             this.graphNodeIdToDocMap = new GraphNodeIdToDocMap(graphNodeIdToDocIds);
             this.compactOrdToDocMap = new GraphNodeIdToDocMap(compactOrdToDocIds);
             log.debug("Created RandomAccessMergedFloatVectorValues with {} total vectors from {} readers", size, readers.length);
+            log.info("Created RandomAccessMergedFloatVectorValues with {} total vectors from {} readers", size, readers.length);
+            log.info("End initializing RandomAccessMergedFloatVectorValues for field {} in segment {}", fieldInfo.name, segmentWriteState.segmentInfo.name);
 
         }
 
@@ -1113,6 +1120,7 @@ public class JVectorWriter extends KnnVectorsWriter {
                     SIMD_POOL_MERGE.submit(
                         () -> IntStream.range(leadingGraph.getIdUpperBound(), heapRavv.size()).parallel().forEach(ord -> {
                             builder.addGraphNode(ord, vv.get().getVector(ord));
+                            log.info("Adding node {} with vector {}", ord, vv.get().getVector(ord));
                         })
                     ).join();
 
@@ -1121,17 +1129,20 @@ public class JVectorWriter extends KnnVectorsWriter {
                         if (!liveGraphNodesPerReader[LEADING_READER_IDX].get(i)) {
                             // we need to convert from the "mid" to the "heap" ordinal space to avoid errors
                             builder.markNodeDeleted(midToHeapOrds[i]);
+                            log.info("Node {} marked as deleted", midToHeapOrds[i]);
                         }
                     }
 
                     builder.cleanup();
 
                     graph = (OnHeapGraphIndex) builder.getGraph();
+                    log.info("Graph Structure after getting graph from merged float vector: {}", graph);
                 }
 
                 // Note that the ordinals for the OnDiskGraphIndex will automatically be compacted
                 // But the OnHeapGraphIndex will not
                 var finalOrdToDocMap = new GraphNodeIdToDocMap(finalOrdToDocId);
+                log.info("Final ordinal mapping for graph index: {}", finalOrdToDocMap);
                 writeField(fieldInfo, heapRavv, null, finalOrdToDocMap, graph);
                 return true;
             }

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
@@ -340,9 +340,16 @@ public class KNNJVectorTests extends LuceneTestCase {
                 final Query filterQuery = new MatchAllDocsQuery();
                 final IndexSearcher searcher = newSearcher(reader);
                 KnnFloatVectorQuery knnFloatVectorQuery = getJVectorKnnFloatVectorQuery("test_field", target, k, filterQuery);
-                TopDocs topDocs = searcher.search(knnFloatVectorQuery, k);
-                assertEquals(k, topDocs.totalHits.value());
-                Document doc = reader.storedFields().document(topDocs.scoreDocs[0].doc);
+                //TopDocs topDocs = searcher.search(knnFloatVectorQuery, k);
+                // One thing I have found when using the match all docs is that none of the documents in the 
+                // segment are actually missing.
+                TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), 10);
+                for (int i = 0; i < 10; i++) {
+                    Document doc = reader.storedFields().document(topDocs.scoreDocs[i].doc);
+                    log.info("DocID: {}, Score: {}, id: {}", topDocs.scoreDocs[i].doc, topDocs.scoreDocs[i].score, doc.get("my_doc_id"));
+                }
+                //assertEquals(k, topDocs.totalHits.value());
+                /*Document doc = reader.storedFields().document(topDocs.scoreDocs[0].doc);
                 assertEquals("1", doc.get("my_doc_id"));
                 Assert.assertEquals(
                     VectorSimilarityFunction.EUCLIDEAN.compare(target, new float[] { 0.0f, 1.0f }),
@@ -362,7 +369,7 @@ public class KNNJVectorTests extends LuceneTestCase {
                     VectorSimilarityFunction.EUCLIDEAN.compare(target, new float[] { 0.0f, 3.0f }),
                     topDocs.scoreDocs[2].score,
                     0.001f
-                );
+                );*/
                 log.info("successfully completed search tests");
             }
         }


### PR DESCRIPTION
### Description
This change shows where I placed the logs to record key data structures in the `JVectorWriter`. I noticed that when docs "disappear", the segments are actually still have all the documents. I verified this by using the match-all query instead of the `JVectorKnnFloatVectorQuery` and checked if all the documents are in the index. Therefore, the search path can be investigated more and why the reader does not read all the documents.

### Related Issues
#281 
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
