### PR TITLE
[Backport] [3.5] Fix guava dependency scope (#344)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 ### Enhancements
 ### Bug Fixes
+* Fixing guava dependency scope, since the dependency is provided by transport-grpc plugin [344] (https://github.com/opensearch-project/opensearch-jvector/pull/344)
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/build.gradle
+++ b/build.gradle
@@ -285,7 +285,7 @@ opensearchplugin {
     // zip file name and plugin name in ${opensearch.plugin.name} read by OpenSearch when plugin loading
     description 'OpenSearch jVector plugin'
     classname 'org.opensearch.knn.plugin.JVectorKNNPlugin'
-    extendedPlugins = ['lang-painless']
+    extendedPlugins = ['lang-painless', 'transport-grpc']
     licenseFile = rootProject.file('LICENSE.txt')
     noticeFile = rootProject.file('NOTICE.txt')
 }
@@ -311,15 +311,19 @@ task release(type: Copy, group: 'build') {
 dependencies {
     api "org.opensearch:opensearch:${opensearch_version}"
     compileOnly "org.opensearch.plugin:opensearch-scripting-painless-spi:${versions.opensearch}"
-    api group: 'com.google.guava', name: 'failureaccess', version:'1.0.2'
-    api group: 'com.google.guava', name: 'guava', version:'33.2.1-jre'
+    // Declare guava as compile time since guava will come from OpenSearch transport-grpc module.
+    compileOnly group: 'com.google.guava', name: 'guava', version: "${versions.guava}"
     api "org.apache.commons:commons-lang3:${versions.commonslang}"
     testFixturesImplementation "org.opensearch.test:framework:${opensearch_version}"
     // Add the high-level client dependency
     testImplementation "org.opensearch.client:opensearch-rest-high-level-client:${opensearch_version}"
     // Add netty dependency so we can use it within internal test clusters (not just external ones)
     testImplementation "org.opensearch.plugin:transport-netty4-client:${opensearch_version}"
+    testImplementation("com.google.guava:guava:${versions.guava}")
 
+    testFixturesImplementation("com.google.guava:guava:${versions.guava}") {
+        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+    }
     // json-path 2.9.0 depends on slf4j 2.0.11, which conflicts with the version used by OpenSearch core.
     // Excluding slf4j here since json-path is only used for testing, and logging failures in this context are acceptable.
     testFixturesImplementation('com.jayway.jsonpath:json-path:2.9.0') {


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-jvector/pull/344 to 3.5