### PR TITLE
[Forwardport] [main] Add 3.5.0.1 release notes (#332)

### DIFF
--- a/release-notes/opensearch-jvector-knn.release-notes-3.5.0.1.md
+++ b/release-notes/opensearch-jvector-knn.release-notes-3.5.0.1.md
@@ -1,0 +1,16 @@
+## Version 3.5.0.1 Release Notes
+
+Compatible with OpenSearch and OpenSearch Dashboards version 3.5.0
+
+### Features
+### Enhancements
+### Bug Fixes
+* Fix issues handling documents without vector fields being populated [288] (https://github.com/opensearch-project/opensearch-jvector/issues/288)
+* Remove usage of the commons-lang 2.6 [317] (https://github.com/opensearch-project/opensearch-jvector/pull/317)
+### Infrastructure
+### Documentation
+### Maintenance
+* Update `com.google.guava:failureaccess` from 1.0.1 to 1.0.2
+* Update `com.google.guava:guava` from 32.1.3-jre to 33.2.1-jre
+### Refactoring
+


### PR DESCRIPTION
Forwardport of https://github.com/opensearch-project/opensearch-jvector/pull/332 to `main`