### PR TITLE
[Forwardport] [main] Prepare 3.5.0.2 release (#346)

### DIFF
--- a/release-notes/opensearch-jvector.release-notes-3.5.0.2.md
+++ b/release-notes/opensearch-jvector.release-notes-3.5.0.2.md
@@ -1,0 +1,13 @@
+## Version 3.5.0.2 Release Notes
+
+Compatible with OpenSearch and OpenSearch Dashboards version 3.5.0
+
+### Features
+### Enhancements
+### Bug Fixes
+* Fixing guava dependency scope, since the dependency is provided by transport-grpc plugin [344] (https://github.com/opensearch-project/opensearch-jvector/pull/344)
+### Infrastructure
+### Documentation
+### Maintenance
+### Refactoring
+


### PR DESCRIPTION
Forwardport of https://github.com/opensearch-project/opensearch-jvector/pull/346 to `main`