### PR TITLE
[Backport] [3.4] Issues handling documents without vector fields being populated (#288)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 ### Enhancements
 ### Bug Fixes
+* Fix issues handling documents without vector fields being populated [288] (https://github.com/opensearch-project/opensearch-jvector/issues/288)
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/main/java/org/opensearch/knn/index/KNNVectorScriptDocValues.java
+++ b/src/main/java/org/opensearch/knn/index/KNNVectorScriptDocValues.java
@@ -10,6 +10,9 @@ import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FloatVectorValues;
@@ -17,9 +20,11 @@ import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.index.fielddata.ScriptDocValues;
+import org.opensearch.knn.index.codec.jvector.GraphNodeIdToDocMap;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public abstract class KNNVectorScriptDocValues extends ScriptDocValues<float[]> {
+    private static final Logger log = LogManager.getLogger(KNNVectorScriptDocValues.class);
 
     private final DocIdSetIterator vectorValues;
     private final String fieldName;
@@ -108,9 +113,15 @@ public abstract class KNNVectorScriptDocValues extends ScriptDocValues<float[]> 
 
         @Override
         protected float[] doGetValue() throws IOException {
-            int docId = this.iterator.index();
+            int docId = this.iterator.docID();
             if (docId == KnnVectorValues.DocIndexIterator.NO_MORE_DOCS) {
                 throw new IllegalStateException("No more ordinals to retrieve vector values.");
+            }
+
+            int ord = this.iterator.index();    // Fetch ordinal (index of vector)
+            if (ord == GraphNodeIdToDocMap.NO_VECTOR_OR_DELETED_DOC) {
+                log.debug("No vector value for docId {}, index is {}", docId, ord);
+                return null; /* no vector value */
             }
 
             // Use the correct method to retrieve the byte vector for the current ordinal
@@ -138,9 +149,14 @@ public abstract class KNNVectorScriptDocValues extends ScriptDocValues<float[]> 
 
         @Override
         protected float[] doGetValue() throws IOException {
-            int ord = iterator.index();    // Fetch ordinal (index of vector)
-            if (ord == KnnVectorValues.DocIndexIterator.NO_MORE_DOCS) {
+            int docId = iterator.docID();
+            if (docId == KnnVectorValues.DocIndexIterator.NO_MORE_DOCS) {
                 throw new IllegalStateException("No more ordinals to retrieve vector values.");
+            }
+            int ord = iterator.index();    // Fetch ordinal (index of vector)
+            if (ord == GraphNodeIdToDocMap.NO_VECTOR_OR_DELETED_DOC) {
+                log.debug("No vector value for docId {}, index is {}", docId, ord);
+                return null; /* no vector value */
             }
             return values.vectorValue(ord);
         }

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/GraphNodeIdToDocMap.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/GraphNodeIdToDocMap.java
@@ -23,6 +23,9 @@ import java.util.Arrays;
  */
 @Log4j2
 public class GraphNodeIdToDocMap {
+    // The marker for documents without vectors (== null) or deleted documents
+    public static final int NO_VECTOR_OR_DELETED_DOC = -1;
+
     private static final int VERSION = 1;
     private int[] graphNodeIdsToDocIds;
     private int[] docIdsToGraphNodeIds;
@@ -43,16 +46,24 @@ public class GraphNodeIdToDocMap {
 
         graphNodeIdsToDocIds = new int[size];
         docIdsToGraphNodeIds = new int[maxDocId];
-        Arrays.fill(graphNodeIdsToDocIds, -1);
-        Arrays.fill(docIdsToGraphNodeIds, -1);
+        Arrays.fill(graphNodeIdsToDocIds, NO_VECTOR_OR_DELETED_DOC);
+        Arrays.fill(docIdsToGraphNodeIds, NO_VECTOR_OR_DELETED_DOC);
         for (int ord = 0; ord < size; ord++) {
             final int docId = in.readVInt();
-            graphNodeIdsToDocIds[ord] = docId;
-            if (docId != -1) {
-                // ignore deleted documents
+            // ignore deleted documents
+            if (docId != NO_VECTOR_OR_DELETED_DOC) {
+                graphNodeIdsToDocIds[ord] = docId;
                 docIdsToGraphNodeIds[docId] = ord;
             }
         }
+    }
+
+    public int getMaxDoc() {
+        return docIdsToGraphNodeIds.length;
+    }
+
+    public GraphNodeIdToDocMap(int[] graphNodeIdsToDocIds) {
+        this(graphNodeIdsToDocIds, graphNodeIdsToDocIds.length > 0 ? Arrays.stream(graphNodeIdsToDocIds).max().getAsInt() : 0);
     }
 
     /**
@@ -60,7 +71,7 @@ public class GraphNodeIdToDocMap {
      *
      * @param graphNodeIdsToDocIds The mapping from ordinals to docIds
      */
-    public GraphNodeIdToDocMap(int[] graphNodeIdsToDocIds) {
+    public GraphNodeIdToDocMap(int[] graphNodeIdsToDocIds, int maxDocId) {
         if (graphNodeIdsToDocIds.length == 0) {
             this.graphNodeIdsToDocIds = new int[0];
             this.docIdsToGraphNodeIds = new int[0];
@@ -68,7 +79,16 @@ public class GraphNodeIdToDocMap {
         }
         this.graphNodeIdsToDocIds = new int[graphNodeIdsToDocIds.length];
         System.arraycopy(graphNodeIdsToDocIds, 0, this.graphNodeIdsToDocIds, 0, graphNodeIdsToDocIds.length);
-        final int maxDocId = Arrays.stream(graphNodeIdsToDocIds).max().getAsInt();
+
+        final int observedMaxDocId = Arrays.stream(graphNodeIdsToDocIds).max().getAsInt();
+        // The graphNodeIdsToDocIds may only contain graphNodes for document with vectors,
+        // the documents without vectors have to be accounted for as well.
+        if (maxDocId < observedMaxDocId) {
+            throw new IllegalArgumentException(
+                "The maxDocId is incorrect, provided " + maxDocId + ", expected at least " + observedMaxDocId
+            );
+        }
+
         final int maxDocs = maxDocId + 1;
         // We are going to assume that the number of ordinals is roughly the same as the number of documents in the segment, therefore,
         // the mapping will not be sparse.

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFloatVectorValues.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFloatVectorValues.java
@@ -74,9 +74,10 @@ public class JVectorFloatVectorValues extends FloatVectorValues {
 
             @Override
             public int nextDoc() throws IOException {
-                // Advance to the next node docId starts from -1 which is why we need to increment docId by 1 "size"
-                // times
-                while (docId < size - 1) {
+                // Advance to the next node docId starts from -1 which is why we need to increment docId by 1
+                // until maxDoc is reached. If the document has vector field but no value (== null), there will
+                // gaps in the document <-> node maps, index() will return NO_VECTOR_OR_DELETED_DOC in such cases.
+                while (docId < graphNodeIdToDocMap.getMaxDoc() - 1) {
                     docId++;
                     if (liveNodes.get(docId)) {
                         return docId;

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorVectorScorer.java
@@ -28,7 +28,11 @@ public class JVectorVectorScorer implements VectorScorer {
 
     @Override
     public float score() throws IOException {
-        return similarityFunction.compare(target, floatVectorValues.vectorFloatValue(docIndexIterator.index()));
+        int index = docIndexIterator.index();
+        if (index == GraphNodeIdToDocMap.NO_VECTOR_OR_DELETED_DOC) {
+            return 0.0f;
+        }
+        return similarityFunction.compare(target, floatVectorValues.vectorFloatValue(index));
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -234,7 +234,10 @@ public class JVectorWriter extends KnnVectorsWriter {
             for (int ord = 0; ord < randomAccessVectorValues.size(); ord++) {
                 ordinalsToDocIds[ord] = field.docIds.get(ord);
             }
-            final GraphNodeIdToDocMap graphNodeIdToDocMap = new GraphNodeIdToDocMap(ordinalsToDocIds);
+            // The ordinalsToDocIds will only track the documents that have vectors,
+            // so we pass the maxDoc to keep the precise number of documents. To calculate the last docId we
+            // subtract 1 from maxDoc since docId start from 0: [0 .. maxDoc - 1]
+            final GraphNodeIdToDocMap graphNodeIdToDocMap = new GraphNodeIdToDocMap(ordinalsToDocIds, maxDoc - 1);
             if (sortMap != null) {
                 graphNodeIdToDocMap.update(sortMap);
             }
@@ -599,8 +602,13 @@ public class JVectorWriter extends KnnVectorsWriter {
         // Total number of documents including those without values
         private final int totalDocsCount;
 
+        // Total number of live (non-deleted) documents
+        private final int totalLiveDocsCount;
+        // Total number of live vectors in leading reader
         private final int totalLiveVectorsInLeadingReader;
+        // Total number of live vectors in all other readers
         private final int totalLiveVectorsInOtherReaders;
+        // Total number of live vectors in all readers
         private final int totalLiveVectorsCount;
 
         // Vector dimension
@@ -636,10 +644,10 @@ public class JVectorWriter extends KnnVectorsWriter {
             // between global ordinals and global lucene doc ids
             int totalVectorsCount = 0;
             int totalLiveVectorsCount = 0;
+            int liveDocsCount = 0;
             int dimension = 0;
             int tempLeadingReaderIdx = -1;
             int vectorsCountInLeadingReader = -1;
-            List<KnnVectorsReader> allReaders = new ArrayList<>();
             final MergeState.DocMap[] docMaps = mergeState.docMaps.clone();
             final Bits[] liveDocs = mergeState.liveDocs.clone();
             this.liveGraphNodesPerReader = new FixedBitSet[liveDocs.length];
@@ -648,8 +656,16 @@ public class JVectorWriter extends KnnVectorsWriter {
                 final int length;
                 if (liveDocs[i] == null) {
                     length = mergeState.maxDocs[i];
+                    liveDocsCount += length;
                 } else {
                     length = liveDocs[i].length();
+                    // We may have segments without vectors, but we still have to count live docs,
+                    // so counting it by calculating how many bits are set
+                    for (int b = 0; b < length; ++b) {
+                        if (liveDocs[i].get(b) == true) {
+                            liveDocsCount += 1;
+                        }
+                    }
                 }
                 liveGraphNodesPerReader[i] = new FixedBitSet(length);
                 liveGraphNodesPerReader[i].set(0, length);
@@ -665,16 +681,19 @@ public class JVectorWriter extends KnnVectorsWriter {
                     if (reader != null) {
                         FloatVectorValues values = reader.getFloatVectorValues(fieldName);
                         if (values != null) {
-                            allReaders.add(reader);
                             int vectorCountInReader = values.size();
                             int liveVectorCountInReader = 0;
                             KnnVectorValues.DocIndexIterator it = values.iterator();
                             while (it.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-                                if (liveDocs[i] == null || liveDocs[i].get(it.docID())) {
-                                    liveVectorCountInReader++;
-                                } else {
-                                    // This vector is deleted so we need to mark it as deleted in the liveGraphNodesPerReader
-                                    liveGraphNodesPerReader[i].clear(it.index());
+                                final int index = it.index();
+                                // We have a document without vector value (or deleted), skipping over it
+                                if (index != GraphNodeIdToDocMap.NO_VECTOR_OR_DELETED_DOC /* no vector or doc */) {
+                                    if (liveDocs[i] == null || liveDocs[i].get(it.docID())) {
+                                        liveVectorCountInReader++;
+                                    } else {
+                                        // This vector is deleted so we need to mark it as deleted in the liveGraphNodesPerReader
+                                        liveGraphNodesPerReader[i].clear(index);
+                                    }
                                 }
                             }
                             if (liveVectorCountInReader >= vectorsCountInLeadingReader) {
@@ -694,9 +713,9 @@ public class JVectorWriter extends KnnVectorsWriter {
             assert (dimension > 0) : "No vectors found for field " + fieldName;
 
             this.size = totalVectorsCount;
-            this.readers = new KnnVectorsReader[allReaders.size()];
+            this.readers = new KnnVectorsReader[mergeState.knnVectorsReaders.length];
             for (int i = 0; i < readers.length; i++) {
-                readers[i] = allReaders.get(i);
+                readers[i] = mergeState.knnVectorsReaders[i];
             }
 
             // always swap the leading reader to the first position
@@ -738,9 +757,12 @@ public class JVectorWriter extends KnnVectorsWriter {
             // only need to map the live vectors
             // Therefore the size of this array is the total number of vectors in the leading reader + the number of live vectors in all
             // other readers
-            totalLiveVectorsInLeadingReader = liveGraphNodesPerReader[LEADING_READER_IDX].cardinality();
-            totalLiveVectorsInOtherReaders = totalLiveVectorsCount - totalLiveVectorsInLeadingReader;
+            this.totalLiveVectorsInLeadingReader = vectorsCountInLeadingReader;
+            this.totalLiveVectorsInOtherReaders = totalLiveVectorsCount - totalLiveVectorsInLeadingReader;
             this.totalLiveVectorsCount = totalLiveVectorsCount;
+            this.totalLiveDocsCount = liveDocsCount;
+            assert (totalLiveDocsCount <= totalDocsCount) : "Total number of live docs exceeds the total number of documents";
+
             this.graphNodeIdsToRavvOrds = new int[totalLiveVectorsInOtherReaders + readers[LEADING_READER_IDX].getFloatVectorValues(
                 fieldName
             ).size()];
@@ -762,11 +784,9 @@ public class JVectorWriter extends KnnVectorsWriter {
                 .getFloatVectorValues(fieldName);
             perReaderFloatVectorValues[LEADING_READER_IDX] = leadingReaderValues;
             var leadingReaderIt = leadingReaderValues.iterator();
-            for (int docId = leadingReaderIt.nextDoc(); docId != DocIdSetIterator.NO_MORE_DOCS; docId = leadingReaderIt.nextDoc()) {
+            for (int docId = leadingReaderIt.nextDoc(); docId != DocIdSetIterator.NO_MORE_DOCS; docId = leadingReaderIt
+                .nextDoc(), documentsIterated++) {
                 final int newGlobalDocId = docMaps[LEADING_READER_IDX].get(docId);
-                // we increment anyway even if deleted because we are going to apply cleanup later to remove deleted nodes from the leading
-                // graph that will be used incremented
-                graphNodeId++;
                 if (newGlobalDocId == -1) {
                     log.debug(
                         "Document {} in reader {} is not mapped to a global ordinal from the merge docMaps. This means it's deleted, Will skip this document for now",
@@ -776,30 +796,41 @@ public class JVectorWriter extends KnnVectorsWriter {
                 }
 
                 final int ravvLocalOrd = leadingReaderIt.index();
-                final int ravvGlobalOrd = ravvLocalOrd + baseOrds[LEADING_READER_IDX];
-                graphNodeIdToDocIds[ravvLocalOrd] = newGlobalDocId;
-                graphNodeIdsToRavvOrds[ravvLocalOrd] = ravvGlobalOrd;
-                if (newGlobalDocId != -1) {
-                    // the "compact" ordinal space doesn't include any deletes
-                    compactOrdsToRavvOrds[compactNodeId] = ravvGlobalOrd;
-                    compactOrdToDocIds[compactNodeId] = newGlobalDocId;
-                    compactNodeId += 1;
-                }
-                ravvOrdToReaderMapping[ravvGlobalOrd][READER_ID] = LEADING_READER_IDX; // Reader index
-                ravvOrdToReaderMapping[ravvGlobalOrd][READER_ORD] = ravvLocalOrd; // Ordinal in reader
+                if (ravvLocalOrd != GraphNodeIdToDocMap.NO_VECTOR_OR_DELETED_DOC) {
+                    final int ravvGlobalOrd = ravvLocalOrd + baseOrds[LEADING_READER_IDX];
+                    graphNodeIdToDocIds[ravvLocalOrd] = newGlobalDocId;
+                    graphNodeIdsToRavvOrds[ravvLocalOrd] = ravvGlobalOrd;
+                    if (newGlobalDocId != -1) {
+                        // the "compact" ordinal space doesn't include any deletes
+                        compactOrdsToRavvOrds[compactNodeId] = ravvGlobalOrd;
+                        compactOrdToDocIds[compactNodeId] = newGlobalDocId;
+                        compactNodeId += 1;
+                    }
+                    ravvOrdToReaderMapping[ravvGlobalOrd][READER_ID] = LEADING_READER_IDX; // Reader index
+                    ravvOrdToReaderMapping[ravvGlobalOrd][READER_ORD] = ravvLocalOrd; // Ordinal in reader
 
-                documentsIterated++;
+                    // we increment anyway even if deleted because we are going to apply cleanup later to remove deleted nodes from the
+                    // leading
+                    // graph that will be used incremented
+                    graphNodeId++;
+                }
             }
 
             // For the remaining readers we map the graph node id to the ravv ordinal in the order they appear
             for (int readerIdx = 1; readerIdx < readers.length; readerIdx++) {
+                // We skip over readers that have no vectors
+                if (readers[readerIdx] == null) {
+                    continue;
+                }
+
                 final JVectorFloatVectorValues values = (JVectorFloatVectorValues) readers[readerIdx].getFloatVectorValues(fieldName);
                 perReaderFloatVectorValues[readerIdx] = values;
                 // For each vector in this reader
                 KnnVectorValues.DocIndexIterator it = values.iterator();
 
-                for (int docId = it.nextDoc(); docId != DocIdSetIterator.NO_MORE_DOCS; docId = it.nextDoc()) {
-                    if (docMaps[readerIdx].get(docId) == -1) {
+                for (int docId = it.nextDoc(); docId != DocIdSetIterator.NO_MORE_DOCS; docId = it.nextDoc(), documentsIterated++) {
+                    final int newGlobalDocId = docMaps[readerIdx].get(docId);
+                    if (newGlobalDocId == -1) {
                         log.debug(
                             "Document {} in reader {} is not mapped to a global ordinal from the merge docMaps. Will skip this document for now",
                             docId,
@@ -809,20 +840,21 @@ public class JVectorWriter extends KnnVectorsWriter {
                         // Mapping from ravv ordinals to [readerIndex, readerOrd]
                         // Map graph node id to ravv ordinal
                         // Map graph node id to doc id
-                        final int newGlobalDocId = docMaps[readerIdx].get(docId);
                         final int ravvLocalOrd = it.index();
-                        final int ravvGlobalOrd = ravvLocalOrd + baseOrds[readerIdx];
-                        graphNodeIdToDocIds[graphNodeId] = newGlobalDocId;
-                        graphNodeIdsToRavvOrds[graphNodeId] = ravvGlobalOrd;
-                        compactOrdsToRavvOrds[compactNodeId] = ravvGlobalOrd;
-                        compactOrdToDocIds[compactNodeId] = newGlobalDocId;
-                        compactNodeId++;
-                        graphNodeId++;
-                        ravvOrdToReaderMapping[ravvGlobalOrd][READER_ID] = readerIdx; // Reader index
-                        ravvOrdToReaderMapping[ravvGlobalOrd][READER_ORD] = ravvLocalOrd; // Ordinal in reader
-                    }
+                        if (ravvLocalOrd != GraphNodeIdToDocMap.NO_VECTOR_OR_DELETED_DOC) {
+                            final int ravvGlobalOrd = ravvLocalOrd + baseOrds[readerIdx];
+                            graphNodeIdToDocIds[graphNodeId] = newGlobalDocId;
+                            graphNodeIdsToRavvOrds[graphNodeId] = ravvGlobalOrd;
 
-                    documentsIterated++;
+                            compactOrdsToRavvOrds[compactNodeId] = ravvGlobalOrd;
+                            compactOrdToDocIds[compactNodeId] = newGlobalDocId;
+                            compactNodeId++;
+
+                            ravvOrdToReaderMapping[ravvGlobalOrd][READER_ID] = readerIdx; // Reader index
+                            ravvOrdToReaderMapping[ravvGlobalOrd][READER_ORD] = ravvLocalOrd; // Ordinal in reader
+                            graphNodeId++;
+                        }
+                    }
                 }
             }
 
@@ -837,10 +869,12 @@ public class JVectorWriter extends KnnVectorsWriter {
                 );
             }
 
-            this.graphNodeIdToDocMap = new GraphNodeIdToDocMap(graphNodeIdToDocIds);
-            this.compactOrdToDocMap = new GraphNodeIdToDocMap(compactOrdToDocIds);
+            // The graphNodeIdToDocIds and compactOrdToDocIds will only track the documents that have vectors,
+            // so we pass the maxDoc to keep the precise number of documents. To calculate the last docId we
+            // subtract 1 from totalLiveDocsCount since docId start from 0: [0 .. totalLiveDocsCount - 1]
+            this.graphNodeIdToDocMap = new GraphNodeIdToDocMap(graphNodeIdToDocIds, totalLiveDocsCount - 1);
+            this.compactOrdToDocMap = new GraphNodeIdToDocMap(compactOrdToDocIds, totalLiveDocsCount - 1);
             log.debug("Created RandomAccessMergedFloatVectorValues with {} total vectors from {} readers", size, readers.length);
-
         }
 
         /**
@@ -911,6 +945,9 @@ public class JVectorWriter extends KnnVectorsWriter {
                 // used to create the leadingCompressor
                 // We assume the leading reader is ALWAYS the first one in the readers array
                 for (int i = LEADING_READER_IDX + 1; i < readers.length; i++) {
+                    if (readers[i] == null) {
+                        continue;
+                    }
                     final FloatVectorValues values = readers[i].getFloatVectorValues(fieldName);
                     final RandomAccessVectorValues randomAccessVectorValues = new RandomAccessVectorValuesOverVectorValues(values);
                     leadingCompressor.refine(randomAccessVectorValues);
@@ -1112,6 +1149,8 @@ public class JVectorWriter extends KnnVectorsWriter {
                     // parallel graph construction from the merge documents Ids
                     SIMD_POOL_MERGE.submit(
                         () -> IntStream.range(leadingGraph.getIdUpperBound(), heapRavv.size()).parallel().forEach(ord -> {
+                            assert heapToGlobalRavvOrds[ord] != GraphNodeIdToDocMap.NO_VECTOR_OR_DELETED_DOC
+                                : "Should be a valid graph node / vector";
                             builder.addGraphNode(ord, vv.get().getVector(ord));
                         })
                     ).join();

--- a/src/main/java/org/opensearch/knn/index/vectorvalues/VectorValueExtractorStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/vectorvalues/VectorValueExtractorStrategy.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.knn.index.vectorvalues;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FloatVectorValues;
@@ -13,6 +15,7 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.codec.jvector.GraphNodeIdToDocMap;
 import org.opensearch.knn.index.codec.util.KNNVectorSerializer;
 import org.opensearch.knn.index.codec.util.KNNVectorSerializerFactory;
 
@@ -67,6 +70,8 @@ public interface VectorValueExtractorStrategy {
      * Strategy to extract the vector from {@link KNNVectorValuesIterator.DocIdsIteratorValues}
      */
     class DISIVectorExtractor implements VectorValueExtractorStrategy {
+        private static final Logger log = LogManager.getLogger(DISIVectorExtractor.class);
+
         @Override
         public <T> T extract(final VectorDataType vectorDataType, final KNNVectorValuesIterator vectorValuesIterator) throws IOException {
             final DocIdSetIterator docIdSetIterator = vectorValuesIterator.getDocIdSetIterator();
@@ -104,6 +109,9 @@ public interface VectorValueExtractorStrategy {
             int ord = docIdSetIterator.index();
             if (ord == docIdsIteratorValues.getLastOrd()) {
                 return (T) docIdsIteratorValues.getLastAccessedVector();
+            } else if (ord == GraphNodeIdToDocMap.NO_VECTOR_OR_DELETED_DOC) {
+                log.debug("No vector value for docId {}, index is {}", docIdSetIterator.docID(), ord);
+                return null; /* no vector */
             }
             docIdsIteratorValues.setLastOrd(ord);
 

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/JVectorMergeWithDeletedDocsTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/JVectorMergeWithDeletedDocsTests.java
@@ -6,14 +6,17 @@
 package org.opensearch.knn.index.codec.jvector;
 
 import static org.opensearch.knn.index.engine.CommonTestUtils.getCodec;
+import static org.hamcrest.Matchers.equalTo;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.document.*;
-import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.index.*;
 import org.apache.lucene.search.*;
 import org.apache.lucene.store.FSDirectory;
@@ -58,6 +61,391 @@ public class JVectorMergeWithDeletedDocsTests extends LuceneTestCase {
             KNNConstants.DEFAULT_QUERY_RERANK_FLOOR.floatValue(),
             KNNConstants.DEFAULT_QUERY_USE_PRUNING
         );
+    }
+
+    /**
+     * Comprehensive test combining merges with one document that
+     * have no vector fields populated, multiple segments.
+     */
+    @Test
+    public void testMergesWithOneDeleteAndOneNullVector() throws IOException {
+        final Map<String, float[]> docs = new HashMap<>();
+        final int dimension = 64;
+        final int k = 4;
+
+        IndexWriterConfig config = newIndexWriterConfig();
+        config.setUseCompoundFile(false);
+        config.setCodec(getCodec(1));
+        config.setMergePolicy(new ForceMergesOnlyMergePolicy());
+        config.setMergeScheduler(new SerialMergeScheduler());
+
+        final Path indexPath = createTempDir();
+
+        try (FSDirectory dir = FSDirectory.open(indexPath); IndexWriter writer = new IndexWriter(dir, config)) {
+            int docId = 0;
+
+            // Segment 1: Updates document with no vector field populated
+            for (int i = 0; i < 1; i++) {
+                Document doc = new Document();
+                doc.add(new StringField(TEST_ID_FIELD, String.valueOf(docId), Field.Store.YES));
+                writer.addDocument(doc);
+                docId++;
+            }
+
+            // Segment 1: add 3 documents
+            log.info("Creating segment 1: 3 docs");
+            for (int i = 0; i < 3; i++) {
+                Document doc = new Document();
+                float[] vector = new float[dimension];
+                Arrays.fill(vector, docId * random().nextFloat(1.0f));
+                doc.add(new KnnFloatVectorField(TEST_FIELD, vector, VectorSimilarityFunction.EUCLIDEAN));
+                doc.add(new StringField(TEST_ID_FIELD, String.valueOf(docId), Field.Store.YES));
+                docs.put(Integer.toString(docId), vector);
+                writer.addDocument(doc);
+                docId++;
+            }
+            writer.commit();
+
+            // Segment 2: Add one more document
+            for (int i = 0; i < 1; i++) {
+                Document doc = new Document();
+                float[] vector = new float[dimension];
+                Arrays.fill(vector, docId * random().nextFloat(1.0f));
+                doc.add(new KnnFloatVectorField(TEST_FIELD, vector, VectorSimilarityFunction.EUCLIDEAN));
+                doc.add(new StringField(TEST_ID_FIELD, String.valueOf(docId), Field.Store.YES));
+                docs.put(Integer.toString(docId), vector);
+                writer.addDocument(doc);
+                docId++;
+
+            }
+            // Delete one document
+            writer.deleteDocuments(new Term(TEST_ID_FIELD, String.valueOf(2)));
+            writer.commit();
+
+            log.info("Performing intermediate merge after segment 2");
+            writer.forceMerge(1);
+
+            // Verify the merged index
+            try (IndexReader reader = DirectoryReader.open(writer)) {
+                Assert.assertEquals("Should have 1 segment after merge", 1, reader.getContext().leaves().size());
+                Assert.assertEquals("Should have correct number of live docs", 4, reader.numDocs());
+
+                // Verify search works correctly
+                final IndexSearcher searcher = newSearcher(reader);
+                TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), k);
+                Assert.assertEquals("Should return k results", k, topDocs.totalHits.value());
+
+                for (int i = 0; i < topDocs.scoreDocs.length; i++) {
+                    Document doc = reader.storedFields().document(topDocs.scoreDocs[i].doc);
+                    String id = doc.get(TEST_ID_FIELD);
+                    assertThat(getVector(reader, TEST_FIELD, topDocs.scoreDocs[i].doc), equalTo(docs.get(id)));
+                    log.info("Result {}: doc ID = {}", i, id);
+                }
+            }
+        }
+    }
+
+    /**
+     * Comprehensive test combining merges with one document that
+     * have no vector fields populated, multiple segments.
+     */
+    @Test
+    public void testMergesWithOneNonNullVector() throws IOException {
+        final Map<String, float[]> docs = new HashMap<>();
+        final int dimension = 64;
+        final int k = 5;
+
+        IndexWriterConfig config = newIndexWriterConfig();
+        config.setUseCompoundFile(false);
+        config.setCodec(getCodec(1));
+        config.setMergePolicy(new ForceMergesOnlyMergePolicy());
+        config.setMergeScheduler(new SerialMergeScheduler());
+
+        final Path indexPath = createTempDir();
+
+        try (FSDirectory dir = FSDirectory.open(indexPath); IndexWriter writer = new IndexWriter(dir, config)) {
+            int docId = 0;
+            int docIdWithVector = random().nextInt(4);
+
+            // Segment 1: Add 3 documents with no vector and one with the vector
+            for (int i = 0; i < 4; i++) {
+                Document doc = new Document();
+
+                if (docId == docIdWithVector) {
+                    float[] vector = new float[dimension];
+                    Arrays.fill(vector, docId * random().nextFloat(1.0f));
+                    doc.add(new KnnFloatVectorField(TEST_FIELD, vector, VectorSimilarityFunction.EUCLIDEAN));
+                    docs.put(Integer.toString(docId), vector);
+                }
+
+                doc.add(new StringField(TEST_ID_FIELD, String.valueOf(docId), Field.Store.YES));
+                writer.addDocument(doc);
+                docId++;
+            }
+            writer.commit();
+
+            // Segment 2: Add one more document with no vectors
+            for (int i = 0; i < 1; i++) {
+                Document doc = new Document();
+                doc.add(new StringField(TEST_ID_FIELD, String.valueOf(docId), Field.Store.YES));
+                writer.addDocument(doc);
+                docId++;
+
+            }
+            writer.commit();
+
+            log.info("Performing intermediate merge after segment 2");
+            writer.forceMerge(1);
+
+            // Verify the merged index
+            try (IndexReader reader = DirectoryReader.open(writer)) {
+                Assert.assertEquals("Should have 1 segment after merge", 1, reader.getContext().leaves().size());
+                Assert.assertEquals("Should have correct number of live docs", 5, reader.numDocs());
+
+                // Verify search works correctly
+                final IndexSearcher searcher = newSearcher(reader);
+                TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), k);
+                Assert.assertEquals("Should return k results", k, topDocs.totalHits.value());
+
+                for (int i = 0; i < topDocs.scoreDocs.length; i++) {
+                    Document doc = reader.storedFields().document(topDocs.scoreDocs[i].doc);
+                    String id = doc.get(TEST_ID_FIELD);
+                    assertThat(getVector(reader, TEST_FIELD, topDocs.scoreDocs[i].doc), equalTo(docs.get(id)));
+                    log.info("Result {}: doc ID = {}", i, id);
+                }
+            }
+        }
+    }
+
+    /**
+     * Comprehensive test combining merges with one document that
+     * have no vector fields populated, multiple segments.
+     */
+    @Test
+    public void testMergesWithOneNullVector() throws IOException {
+        final Map<String, float[]> docs = new HashMap<>();
+        final int dimension = 64;
+        final int k = 5;
+
+        IndexWriterConfig config = newIndexWriterConfig();
+        config.setUseCompoundFile(false);
+        config.setCodec(getCodec(1));
+        config.setMergePolicy(new ForceMergesOnlyMergePolicy());
+        config.setMergeScheduler(new SerialMergeScheduler());
+
+        final Path indexPath = createTempDir();
+
+        try (FSDirectory dir = FSDirectory.open(indexPath); IndexWriter writer = new IndexWriter(dir, config)) {
+            int docId = 0;
+
+            // Segment 1: Updates document with no vector field populated
+            for (int i = 0; i < 1; i++) {
+                Document doc = new Document();
+                doc.add(new StringField(TEST_ID_FIELD, String.valueOf(docId), Field.Store.YES));
+                writer.addDocument(doc);
+                docId++;
+            }
+
+            // Segment 1: add 3 documents
+            log.info("Creating segment 1: 3 docs");
+            for (int i = 0; i < 3; i++) {
+                Document doc = new Document();
+                float[] vector = new float[dimension];
+                Arrays.fill(vector, docId * random().nextFloat(1.0f));
+                doc.add(new KnnFloatVectorField(TEST_FIELD, vector, VectorSimilarityFunction.EUCLIDEAN));
+                doc.add(new StringField(TEST_ID_FIELD, String.valueOf(docId), Field.Store.YES));
+                docs.put(Integer.toString(docId), vector);
+                writer.addDocument(doc);
+                docId++;
+            }
+            writer.commit();
+
+            // Segment 2: Add one more document
+            for (int i = 0; i < 1; i++) {
+                Document doc = new Document();
+                float[] vector = new float[dimension];
+                Arrays.fill(vector, docId * random().nextFloat(1.0f));
+                doc.add(new KnnFloatVectorField(TEST_FIELD, vector, VectorSimilarityFunction.EUCLIDEAN));
+                doc.add(new StringField(TEST_ID_FIELD, String.valueOf(docId), Field.Store.YES));
+                docs.put(Integer.toString(docId), vector);
+                writer.addDocument(doc);
+                docId++;
+
+            }
+            writer.commit();
+
+            log.info("Performing intermediate merge after segment 2");
+            writer.forceMerge(1);
+
+            // Verify the merged index
+            try (IndexReader reader = DirectoryReader.open(writer)) {
+                Assert.assertEquals("Should have 1 segment after merge", 1, reader.getContext().leaves().size());
+                Assert.assertEquals("Should have correct number of live docs", 5, reader.numDocs());
+
+                // Verify search works correctly
+                final IndexSearcher searcher = newSearcher(reader);
+                TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), k);
+                Assert.assertEquals("Should return k results", k, topDocs.totalHits.value());
+
+                for (int i = 0; i < topDocs.scoreDocs.length; i++) {
+                    Document doc = reader.storedFields().document(topDocs.scoreDocs[i].doc);
+                    String id = doc.get(TEST_ID_FIELD);
+                    assertThat(getVector(reader, TEST_FIELD, topDocs.scoreDocs[i].doc), equalTo(docs.get(id)));
+                    log.info("Result {}: doc ID = {}", i, id);
+                }
+            }
+        }
+
+    }
+
+    /**
+     * Comprehensive test combining merges with documents that
+     * have no vector fields populated, multiple segments where leading is not the first one.
+     */
+    @Test
+    public void testMergesWithNullVectorsAndLastLeadingSegment() throws IOException {
+        final Map<String, float[]> docs = new HashMap<>();
+        final int dimension = 64;
+        final int k = 9;
+
+        IndexWriterConfig config = newIndexWriterConfig();
+        config.setUseCompoundFile(false);
+        config.setCodec(getCodec(1));
+        config.setMergePolicy(new ForceMergesOnlyMergePolicy());
+        config.setMergeScheduler(new SerialMergeScheduler());
+
+        final Path indexPath = createTempDir();
+
+        try (FSDirectory dir = FSDirectory.open(indexPath); IndexWriter writer = new IndexWriter(dir, config)) {
+            int docId = 0;
+
+            // Segment 1: 3 documents with one document having no vector field populated
+            log.info("Creating segment 1: 3 docs");
+            for (int i = 0; i < 2; i++) {
+                Document doc = new Document();
+                float[] vector = new float[dimension];
+                Arrays.fill(vector, docId * random().nextFloat(1.0f));
+                doc.add(new KnnFloatVectorField(TEST_FIELD, vector, VectorSimilarityFunction.EUCLIDEAN));
+                doc.add(new StringField(TEST_ID_FIELD, String.valueOf(docId), Field.Store.YES));
+                docs.put(Integer.toString(docId), vector);
+                writer.addDocument(doc);
+                docId++;
+            }
+            writer.commit();
+
+            // Segment 2: Add document with no vector field populated
+            for (int i = 2; i < 3; i++) {
+                Document doc = new Document();
+                doc.add(new StringField(TEST_ID_FIELD, String.valueOf(docId), Field.Store.YES));
+                writer.addDocument(doc);
+                docId++;
+            }
+            writer.commit();
+
+            // Segment 3: 6 document
+            log.info("Creating segment 3: 6 docs");
+            for (int i = 4; i < 10; i++) {
+                Document doc = new Document();
+                float[] vector = new float[dimension];
+                Arrays.fill(vector, docId * random().nextFloat(1.0f));
+                doc.add(new KnnFloatVectorField(TEST_FIELD, vector, VectorSimilarityFunction.EUCLIDEAN));
+                doc.add(new StringField(TEST_ID_FIELD, String.valueOf(docId), Field.Store.YES));
+                docs.put(Integer.toString(docId), vector);
+                writer.addDocument(doc);
+                docId++;
+            }
+            writer.commit();
+
+            log.info("Performing intermediate merge after segment 2");
+            writer.forceMerge(1);
+
+            // Verify the merged index
+            try (IndexReader reader = DirectoryReader.open(writer)) {
+                Assert.assertEquals("Should have 1 segment after merge", 1, reader.getContext().leaves().size());
+                Assert.assertEquals("Should have correct number of live docs", 9, reader.numDocs());
+
+                // Verify search works correctly
+                final IndexSearcher searcher = newSearcher(reader);
+                TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), k);
+                Assert.assertEquals("Should return k results", k, topDocs.totalHits.value());
+
+                for (int i = 0; i < topDocs.scoreDocs.length; i++) {
+                    Document doc = reader.storedFields().document(topDocs.scoreDocs[i].doc);
+                    String id = doc.get(TEST_ID_FIELD);
+                    assertThat(getVector(reader, TEST_FIELD, topDocs.scoreDocs[i].doc), equalTo(docs.get(id)));
+                    log.info("Result {}: doc ID = {}", i, id);
+                }
+            }
+        }
+    }
+
+    /**
+     * Comprehensive test combining merges with documents that
+     * have no vector fields populated.
+     */
+    @Test
+    public void testMergesWithNullVectors() throws IOException {
+        final Map<String, float[]> docs = new HashMap<>();
+        final int dimension = 64;
+        final int k = 2;
+
+        IndexWriterConfig config = newIndexWriterConfig();
+        config.setUseCompoundFile(false);
+        config.setCodec(getCodec(1));
+        config.setMergePolicy(new ForceMergesOnlyMergePolicy());
+        config.setMergeScheduler(new SerialMergeScheduler());
+
+        final Path indexPath = createTempDir();
+
+        try (FSDirectory dir = FSDirectory.open(indexPath); IndexWriter writer = new IndexWriter(dir, config)) {
+            int docId = 0;
+
+            // Segment 1: 3 documents with one document having no vector field populated
+            log.info("Creating segment 1: 3 docs");
+            for (int i = 0; i < 3; i++) {
+                Document doc = new Document();
+                if (i != 1) {
+                    float[] vector = new float[dimension];
+                    Arrays.fill(vector, docId * random().nextFloat(1.0f));
+                    doc.add(new KnnFloatVectorField(TEST_FIELD, vector, VectorSimilarityFunction.EUCLIDEAN));
+                    doc.add(new StringField(TEST_ID_FIELD, String.valueOf(docId), Field.Store.YES));
+                    docs.put(Integer.toString(docId), vector);
+                } else {
+                    doc.add(new StringField(TEST_ID_FIELD, String.valueOf(docId), Field.Store.YES));
+                }
+                writer.addDocument(doc);
+                docId++;
+            }
+            writer.commit();
+
+            // Segment 2: Delete document with no vector field populated
+            writer.deleteDocuments(new Term(TEST_ID_FIELD, String.valueOf(1)));
+            writer.commit();
+
+            log.info("Performing intermediate merge after segment 2");
+            writer.forceMerge(1);
+
+            // Verify the merged index
+            try (IndexReader reader = DirectoryReader.open(writer)) {
+                Assert.assertEquals("Should have 1 segment after merge", 1, reader.getContext().leaves().size());
+                Assert.assertEquals("Should have correct number of live docs", 2, reader.numDocs());
+
+                // Verify search works correctly
+                final float[] target = new float[dimension];
+                Arrays.fill(target, 0.5f);
+                final IndexSearcher searcher = newSearcher(reader);
+                JVectorKnnFloatVectorQuery query = getJVectorKnnFloatVectorQuery(TEST_FIELD, target, k, new MatchAllDocsQuery());
+                TopDocs topDocs = searcher.search(query, k);
+                Assert.assertEquals("Should return k results", k, topDocs.totalHits.value());
+
+                for (int i = 0; i < topDocs.scoreDocs.length; i++) {
+                    Document doc = reader.storedFields().document(topDocs.scoreDocs[i].doc);
+                    String id = doc.get(TEST_ID_FIELD);
+                    assertThat(getVector(reader, TEST_FIELD, topDocs.scoreDocs[i].doc), equalTo(docs.get(id)));
+                    log.info("Result {}: doc ID = {}", i, id);
+                }
+            }
+        }
     }
 
     /**
@@ -320,4 +708,741 @@ public class JVectorMergeWithDeletedDocsTests extends LuceneTestCase {
         }
     }
 
+    /**
+     * Test merges with root-level vector field and nested child documents.
+     *
+     * This test validates the scenario where:
+     * - Vector field ("embedding") is at the root (parent) document level
+     * - Nested child documents ("authors") contain metadata without vectors
+     * - Documents are merged across multiple segments with deletions
+     *
+     * In Lucene, nested documents are stored as:
+     * - Child documents come first (authors)
+     * - Parent document comes last (with vector)
+     * - All are added as a single block using addDocuments()
+     *
+     * This mirrors the OpenSearch index structure:
+     * {
+     *   "embedding": [vector],
+     *   "authors": [
+     *     {"name": "Author 1"},
+     *     {"name": "Author 2"}
+     *   ]
+     * }
+     */
+    @Test
+    public void testMergesWithRootVectorAndNestedChildren() throws IOException {
+        final int dimension = 128;
+        final int k = 147;
+        final String VECTOR_FIELD = "embedding";
+        final String AUTHOR_NAME_FIELD = "authors.name";
+        final String DOC_TYPE_FIELD = "type"; // To distinguish parent from child docs
+
+        log.info("Testing merges with root-level vectors and nested child documents");
+
+        IndexWriterConfig config = newIndexWriterConfig();
+        config.setUseCompoundFile(false);
+        config.setCodec(getCodec(1));
+        config.setMergePolicy(new ForceMergesOnlyMergePolicy());
+        config.setMergeScheduler(new SerialMergeScheduler());
+
+        final Path indexPath = createTempDir();
+
+        try (FSDirectory dir = FSDirectory.open(indexPath); IndexWriter writer = new IndexWriter(dir, config)) {
+            int parentDocId = 0;
+
+            // Segment 1: 50 parent documents, each with 1-3 nested child documents
+            log.info("Creating segment 1: 50 parent docs with nested children");
+            for (int i = 0; i < 50; i++) {
+                // Create nested structure: children first, then parent
+                int numChildren = 1 + (i % 3); // 1-3 children per parent
+                Document[] docBlock = new Document[numChildren + 1];
+
+                // Add child documents (authors)
+                for (int c = 0; c < numChildren; c++) {
+                    Document childDoc = new Document();
+                    childDoc.add(new StringField(DOC_TYPE_FIELD, "nested", Field.Store.YES));
+                    childDoc.add(new TextField(AUTHOR_NAME_FIELD, "Author_" + parentDocId + "_" + c, Field.Store.YES));
+                    childDoc.add(new StringField("parent_id", String.valueOf(parentDocId), Field.Store.YES));
+                    docBlock[c] = childDoc;
+                }
+
+                // Add parent document with vector (must be last in block)
+                Document parentDoc = new Document();
+                float[] vector = new float[dimension];
+                for (int d = 0; d < dimension; d++) {
+                    vector[d] = (parentDocId * 0.01f) + (d * 0.001f);
+                }
+                parentDoc.add(new KnnFloatVectorField(VECTOR_FIELD, vector, VectorSimilarityFunction.COSINE));
+                parentDoc.add(new StringField(TEST_ID_FIELD, String.valueOf(parentDocId), Field.Store.YES));
+                parentDoc.add(new StringField(DOC_TYPE_FIELD, "parent", Field.Store.YES));
+                parentDoc.add(new NumericDocValuesField("num_children", numChildren));
+                docBlock[numChildren] = parentDoc;
+
+                // Add the entire block (children + parent) atomically
+                writer.addDocuments(Arrays.asList(docBlock));
+                parentDocId++;
+            }
+            writer.commit();
+
+            // Delete 10 parent documents (and their children) from segment 1
+            log.info("Deleting 10 parent documents from segment 1");
+            for (int i = 5; i < 15; i++) {
+                writer.deleteDocuments(new Term(TEST_ID_FIELD, String.valueOf(i)));
+            }
+            writer.commit();
+
+            // Segment 2: 75 parent documents with nested children
+            log.info("Creating segment 2: 75 parent docs with nested children");
+            for (int i = 0; i < 75; i++) {
+                int numChildren = 2 + (i % 3); // 2-4 children per parent
+                Document[] docBlock = new Document[numChildren + 1];
+
+                // Child documents
+                for (int c = 0; c < numChildren; c++) {
+                    Document childDoc = new Document();
+                    childDoc.add(new StringField(DOC_TYPE_FIELD, "child", Field.Store.YES));
+                    childDoc.add(new TextField(AUTHOR_NAME_FIELD, "Author_" + parentDocId + "_" + c, Field.Store.YES));
+                    childDoc.add(new StringField("parent_id", String.valueOf(parentDocId), Field.Store.YES));
+                    docBlock[c] = childDoc;
+                }
+
+                // Parent document with vector
+                Document parentDoc = new Document();
+                float[] vector = new float[dimension];
+                for (int d = 0; d < dimension; d++) {
+                    vector[d] = (parentDocId * 0.01f) + (d * 0.001f);
+                }
+                parentDoc.add(new KnnFloatVectorField(VECTOR_FIELD, vector, VectorSimilarityFunction.COSINE));
+                parentDoc.add(new StringField(TEST_ID_FIELD, String.valueOf(parentDocId), Field.Store.YES));
+                parentDoc.add(new StringField(DOC_TYPE_FIELD, "parent", Field.Store.YES));
+                parentDoc.add(new NumericDocValuesField("num_children", numChildren));
+                docBlock[numChildren] = parentDoc;
+
+                writer.addDocuments(Arrays.asList(docBlock));
+                parentDocId++;
+            }
+            writer.commit();
+
+            // Update 15 parent documents in segment 2
+            log.info("Updating 15 parent documents in segment 2");
+            for (int i = 50; i < 65; i++) {
+                int numChildren = 2;
+                Document[] docBlock = new Document[numChildren + 1];
+
+                for (int c = 0; c < numChildren; c++) {
+                    Document childDoc = new Document();
+                    childDoc.add(new StringField(DOC_TYPE_FIELD, "child", Field.Store.YES));
+                    childDoc.add(new TextField(AUTHOR_NAME_FIELD, "UpdatedAuthor_" + i + "_" + c, Field.Store.YES));
+                    childDoc.add(new StringField("parent_id", String.valueOf(i), Field.Store.YES));
+                    docBlock[c] = childDoc;
+                }
+
+                Document parentDoc = new Document();
+                float[] vector = new float[dimension];
+                for (int d = 0; d < dimension; d++) {
+                    vector[d] = ((i + 1000) * 0.01f) + (d * 0.001f);
+                }
+                parentDoc.add(new KnnFloatVectorField(VECTOR_FIELD, vector, VectorSimilarityFunction.COSINE));
+                parentDoc.add(new StringField(TEST_ID_FIELD, String.valueOf(i), Field.Store.YES));
+                parentDoc.add(new StringField(DOC_TYPE_FIELD, "parent", Field.Store.YES));
+                parentDoc.add(new NumericDocValuesField("num_children", numChildren));
+                docBlock[numChildren] = parentDoc;
+
+                writer.updateDocuments(new Term(TEST_ID_FIELD, String.valueOf(i)), Arrays.asList(docBlock));
+            }
+            writer.commit();
+
+            // First intermediate merge
+            log.info("Performing first intermediate merge");
+            writer.forceMerge(1);
+
+            // Segment 3: 40 parent documents
+            log.info("Creating segment 3: 40 parent docs with nested children");
+            for (int i = 0; i < 40; i++) {
+                int numChildren = 1 + (i % 4); // 1-4 children
+                Document[] docBlock = new Document[numChildren + 1];
+
+                for (int c = 0; c < numChildren; c++) {
+                    Document childDoc = new Document();
+                    childDoc.add(new StringField(DOC_TYPE_FIELD, "child", Field.Store.YES));
+                    childDoc.add(new TextField(AUTHOR_NAME_FIELD, "Author_" + parentDocId + "_" + c, Field.Store.YES));
+                    childDoc.add(new StringField("parent_id", String.valueOf(parentDocId), Field.Store.YES));
+                    docBlock[c] = childDoc;
+                }
+
+                Document parentDoc = new Document();
+                float[] vector = new float[dimension];
+                for (int d = 0; d < dimension; d++) {
+                    vector[d] = (parentDocId * 0.01f) + (d * 0.001f);
+                }
+                parentDoc.add(new KnnFloatVectorField(VECTOR_FIELD, vector, VectorSimilarityFunction.COSINE));
+                parentDoc.add(new StringField(TEST_ID_FIELD, String.valueOf(parentDocId), Field.Store.YES));
+                parentDoc.add(new StringField(DOC_TYPE_FIELD, "parent", Field.Store.YES));
+                parentDoc.add(new NumericDocValuesField("num_children", numChildren));
+                docBlock[numChildren] = parentDoc;
+
+                writer.addDocuments(Arrays.asList(docBlock));
+                parentDocId++;
+            }
+            writer.commit();
+
+            // Delete 8 parent documents from segment 3
+            log.info("Deleting 8 parent documents from segment 3");
+            for (int i = 125; i < 133; i++) {
+                writer.deleteDocuments(new Term(TEST_ID_FIELD, String.valueOf(i)));
+            }
+            writer.commit();
+
+            // Calculate expected parent documents
+            // Segment 1: 50 - 10 deleted = 40 parents
+            // Segment 2: 75 parents (updates don't change count)
+            // Segment 3: 40 - 8 deleted = 32 parents
+            int expectedParents = 40 + 75 + 32;
+            log.info("Expected parent documents: {}", expectedParents);
+
+            // Final force merge
+            log.info("Starting final force merge");
+            writer.forceMerge(1);
+
+            // Verify the merged index
+            try (IndexReader reader = DirectoryReader.open(writer)) {
+                Assert.assertEquals("Should have 1 segment after final merge", 1, reader.getContext().leaves().size());
+
+                // Count parent documents
+                IndexSearcher searcher = newSearcher(reader);
+                TopDocs parentDocs = searcher.search(new TermQuery(new Term(DOC_TYPE_FIELD, "parent")), Integer.MAX_VALUE);
+                Assert.assertEquals("Should have correct number of parent docs", expectedParents, parentDocs.totalHits.value());
+
+                // Verify vector search works on parent documents
+                log.info("Verifying vector search on merged index with nested structure");
+                final float[] target = new float[dimension];
+                Arrays.fill(target, 0.5f);
+                JVectorKnnFloatVectorQuery query = getJVectorKnnFloatVectorQuery(
+                    VECTOR_FIELD,
+                    target,
+                    k,
+                    new TermQuery(new Term(DOC_TYPE_FIELD, "parent")) // Only search parent docs
+                );
+                TopDocs topDocs = searcher.search(query, k);
+                Assert.assertEquals("Should return k results", k, topDocs.totalHits.value());
+
+                // Verify results are parent documents with vectors
+                log.info("Verifying search results are parent documents");
+                for (int i = 0; i < topDocs.scoreDocs.length; i++) {
+                    Document doc = reader.storedFields().document(topDocs.scoreDocs[i].doc);
+                    String docType = doc.get(DOC_TYPE_FIELD);
+                    String id = doc.get(TEST_ID_FIELD);
+
+                    Assert.assertEquals("Result should be a parent document", "parent", docType);
+                    assertNotNull("Parent document should have ID", id);
+
+                    log.info("Result {}: parent doc ID = {}, score = {}", i, id, topDocs.scoreDocs[i].score);
+                }
+
+                // Verify deleted parent documents are not in results
+                log.info("Verifying deleted parent documents are not in index");
+                for (int deletedId = 5; deletedId < 15; deletedId++) {
+                    TopDocs deletedDocs = searcher.search(
+                        new BooleanQuery.Builder().add(
+                            new TermQuery(new Term(TEST_ID_FIELD, String.valueOf(deletedId))),
+                            BooleanClause.Occur.MUST
+                        ).add(new TermQuery(new Term(DOC_TYPE_FIELD, "parent")), BooleanClause.Occur.MUST).build(),
+                        1
+                    );
+                    Assert.assertEquals("Deleted parent document " + deletedId + " should not be found", 0, deletedDocs.totalHits.value());
+                }
+
+                log.info("Test passed! Root vectors with nested children handled correctly during merge");
+            }
+        }
+    }
+
+    /**
+     * Test merges with root-level vector field and nested child documents,
+     * one of the documents has root-level vector field set to null.
+     *
+     * This test validates the scenario where:
+     * - Vector field ("embedding") is at the root (parent) document level
+     * - Nested child documents ("authors") contain metadata without vectors
+     * - Documents are merged across multiple segments with deletions
+     *
+     * In Lucene, nested documents are stored as:
+     * - Child documents come first (authors)
+     * - Parent document comes last (with vector)
+     * - All are added as a single block using addDocuments()
+     *
+     * This mirrors the OpenSearch index structure:
+     * {
+     *   "embedding": [vector],
+     *   "authors": [
+     *     {"name": "Author 1"},
+     *     {"name": "Author 2"}
+     *   ]
+     * }
+     */
+    @Test
+    public void testMergesWithRootNullVectorAndNestedChildren() throws IOException {
+        final Map<String, float[]> docs = new HashMap<>();
+
+        final int dimension = 128;
+        final int k = 1;
+        final String VECTOR_FIELD = "embedding";
+        final String AUTHOR_NAME_FIELD = "authors.name";
+        final String DOC_TYPE_FIELD = "type"; // To distinguish parent from child docs
+
+        log.info("Testing merges with root-level nullable vectors and nested child documents");
+
+        IndexWriterConfig config = newIndexWriterConfig();
+        config.setUseCompoundFile(false);
+        config.setCodec(getCodec(1));
+        config.setMergePolicy(new ForceMergesOnlyMergePolicy());
+        config.setMergeScheduler(new SerialMergeScheduler());
+
+        final Path indexPath = createTempDir();
+
+        try (FSDirectory dir = FSDirectory.open(indexPath); IndexWriter writer = new IndexWriter(dir, config)) {
+            int parentDocId = 0;
+            final int parentDocIdWithoutVector = random().nextInt(3);
+
+            // Segment 1: 3 parent documents, each with 1-3 nested child documents
+            log.info("Creating segment 1: 2 parent docs with nested children");
+            for (int i = 0; i < 3; i++) {
+                // Create nested structure: children first, then parent
+                int numChildren = 1 + (i % 3); // 1-3 children per parent
+                Document[] docBlock = new Document[numChildren + 1];
+
+                // Add child documents (authors)
+                for (int c = 0; c < numChildren; c++) {
+                    Document childDoc = new Document();
+                    childDoc.add(new StringField(DOC_TYPE_FIELD, "nested", Field.Store.YES));
+                    childDoc.add(new TextField(AUTHOR_NAME_FIELD, "Author_" + parentDocId + "_" + c, Field.Store.YES));
+                    childDoc.add(new StringField("parent_id", String.valueOf(parentDocId), Field.Store.YES));
+                    docBlock[c] = childDoc;
+                }
+
+                // Add parent document with vector (must be last in block)
+                Document parentDoc = new Document();
+                // No vector for this document
+                if (parentDocId != parentDocIdWithoutVector) {
+                    float[] vector = new float[dimension];
+                    Arrays.fill(vector, (parentDocId + 1) * random().nextFloat(1.0f));
+                    parentDoc.add(new KnnFloatVectorField(VECTOR_FIELD, vector, VectorSimilarityFunction.COSINE));
+                    docs.put(Integer.toString(parentDocId), vector);
+                }
+                parentDoc.add(new StringField(TEST_ID_FIELD, String.valueOf(parentDocId), Field.Store.YES));
+                parentDoc.add(new StringField(DOC_TYPE_FIELD, "parent", Field.Store.YES));
+                parentDoc.add(new NumericDocValuesField("num_children", numChildren));
+                docBlock[numChildren] = parentDoc;
+
+                // Add the entire block (children + parent) atomically
+                writer.addDocuments(Arrays.asList(docBlock));
+                parentDocId++;
+            }
+            writer.commit();
+
+            // Delete 1 parent documents (and their children) from segment 1
+            log.info("Deleting 1 parent document 2 from segment 1");
+            writer.deleteDocuments(new Term(TEST_ID_FIELD, String.valueOf(2)));
+            writer.commit();
+
+            // First intermediate merge
+            log.info("Performing first intermediate merge");
+            writer.forceMerge(1);
+
+            // Verify the merged index
+            try (IndexReader reader = DirectoryReader.open(writer)) {
+                Assert.assertEquals("Should have 1 segment after final merge", 1, reader.getContext().leaves().size());
+
+                // Count parent documents
+                IndexSearcher searcher = newSearcher(reader);
+                TopDocs parentDocs = searcher.search(new TermQuery(new Term(DOC_TYPE_FIELD, "parent")), Integer.MAX_VALUE);
+                Assert.assertEquals("Should have correct number of parent docs", 2, parentDocs.totalHits.value());
+
+                // Verify vector search works on parent documents
+                log.info("Verifying vector search on merged index with nested structure");
+                final float[] target = new float[dimension];
+                Arrays.fill(target, 0.5f);
+                JVectorKnnFloatVectorQuery query = getJVectorKnnFloatVectorQuery(
+                    VECTOR_FIELD,
+                    target,
+                    k,
+                    new TermQuery(new Term(DOC_TYPE_FIELD, "parent")) // Only search parent docs
+                );
+                TopDocs topDocs = searcher.search(query, k);
+                Assert.assertEquals("Should return k results", k, topDocs.totalHits.value());
+
+                // Verify results are parent documents with vectors
+                log.info("Verifying search results are parent documents");
+                for (int i = 0; i < topDocs.scoreDocs.length; i++) {
+                    Document doc = reader.storedFields().document(topDocs.scoreDocs[i].doc);
+                    String docType = doc.get(DOC_TYPE_FIELD);
+                    String id = doc.get(TEST_ID_FIELD);
+
+                    Assert.assertEquals("Result should be a parent document", "parent", docType);
+                    assertNotNull("Parent document should have ID", id);
+
+                    log.info("Result {}: parent doc ID = {}, score = {}", i, id, topDocs.scoreDocs[i].score);
+                }
+
+                topDocs = searcher.search(new MatchAllDocsQuery(), 8);
+                Assert.assertEquals("Should return k results", 8, topDocs.totalHits.value());
+
+                for (int i = 0; i < topDocs.scoreDocs.length; i++) {
+                    Document doc = reader.storedFields().document(topDocs.scoreDocs[i].doc);
+                    String id = doc.get(TEST_ID_FIELD);
+                    assertThat(getVector(reader, VECTOR_FIELD, topDocs.scoreDocs[i].doc), equalTo(docs.get(id)));
+                    log.info("Result {}: doc ID = {}", i, id);
+                }
+
+                topDocs = searcher.search(new TermQuery(new Term(DOC_TYPE_FIELD, "parent")), 10);
+                Assert.assertEquals("Should return k results", 2, topDocs.totalHits.value());
+
+                for (int i = 0; i < topDocs.scoreDocs.length; i++) {
+                    Document doc = reader.storedFields().document(topDocs.scoreDocs[i].doc);
+                    String id = doc.get(TEST_ID_FIELD);
+                    assertThat(getVector(reader, VECTOR_FIELD, topDocs.scoreDocs[i].doc), equalTo(docs.get(id)));
+                    log.info("Result {}: doc ID = {}", i, id);
+                }
+            }
+        }
+    }
+
+    /**
+     * Test merges with root-level vector field and nested child documents,
+     * one of the documents has root-level vector field set to null, all child
+     * documents have vectors.
+     *
+     * This test validates the scenario where:
+     * - Vector field ("embedding") is at the root (parent) document level
+     * - Nested child documents ("authors") contain metadata without vectors
+     * - Documents are merged across multiple segments with deletions
+     *
+     * In Lucene, nested documents are stored as:
+     * - Child documents come first (authors)
+     * - Parent document comes last (with vector)
+     * - All are added as a single block using addDocuments()
+     *
+     * This mirrors the OpenSearch index structure:
+     * {
+     *   "embedding": [vector],
+     *   "authors": [
+     *     {"name": "Author 1"},
+     *     {"name": "Author 2"}
+     *   ]
+     * }
+     */
+    @Test
+    public void testMergesWithRootVectorAndNestedChildrenVectors() throws IOException {
+        final Map<String, float[]> docs = new HashMap<>();
+
+        final int dimension = 128;
+        final int k = 1;
+        final String VECTOR_FIELD = "embedding";
+        final String AUTHOR_NAME_FIELD = "authors.name";
+        final String DOC_TYPE_FIELD = "type"; // To distinguish parent from child docs
+
+        log.info("Testing merges with root-level nullable vectors and nested child documents");
+
+        IndexWriterConfig config = newIndexWriterConfig();
+        config.setUseCompoundFile(false);
+        config.setCodec(getCodec(1));
+        config.setMergePolicy(new ForceMergesOnlyMergePolicy());
+        config.setMergeScheduler(new SerialMergeScheduler());
+
+        final Path indexPath = createTempDir();
+
+        try (FSDirectory dir = FSDirectory.open(indexPath); IndexWriter writer = new IndexWriter(dir, config)) {
+            int parentDocId = 0;
+            final int parentDocIdWithoutVector = random().nextInt(3);
+
+            // Segment 1: 3 parent documents, each with 1-3 nested child documents
+            log.info("Creating segment 1: 2 parent docs with nested children");
+            for (int i = 0; i < 3; i++) {
+                // Create nested structure: children first, then parent
+                int numChildren = 1 + (i % 3); // 1-3 children per parent
+                Document[] docBlock = new Document[numChildren + 1];
+
+                // Add child documents (authors)
+                for (int c = 0; c < numChildren; c++) {
+                    Document childDoc = new Document();
+                    float[] vector = new float[dimension];
+                    Arrays.fill(vector, (c + 1) * random().nextFloat(1.0f));
+                    final String childDocId = String.valueOf(parentDocId) + "-" + String.valueOf(c);
+                    childDoc.add(new StringField(DOC_TYPE_FIELD, "nested", Field.Store.YES));
+                    childDoc.add(new TextField(AUTHOR_NAME_FIELD, "Author_" + parentDocId + "_" + c, Field.Store.YES));
+                    childDoc.add(new StringField("parent_id", String.valueOf(parentDocId), Field.Store.YES));
+                    childDoc.add(new StringField(TEST_ID_FIELD, childDocId, Field.Store.YES));
+                    childDoc.add(new KnnFloatVectorField(VECTOR_FIELD, vector, VectorSimilarityFunction.COSINE));
+                    docs.put(childDocId, vector);
+                    docBlock[c] = childDoc;
+                }
+
+                // Add parent document with vector (must be last in block)
+                Document parentDoc = new Document();
+                // No vector for this document
+                if (parentDocId != parentDocIdWithoutVector) {
+                    float[] vector = new float[dimension];
+                    Arrays.fill(vector, (parentDocId + 1) * random().nextFloat(1.0f));
+                    parentDoc.add(new KnnFloatVectorField(VECTOR_FIELD, vector, VectorSimilarityFunction.COSINE));
+                    docs.put(Integer.toString(parentDocId), vector);
+                }
+                parentDoc.add(new StringField(TEST_ID_FIELD, String.valueOf(parentDocId), Field.Store.YES));
+                parentDoc.add(new StringField(DOC_TYPE_FIELD, "parent", Field.Store.YES));
+                parentDoc.add(new NumericDocValuesField("num_children", numChildren));
+                docBlock[numChildren] = parentDoc;
+
+                // Add the entire block (children + parent) atomically
+                writer.addDocuments(Arrays.asList(docBlock));
+                parentDocId++;
+            }
+            writer.commit();
+
+            // Delete 1 parent documents (and their children) from segment 1
+            log.info("Deleting 1 parent document 2 from segment 1");
+            writer.deleteDocuments(new Term(TEST_ID_FIELD, String.valueOf(2)));
+            writer.commit();
+
+            // First intermediate merge
+            log.info("Performing first intermediate merge");
+            writer.forceMerge(1);
+
+            // Verify the merged index
+            try (IndexReader reader = DirectoryReader.open(writer)) {
+                Assert.assertEquals("Should have 1 segment after final merge", 1, reader.getContext().leaves().size());
+
+                // Count parent documents
+                IndexSearcher searcher = newSearcher(reader);
+                TopDocs parentDocs = searcher.search(new TermQuery(new Term(DOC_TYPE_FIELD, "parent")), Integer.MAX_VALUE);
+                Assert.assertEquals("Should have correct number of parent docs", 2, parentDocs.totalHits.value());
+
+                // Verify vector search works on parent documents
+                log.info("Verifying vector search on merged index with nested structure");
+                final float[] target = new float[dimension];
+                Arrays.fill(target, 0.5f);
+                JVectorKnnFloatVectorQuery query = getJVectorKnnFloatVectorQuery(
+                    VECTOR_FIELD,
+                    target,
+                    k,
+                    new TermQuery(new Term(DOC_TYPE_FIELD, "parent")) // Only search parent docs
+                );
+                TopDocs topDocs = searcher.search(query, k);
+                Assert.assertEquals("Should return k results", k, topDocs.totalHits.value());
+
+                // Verify results are parent documents with vectors
+                log.info("Verifying search results are parent documents");
+                for (int i = 0; i < topDocs.scoreDocs.length; i++) {
+                    Document doc = reader.storedFields().document(topDocs.scoreDocs[i].doc);
+                    String docType = doc.get(DOC_TYPE_FIELD);
+                    String id = doc.get(TEST_ID_FIELD);
+
+                    Assert.assertEquals("Result should be a parent document", "parent", docType);
+                    assertNotNull("Parent document should have ID", id);
+
+                    log.info("Result {}: parent doc ID = {}, score = {}", i, id, topDocs.scoreDocs[i].score);
+                }
+
+                topDocs = searcher.search(new MatchAllDocsQuery(), 8);
+                Assert.assertEquals("Should return k results", 8, topDocs.totalHits.value());
+
+                for (int i = 0; i < topDocs.scoreDocs.length; i++) {
+                    Document doc = reader.storedFields().document(topDocs.scoreDocs[i].doc);
+                    String id = doc.get(TEST_ID_FIELD);
+                    assertThat(getVector(reader, VECTOR_FIELD, topDocs.scoreDocs[i].doc), equalTo(docs.get(id)));
+                    log.info("Result {}: doc ID = {}", i, id);
+                }
+
+                topDocs = searcher.search(new TermQuery(new Term(DOC_TYPE_FIELD, "parent")), 10);
+                Assert.assertEquals("Should return k results", 2, topDocs.totalHits.value());
+
+                for (int i = 0; i < topDocs.scoreDocs.length; i++) {
+                    Document doc = reader.storedFields().document(topDocs.scoreDocs[i].doc);
+                    String id = doc.get(TEST_ID_FIELD);
+                    assertThat(getVector(reader, VECTOR_FIELD, topDocs.scoreDocs[i].doc), equalTo(docs.get(id)));
+                    log.info("Result {}: doc ID = {}", i, id);
+                }
+            }
+        }
+    }
+
+    /**
+     * Test merges with root-level vector field and nested child documents,
+     * one of the documents has root-level vector field set to null and its all child
+     * documents have no vectors.
+     *
+     * This test validates the scenario where:
+     * - Vector field ("embedding") is at the root (parent) document level
+     * - Nested child documents ("authors") contain metadata without vectors
+     * - Documents are merged across multiple segments with deletions
+     *
+     * In Lucene, nested documents are stored as:
+     * - Child documents come first (authors)
+     * - Parent document comes last (with vector)
+     * - All are added as a single block using addDocuments()
+     *
+     * This mirrors the OpenSearch index structure:
+     * {
+     *   "embedding": [vector],
+     *   "authors": [
+     *     {"name": "Author 1"},
+     *     {"name": "Author 2"}
+     *   ]
+     * }
+     */
+    @Test
+    public void testMergesWithRootNoVectorAndNestedChildrenNoVector() throws IOException {
+        final Map<String, float[]> docs = new HashMap<>();
+
+        final int dimension = 128;
+        final int k = 1;
+        final String VECTOR_FIELD = "embedding";
+        final String AUTHOR_NAME_FIELD = "authors.name";
+        final String DOC_TYPE_FIELD = "type"; // To distinguish parent from child docs
+
+        log.info("Testing merges with root-level nullable vectors and nested child documents");
+
+        IndexWriterConfig config = newIndexWriterConfig();
+        config.setUseCompoundFile(false);
+        config.setCodec(getCodec(1));
+        config.setMergePolicy(new ForceMergesOnlyMergePolicy());
+        config.setMergeScheduler(new SerialMergeScheduler());
+
+        final Path indexPath = createTempDir();
+
+        try (FSDirectory dir = FSDirectory.open(indexPath); IndexWriter writer = new IndexWriter(dir, config)) {
+            int parentDocId = 0;
+            final int parentDocIdWithoutVector = random().nextInt(3);
+
+            // Segment 1: 3 parent documents, each with 1-3 nested child documents
+            log.info("Creating segment 1: 2 parent docs with nested children");
+            for (int i = 0; i < 3; i++) {
+                // Create nested structure: children first, then parent
+                int numChildren = 1 + (i % 3); // 1-3 children per parent
+                Document[] docBlock = new Document[numChildren + 1];
+
+                // Add child documents (authors)
+                for (int c = 0; c < numChildren; c++) {
+                    Document childDoc = new Document();
+                    final String childDocId = String.valueOf(parentDocId) + "-" + String.valueOf(c);
+                    childDoc.add(new StringField(DOC_TYPE_FIELD, "nested", Field.Store.YES));
+                    childDoc.add(new TextField(AUTHOR_NAME_FIELD, "Author_" + parentDocId + "_" + c, Field.Store.YES));
+                    childDoc.add(new StringField("parent_id", String.valueOf(parentDocId), Field.Store.YES));
+                    childDoc.add(new StringField(TEST_ID_FIELD, childDocId, Field.Store.YES));
+                    if (parentDocId != parentDocIdWithoutVector) {
+                        float[] vector = new float[dimension];
+                        Arrays.fill(vector, (c + 1) * random().nextFloat(1.0f));
+                        childDoc.add(new KnnFloatVectorField(VECTOR_FIELD, vector, VectorSimilarityFunction.COSINE));
+                        docs.put(childDocId, vector);
+                    }
+                    docBlock[c] = childDoc;
+                }
+
+                // Add parent document with vector (must be last in block)
+                Document parentDoc = new Document();
+                // No vector for this document
+                if (parentDocId != parentDocIdWithoutVector) {
+                    float[] vector = new float[dimension];
+                    Arrays.fill(vector, (parentDocId + 1) * random().nextFloat(1.0f));
+                    parentDoc.add(new KnnFloatVectorField(VECTOR_FIELD, vector, VectorSimilarityFunction.COSINE));
+                    docs.put(Integer.toString(parentDocId), vector);
+                }
+                parentDoc.add(new StringField(TEST_ID_FIELD, String.valueOf(parentDocId), Field.Store.YES));
+                parentDoc.add(new StringField(DOC_TYPE_FIELD, "parent", Field.Store.YES));
+                parentDoc.add(new NumericDocValuesField("num_children", numChildren));
+                docBlock[numChildren] = parentDoc;
+
+                // Add the entire block (children + parent) atomically
+                writer.addDocuments(Arrays.asList(docBlock));
+                parentDocId++;
+            }
+            writer.commit();
+
+            // Delete 1 parent documents (and their children) from segment 1
+            log.info("Deleting 1 parent document 2 from segment 1");
+            writer.deleteDocuments(new Term(TEST_ID_FIELD, String.valueOf(2)));
+            writer.commit();
+
+            // First intermediate merge
+            log.info("Performing first intermediate merge");
+            writer.forceMerge(1);
+
+            // Verify the merged index
+            try (IndexReader reader = DirectoryReader.open(writer)) {
+                Assert.assertEquals("Should have 1 segment after final merge", 1, reader.getContext().leaves().size());
+
+                // Count parent documents
+                IndexSearcher searcher = newSearcher(reader);
+                TopDocs parentDocs = searcher.search(new TermQuery(new Term(DOC_TYPE_FIELD, "parent")), Integer.MAX_VALUE);
+                Assert.assertEquals("Should have correct number of parent docs", 2, parentDocs.totalHits.value());
+
+                // Verify vector search works on parent documents
+                log.info("Verifying vector search on merged index with nested structure");
+                final float[] target = new float[dimension];
+                Arrays.fill(target, 0.5f);
+                JVectorKnnFloatVectorQuery query = getJVectorKnnFloatVectorQuery(
+                    VECTOR_FIELD,
+                    target,
+                    k,
+                    new TermQuery(new Term(DOC_TYPE_FIELD, "parent")) // Only search parent docs
+                );
+                TopDocs topDocs = searcher.search(query, k);
+                Assert.assertEquals("Should return k results", k, topDocs.totalHits.value());
+
+                // Verify results are parent documents with vectors
+                log.info("Verifying search results are parent documents");
+                for (int i = 0; i < topDocs.scoreDocs.length; i++) {
+                    Document doc = reader.storedFields().document(topDocs.scoreDocs[i].doc);
+                    String docType = doc.get(DOC_TYPE_FIELD);
+                    String id = doc.get(TEST_ID_FIELD);
+
+                    Assert.assertEquals("Result should be a parent document", "parent", docType);
+                    assertNotNull("Parent document should have ID", id);
+
+                    log.info("Result {}: parent doc ID = {}, score = {}", i, id, topDocs.scoreDocs[i].score);
+                }
+
+                topDocs = searcher.search(new MatchAllDocsQuery(), 8);
+                Assert.assertEquals("Should return k results", 8, topDocs.totalHits.value());
+
+                for (int i = 0; i < topDocs.scoreDocs.length; i++) {
+                    Document doc = reader.storedFields().document(topDocs.scoreDocs[i].doc);
+                    String id = doc.get(TEST_ID_FIELD);
+                    assertThat(getVector(reader, VECTOR_FIELD, topDocs.scoreDocs[i].doc), equalTo(docs.get(id)));
+                    log.info("Result {}: doc ID = {}", i, id);
+                }
+
+                topDocs = searcher.search(new TermQuery(new Term(DOC_TYPE_FIELD, "parent")), 10);
+                Assert.assertEquals("Should return k results", 2, topDocs.totalHits.value());
+
+                for (int i = 0; i < topDocs.scoreDocs.length; i++) {
+                    Document doc = reader.storedFields().document(topDocs.scoreDocs[i].doc);
+                    String id = doc.get(TEST_ID_FIELD);
+                    assertThat(getVector(reader, VECTOR_FIELD, topDocs.scoreDocs[i].doc), equalTo(docs.get(id)));
+                    log.info("Result {}: doc ID = {}", i, id);
+                }
+            }
+        }
+    }
+
+    private static float[] getVector(final IndexReader reader, final String field, final int doc) throws IOException {
+        for (LeafReaderContext context : reader.leaves()) {
+            final FloatVectorValues vectorValues = context.reader().getFloatVectorValues(field);
+            if (vectorValues != null) {
+                final var docIdSetIterator = vectorValues.iterator(); // iterator for all the vectors with values
+                int docId = -1;
+                for (docId = docIdSetIterator.nextDoc(); docId != DocIdSetIterator.NO_MORE_DOCS; docId = docIdSetIterator.nextDoc()) {
+                    if (docId == doc) {
+                        final int index = docIdSetIterator.index();
+                        if (index == GraphNodeIdToDocMap.NO_VECTOR_OR_DELETED_DOC) {
+                            return null; /* no vector value set */
+                        } else {
+                            return vectorValues.vectorValue(index);
+                        }
+                    }
+                }
+            }
+        }
+
+        throw new IllegalStateException("The docId " + doc + " expected but was not found");
+    }
 }


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-jvector/pull/288 to `3.4`