### PR TITLE
Add user guide and end-to-end demo script for jVector plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Upgrade jvector from 4.0.0-rc.6 to 4.0.0-rc.8 [370](https://github.com/opensearch-project/opensearch-jvector/pull/370)
 * Update Gradle to 9.4.1 [381](https://github.com/opensearch-project/opensearch-jvector/pull/381)
 ### Documentation
+* Update user guide covering index creation, search tuning, compression levels, and advanced topics; add demo script walking through cluster health check, bulk indexing, filtered/tuned KNN search, force merge, and node stats
 ### Maintenance
 * Update `com.google.guava:failureaccess` from 1.0.1 to 1.0.2
 * Update `com.google.guava:guava` from 32.1.3-jre to 33.2.1-jre

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -77,7 +77,7 @@ This builds the plugin zip, installs it into a local OpenSearch distribution, an
 Open a second terminal and run:
 
 ```bash
-./scripts/demo.sh
+./scripts/demo_full.sh
 ```
 
 The script will:
@@ -105,13 +105,13 @@ The script will:
 
 ```bash
 # Default (localhost, no auth)
-./scripts/demo.sh
+./scripts/demo_full.sh
 
 # Remote cluster with auth over HTTPS
-./scripts/demo.sh -h my-cluster:9200 -u admin -p secret -s
+./scripts/demo_full.sh -h my-cluster:9200 -u admin -p secret -s
 
 # Keep the index so you can explore it afterwards
-./scripts/demo.sh -x
+./scripts/demo_full.sh -x
 ```
 
 ---
@@ -217,18 +217,6 @@ curl -X PUT "http://localhost:9200/my-vectors-disk" \
   }
 }'
 ```
-
-Compression levels and their trade-offs:
-
-| `compression_level` | Bits per float | RAM savings | Notes |
-|---|---|---|---|
-| `1x` | 32-bit | none | Full precision, in-memory |
-| `2x` | 16-bit | ~50% | |
-| `4x` | 8-bit | ~75% | |
-| `8x` | 4-bit | ~87% | Requires `mode: on_disk` |
-| `16x` | 2-bit | ~94% | |
-| `32x` | 1-bit | ~97% | |
-| `64x` | 1-bit (64-bit floats) | ~98% | |
 
 Higher compression levels require larger `advanced.num_pq_subspaces` to maintain recall quality.
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,0 +1,480 @@
+# OpenSearch jVector Plugin — User Guide
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Prerequisites](#prerequisites)
+- [Running the Demo](#running-the-demo)
+- [Create an Index](#create-an-index)
+  - [Minimal Example](#minimal-example)
+  - [Full Configuration Reference](#full-configuration-reference)
+  - [Quantized / On-Disk Index](#quantized--on-disk-index)
+- [Index Documents](#index-documents)
+- [Search](#search)
+  - [Basic KNN Search](#basic-knn-search)
+  - [Search with Filters](#search-with-filters)
+  - [Search Tuning Parameters](#search-tuning-parameters)
+- [Force Merge](#force-merge)
+- [Space Types](#space-types)
+- [Advanced Topics](#advanced-topics)
+  - [Product Quantization (PQ)](#product-quantization-pq)
+  - [DiskANN Mode](#diskann-mode)
+  - [MMR Search](#mmr-search)
+- [Index Settings Reference](#index-settings-reference)
+- [Mapping Parameters Reference](#mapping-parameters-reference)
+
+---
+
+## Overview
+
+The OpenSearch jVector plugin replaces the default KNN engine with [jVector](https://github.com/jbellis/jvector), a pure-Java DiskANN implementation. It provides:
+
+- **Higher throughput** during indexing via thread-safe concurrent inserts
+- **Lower search latency** due to quantized graph traversal
+- **Incremental merges** — existing graphs are extended rather than rebuilt from scratch
+- **DiskANN** — RAM-efficient ANN search that keeps quantized vectors on disk and re-ranks with full precision
+
+The plugin exposes the same `knn_vector` field type and `knn` query used by the standard KNN plugin, so switching is mostly a matter of specifying `"engine": "jvector"` in your mapping.
+
+---
+
+## Prerequisites
+
+- OpenSearch 3.x with the jVector plugin installed
+- The plugin replaces `opensearch-knn`. Both cannot be active at the same time.
+
+Verify the plugin is loaded:
+
+```bash
+curl -s http://localhost:9200/_cat/plugins?v | grep jvector
+```
+
+---
+
+## Running the Demo
+
+The repository ships a self-contained demo script that walks through every core operation end-to-end: create index → bulk index → search → filtered search → tuned search → force merge → post-merge search → node stats.
+
+### 1. Start OpenSearch with the jVector plugin
+
+If you don't have an existing cluster, start one locally using Gradle (from the repo root):
+
+```bash
+./gradlew run
+```
+
+Wait until the log shows:
+
+```
+[INFO][o.e.h.AbstractHttpServerTransport] publish_address {127.0.0.1:9200}
+[INFO][o.e.n.Node] started
+```
+
+This builds the plugin zip, installs it into a local OpenSearch distribution, and boots a single-node cluster on `http://localhost:9200`.
+
+### 2. Run the demo script
+
+Open a second terminal and run:
+
+```bash
+./scripts/demo.sh
+```
+
+The script will:
+1. Check cluster health and confirm the jVector plugin is installed (exits with an error if not)
+2. Create a `jvector-demo` index with an 8-dimensional `cosinesimil` vector field
+3. Bulk-index 10 movie documents, each with a genre, year, and embedding
+4. Run a basic KNN search (sci-fi/action query vector)
+5. Run a filtered KNN search (same vector, restricted to `genre=action`)
+6. Run a tuned KNN search (`overquery_factor=10`) on an animation query
+7. Force merge to 1 segment and repeat the search to verify consistency
+8. Print jVector node stats (`visited_nodes`, `expanded_nodes`, `merge_time`)
+9. Delete the demo index
+
+### Options
+
+| Flag | Description |
+|---|---|
+| `-h HOST` | OpenSearch host:port (default: `localhost:9200`) |
+| `-u USER` | Basic-auth username |
+| `-p PASS` | Basic-auth password |
+| `-s` | Use HTTPS instead of HTTP |
+| `-x` | Keep the demo index after the run |
+
+**Examples:**
+
+```bash
+# Default (localhost, no auth)
+./scripts/demo.sh
+
+# Remote cluster with auth over HTTPS
+./scripts/demo.sh -h my-cluster:9200 -u admin -p secret -s
+
+# Keep the index so you can explore it afterwards
+./scripts/demo.sh -x
+```
+
+---
+
+## Create an Index
+
+### Minimal Example
+
+```bash
+curl -X PUT "http://localhost:9200/my-vectors" \
+  -H "Content-Type: application/json" -d '
+{
+  "settings": {
+    "index.knn": true
+  },
+  "mappings": {
+    "properties": {
+      "embedding": {
+        "type": "knn_vector",
+        "dimension": 128,
+        "method": {
+          "name": "disk_ann",
+          "engine": "jvector",
+          "space_type": "l2"
+        }
+      }
+    }
+  }
+}'
+```
+
+Key points:
+- `index.knn: true` — required to activate the KNN plugin on this index
+- `method.engine: "jvector"` — selects the jVector engine
+- `method.name: "disk_ann"` — the only available algorithm for jVector
+- `dimension` — must match the dimension of your embedding model exactly
+
+### Full Configuration Reference
+
+```bash
+curl -X PUT "http://localhost:9200/my-vectors" \
+  -H "Content-Type: application/json" -d '
+{
+  "settings": {
+    "index.knn": true,
+    "number_of_shards": 1,
+    "number_of_replicas": 0
+  },
+  "mappings": {
+    "properties": {
+      "title": { "type": "text" },
+      "category": { "type": "keyword" },
+      "embedding": {
+        "type": "knn_vector",
+        "dimension": 128,
+        "method": {
+          "name": "disk_ann",
+          "engine": "jvector",
+          "space_type": "cosinesimil",
+          "parameters": {
+            "m": 16,
+            "ef_construction": 100,
+            "advanced.alpha": 1.2,
+            "advanced.neighbor_overflow": 1.2,
+            "advanced.hierarchy_enabled": false
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+### Quantized / On-Disk Index
+
+For large datasets that exceed available RAM, use `on_disk` mode with a compression level:
+
+```bash
+curl -X PUT "http://localhost:9200/my-vectors-disk" \
+  -H "Content-Type: application/json" -d '
+{
+  "settings": {
+    "index.knn": true
+  },
+  "mappings": {
+    "properties": {
+      "embedding": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "mode": "on_disk",
+        "compression_level": "8x",
+        "method": {
+          "name": "disk_ann",
+          "engine": "jvector",
+          "space_type": "l2",
+          "parameters": {
+            "advanced.num_pq_subspaces": 96,
+            "advanced.min_batch_size_for_quantization": 1024
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+Compression levels and their trade-offs:
+
+| `compression_level` | Bits per float | RAM savings | Notes |
+|---|---|---|---|
+| `1x` | 32-bit | none | Full precision, in-memory |
+| `2x` | 16-bit | ~50% | |
+| `4x` | 8-bit | ~75% | |
+| `8x` | 4-bit | ~87% | Requires `mode: on_disk` |
+| `16x` | 2-bit | ~94% | |
+| `32x` | 1-bit | ~97% | |
+| `64x` | 1-bit (64-bit floats) | ~98% | |
+
+Higher compression levels require larger `advanced.num_pq_subspaces` to maintain recall quality.
+
+---
+
+## Index Documents
+
+Index documents the same way as any OpenSearch index. The vector field accepts a flat array of floats whose length must equal `dimension`.
+
+**Single document:**
+
+```bash
+curl -X PUT "http://localhost:9200/my-vectors/_doc/1" \
+  -H "Content-Type: application/json" -d '
+{
+  "title": "Introduction to vector search",
+  "category": "technology",
+  "embedding": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+}'
+```
+
+**Bulk indexing (recommended for large datasets):**
+
+```bash
+curl -X POST "http://localhost:9200/_bulk" \
+  -H "Content-Type: application/json" -d '
+{ "index": { "_index": "my-vectors", "_id": "1" } }
+{ "title": "Document one", "embedding": [0.1, 0.2, 0.3, 0.4] }
+{ "index": { "_index": "my-vectors", "_id": "2" } }
+{ "title": "Document two", "embedding": [0.9, 0.8, 0.7, 0.6] }
+{ "index": { "_index": "my-vectors", "_id": "3" } }
+{ "title": "Document three", "embedding": [0.5, 0.5, 0.5, 0.5] }
+'
+```
+
+---
+
+## Search
+
+### Basic KNN Search
+
+```bash
+curl -X POST "http://localhost:9200/my-vectors/_search" \
+  -H "Content-Type: application/json" -d '
+{
+  "size": 5,
+  "query": {
+    "knn": {
+      "embedding": {
+        "vector": [0.1, 0.2, 0.3, 0.4],
+        "k": 5
+      }
+    }
+  }
+}'
+```
+
+- `vector` — the query vector; must have the same dimension as the field
+- `k` — number of nearest neighbors to return (max 10,000)
+
+### Search with Filters
+
+Combine KNN with standard OpenSearch filters to restrict the candidate set:
+
+```bash
+curl -X POST "http://localhost:9200/my-vectors/_search" \
+  -H "Content-Type: application/json" -d '
+{
+  "size": 5,
+  "query": {
+    "knn": {
+      "embedding": {
+        "vector": [0.1, 0.2, 0.3, 0.4],
+        "k": 5,
+        "filter": {
+          "term": { "category": "technology" }
+        }
+      }
+    }
+  }
+}'
+```
+
+### Search Tuning Parameters
+
+Use `method_parameters` to trade off latency against recall at query time:
+
+```bash
+curl -X POST "http://localhost:9200/my-vectors/_search" \
+  -H "Content-Type: application/json" -d '
+{
+  "size": 10,
+  "query": {
+    "knn": {
+      "embedding": {
+        "vector": [0.1, 0.2, 0.3, 0.4],
+        "k": 10,
+        "method_parameters": {
+          "overquery_factor": 10,
+          "advanced.rerank_floor": 0.1
+        }
+      }
+    }
+  }
+}'
+```
+
+| Parameter | Default | Effect |
+|---|---|---|
+| `overquery_factor` | `5` | Internal candidate list = `k × overquery_factor`. Higher values improve recall at the cost of latency. |
+| `advanced.threshold` | `0.0` | Minimum similarity score for a candidate to enter the result set. |
+| `advanced.rerank_floor` | `0.0` | Minimum score for a candidate to be re-ranked with full-precision vectors. |
+| `advanced.use_pruning` | `false` | Enable graph traversal pruning to reduce nodes visited. |
+
+---
+
+## Force Merge
+
+Force merging consolidates segments and triggers jVector's incremental graph merge, improving search performance significantly for write-heavy workloads.
+
+```bash
+# Merge down to 1 segment (recommended for read-heavy indexes)
+curl -X POST "http://localhost:9200/my-vectors/_forcemerge?max_num_segments=1"
+```
+
+Wait for the operation to complete before querying — it runs synchronously and returns when done.
+
+**Merge behaviour with jVector:**  
+Unlike Lucene's full rebuild, jVector performs an *incremental merge* — nodes from smaller segments are inserted into the existing graph rather than re-indexing from scratch. This makes merges on large indexes dramatically faster (see the [README benchmarks](../README.md#incremental-merges)).
+
+To prevent the leading (largest) segment from being touched during merge, set in your mapping:
+
+```json
+"parameters": {
+  "advanced.leading_segment_merge_disabled": true
+}
+```
+
+---
+
+## Space Types
+
+The `space_type` field controls which distance metric is used.
+
+| Value | Distance metric | Use case |
+|---|---|---|
+| `l2` | Euclidean | General-purpose; raw coordinates |
+| `cosinesimil` | Cosine similarity | Text embeddings; direction matters more than magnitude |
+| `innerproduct` | Dot product | Embeddings where magnitude carries meaning (e.g. biencoder models) |
+| `l1` | Manhattan | Robust to outliers |
+| `linf` | Chebyshev | Maximum per-dimension deviation |
+
+The default is `l2` when `space_type` is omitted.
+
+---
+
+## Advanced Topics
+
+### Product Quantization (PQ)
+
+PQ compresses vector storage by dividing each vector into subspaces and quantizing each independently. Set `advanced.num_pq_subspaces` in `method.parameters`:
+
+```json
+"parameters": {
+  "advanced.num_pq_subspaces": 48,
+  "advanced.min_batch_size_for_quantization": 1024
+}
+```
+
+Rules:
+- `num_pq_subspaces` must be ≤ `dimension` and ideally a divisor of it
+- Quantization training is triggered automatically once the segment has at least `min_batch_size_for_quantization` documents
+- More subspaces = less compression but better recall
+
+### DiskANN Mode
+
+For indexes that exceed available RAM, combine `mode: on_disk` with PQ:
+
+```json
+{
+  "type": "knn_vector",
+  "dimension": 1536,
+  "mode": "on_disk",
+  "compression_level": "8x",
+  "method": {
+    "name": "disk_ann",
+    "engine": "jvector",
+    "space_type": "cosinesimil",
+    "parameters": {
+      "m": 32,
+      "ef_construction": 200,
+      "advanced.num_pq_subspaces": 192,
+      "advanced.min_batch_size_for_quantization": 2048
+    }
+  }
+}
+```
+
+During search, jVector uses the compressed vectors for graph traversal and re-ranks the top candidates using full-precision vectors read from disk. Increase `overquery_factor` at query time to improve recall at the cost of more re-ranking disk reads.
+
+### MMR Search
+
+For diverse result sets, see [docs/mmr_search.md](mmr_search.md).
+
+---
+
+## Index Settings Reference
+
+| Setting | Default | Description |
+|---|---|---|
+| `index.knn` | — | Set to `true` to enable the KNN plugin on the index (required) |
+| `index.knn.advanced.approximate_threshold` | `15000` | Minimum document count per segment before an approximate graph is built |
+| `index.knn.disk.vector.shard_level_rescoring_disabled` | `false` | Disable shard-level re-scoring for on-disk vectors |
+| `index.knn.derived_source.enabled` | `true` | Store vectors in derived source fields |
+
+---
+
+## Mapping Parameters Reference
+
+### Field-level
+
+| Parameter | Required | Default | Description |
+|---|---|---|---|
+| `type` | yes | — | Must be `"knn_vector"` |
+| `dimension` | yes | — | Integer 1–16,000 |
+| `data_type` | no | `"float"` | Only `"float"` is supported |
+| `mode` | no | `"in_memory"` | `"in_memory"` or `"on_disk"` |
+| `compression_level` | no | `"1x"` | `"1x"` through `"64x"` |
+
+### `method` object
+
+| Parameter | Required | Default | Description |
+|---|---|---|---|
+| `name` | yes | — | Must be `"disk_ann"` |
+| `engine` | yes | — | Must be `"jvector"` |
+| `space_type` | no | `"l2"` | See [Space Types](#space-types) |
+
+### `method.parameters`
+
+| Parameter | Default | Description |
+|---|---|---|
+| `m` | `16` | Bi-directional link count per node. Higher values improve recall, increase index size. |
+| `ef_construction` | `100` | Candidate list size during graph construction. Higher values improve recall, slow ingestion. |
+| `advanced.alpha` | `1.2` | Diversity factor for neighbor selection |
+| `advanced.neighbor_overflow` | `1.2` | Overflow factor for neighbor lists |
+| `advanced.hierarchy_enabled` | `false` | Enable hierarchical graph structure |
+| `advanced.num_pq_subspaces` | — | Number of PQ subspaces. Must be ≤ dimension. |
+| `advanced.min_batch_size_for_quantization` | `1024` | Documents needed before quantization is trained |
+| `advanced.leading_segment_merge_disabled` | `false` | Prevent leading segment from being rebuilt during force merge |

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -1,315 +1,107 @@
-#!/usr/bin/env bash
-# =============================================================================
-# OpenSearch jVector Plugin — Demo Script
-#
-# Walks through the core jVector workflow:
-#   1. Create an index with a knn_vector mapping
-#   2. Bulk-index documents that have vector + metadata fields
-#   3. Basic KNN search
-#   4. Filtered KNN search (combine vector similarity with a term filter)
-#   5. KNN search with tuning parameters (overquery_factor, rerank_floor, …)
-#   6. Force merge  ← triggers jVector's incremental graph merge
-#   7. KNN search after merge  ← verify results are consistent
-#   8. jVector node stats
-#
-# Usage:
-#   ./scripts/demo.sh [OPTIONS]
-#
-# Options:
-#   -h HOST   OpenSearch host:port   (default: localhost:9200)
-#   -u USER   Basic-auth username    (optional)
-#   -p PASS   Basic-auth password    (optional)
-#   -s        Use HTTPS              (default: HTTP)
-#   -x        Keep the demo index after the run (default: delete it)
-# =============================================================================
+############## Demo script for jVector k-NN ##############
 
-set -euo pipefail
-
-# ---------- defaults ----------------------------------------------------------
-HOST="localhost:9200"
-SCHEME="http"
-AUTH_USER=""
-AUTH_PASS=""
-SKIP_CLEANUP=false
-INDEX="jvector-demo"
-
-# ---------- argument parsing --------------------------------------------------
-while getopts "h:u:p:sx" opt; do
-  case $opt in
-    h) HOST="$OPTARG"      ;;
-    u) AUTH_USER="$OPTARG" ;;
-    p) AUTH_PASS="$OPTARG" ;;
-    s) SCHEME="https"      ;;
-    x) SKIP_CLEANUP=true   ;;
-    *) echo "Unknown option -$OPTARG" >&2; exit 1 ;;
-  esac
-done
-
-BASE_URL="${SCHEME}://${HOST}"
-CURL_FLAGS="-sk"
-[[ -n "$AUTH_USER" && -n "$AUTH_PASS" ]] && CURL_FLAGS="$CURL_FLAGS -u ${AUTH_USER}:${AUTH_PASS}"
-CURL="curl ${CURL_FLAGS}"
-
-# ---------- pretty-print helper -----------------------------------------------
-pp() {
-  if command -v python3 &>/dev/null; then
-    python3 -m json.tool 2>/dev/null || cat
-  else
-    cat
-  fi
-}
-
-# ---------- section header helper ---------------------------------------------
-section() { printf "\n\033[1;34m=== %s ===\033[0m\n" "$*"; }
-ok()      { printf "\033[1;32m  ✓ %s\033[0m\n" "$*"; }
-info()    { printf "  %s\n" "$*"; }
-
-# =============================================================================
-section "0 · Cluster health check"
-# =============================================================================
-
-health=$($CURL "${BASE_URL}/_cluster/health")
-status=$(echo "$health" | grep -o '"status":"[^"]*"' | head -1 | cut -d'"' -f4)
-version=$($CURL "${BASE_URL}" | grep -o '"number" *: *"[^"]*"' | head -1 | grep -o '[0-9][^"]*' || true)
-info "OpenSearch version : ${version:-unknown}"
-info "Cluster status     : ${status:-unknown}"
-
-plugins=$($CURL "${BASE_URL}/_cat/plugins?h=component" 2>/dev/null || true)
-if echo "$plugins" | grep -qi "jvector" 2>/dev/null; then
-  ok "jVector plugin detected"
-else
-  printf "\033[1;31m  ✗ jVector plugin not found — install it before running this demo\033[0m\n"
-  printf "  See DEVELOPER_GUIDE.md for installation instructions.\n"
-  exit 1
-fi
-
-if [[ "${status:-}" == "red" ]]; then
-  echo "Cluster is RED — aborting." >&2; exit 1
-fi
-
-# =============================================================================
-section "1 · Delete previous demo index (if any)"
-# =============================================================================
-
-$CURL -X DELETE "${BASE_URL}/${INDEX}" >/dev/null 2>&1 || true
-ok "Old index removed (or did not exist)"
-
-# =============================================================================
-section "2 · Create index"
-# =============================================================================
-#
-# This demo stores 8-dimensional embeddings for a small movie catalogue.
-# The 8 dimensions loosely represent:
-#   [action, drama, comedy, sci-fi, romance, thriller, horror, animation]
-#
-# We use cosinesimil so the ranking is based on angle, not magnitude.
-# =============================================================================
-
-$CURL -X PUT "${BASE_URL}/${INDEX}" \
-  -H "Content-Type: application/json" -d '
+# 1. Create an index with knn_vector mapping
+curl -X PUT "localhost:9200/jvector-index?pretty" -H 'Content-Type: application/json' -d'
 {
   "settings": {
-    "index.knn": true,
-    "number_of_shards": 1,
-    "number_of_replicas": 0
+    "index": {
+      "knn": true
+    }
   },
   "mappings": {
     "properties": {
-      "title":    { "type": "text"    },
-      "genre":    { "type": "keyword" },
-      "year":     { "type": "integer" },
-      "embedding": {
+      "my_vector": {
         "type": "knn_vector",
-        "dimension": 8,
         "method": {
-          "name":       "disk_ann",
-          "engine":     "jvector",
-          "space_type": "cosinesimil",
-          "parameters": {
-            "m":               16,
-            "ef_construction": 100
-          }
-        }
+          "name": "disk_ann",
+          "space_type": "l2",
+          "engine": "jvector",
+          "parameters": {}
+        },
+        "dimension": 4
       }
     }
   }
-}' | pp
-ok "Index '${INDEX}' created"
+}'
 
-# =============================================================================
-section "3 · Bulk-index 10 movie documents"
-# =============================================================================
+# Alternatively you can create the index with advanced construction parameters
+curl -X PUT "localhost:9200/jvector-index?pretty" -H 'Content-Type: application/json' -d'
+{
+  "settings": {
+    "index": {
+      "knn": true
+    }
+  },
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "method": {
+          "name": "disk_ann",
+          "space_type": "l2",
+          "engine": "jvector",
+          "parameters": {
+            "m": 16,
+            "ef_construction": 100
+          }
+        },
+        "dimension": 4
+      }
+    }
+  }
+}'
 
-$CURL -X POST "${BASE_URL}/_bulk" \
-  -H "Content-Type: application/json" -d '
-{ "index": { "_index": "jvector-demo", "_id": "1" } }
-{ "title": "The Dark Knight",          "genre": "action",    "year": 2008, "embedding": [0.9, 0.6, 0.1, 0.2, 0.0, 0.7, 0.1, 0.0] }
-{ "index": { "_index": "jvector-demo", "_id": "2" } }
-{ "title": "Inception",                "genre": "scifi",     "year": 2010, "embedding": [0.7, 0.5, 0.1, 0.9, 0.2, 0.6, 0.0, 0.0] }
-{ "index": { "_index": "jvector-demo", "_id": "3" } }
-{ "title": "The Shawshank Redemption", "genre": "drama",     "year": 1994, "embedding": [0.1, 0.9, 0.3, 0.0, 0.4, 0.2, 0.0, 0.0] }
-{ "index": { "_index": "jvector-demo", "_id": "4" } }
-{ "title": "Toy Story",                "genre": "animation", "year": 1995, "embedding": [0.2, 0.4, 0.8, 0.1, 0.3, 0.0, 0.0, 0.9] }
-{ "index": { "_index": "jvector-demo", "_id": "5" } }
-{ "title": "Interstellar",             "genre": "scifi",     "year": 2014, "embedding": [0.5, 0.6, 0.0, 0.9, 0.1, 0.4, 0.0, 0.0] }
-{ "index": { "_index": "jvector-demo", "_id": "6" } }
-{ "title": "The Notebook",             "genre": "romance",   "year": 2004, "embedding": [0.0, 0.7, 0.4, 0.0, 0.9, 0.1, 0.0, 0.0] }
-{ "index": { "_index": "jvector-demo", "_id": "7" } }
-{ "title": "Get Out",                  "genre": "horror",    "year": 2017, "embedding": [0.3, 0.5, 0.0, 0.2, 0.0, 0.8, 0.9, 0.0] }
-{ "index": { "_index": "jvector-demo", "_id": "8" } }
-{ "title": "Mad Max: Fury Road",       "genre": "action",    "year": 2015, "embedding": [0.9, 0.3, 0.0, 0.3, 0.0, 0.5, 0.2, 0.0] }
-{ "index": { "_index": "jvector-demo", "_id": "9" } }
-{ "title": "Finding Nemo",             "genre": "animation", "year": 2003, "embedding": [0.1, 0.5, 0.7, 0.0, 0.5, 0.0, 0.0, 0.9] }
-{ "index": { "_index": "jvector-demo", "_id": "10" } }
-{ "title": "A Beautiful Mind",         "genre": "drama",     "year": 2001, "embedding": [0.1, 0.8, 0.2, 0.3, 0.3, 0.3, 0.0, 0.0] }
-' | pp
+# 2. Index 5 documents document with a vector
+curl -X PUT "localhost:9200/jvector-index/_doc/1?pretty" -H 'Content-Type: application/json' -d'
+{
+  "my_vector": [1.0, 2.0, 3.0, 4.0]
+}'
+curl -X PUT "localhost:9200/jvector-index/_doc/2?pretty" -H 'Content-Type: application/json' -d'
+{
+  "my_vector": [5.0, 6.0, 7.0, 8.0]
+}'
+curl -X PUT "localhost:9200/jvector-index/_doc/3?pretty" -H 'Content-Type: application/json' -d'
+{
+  "my_vector": [9.0, 10.0, 11.0, 12.0]
+}'
+curl -X PUT "localhost:9200/jvector-index/_doc/4?pretty" -H 'Content-Type: application/json' -d'
+{
+  "my_vector": [13.0, 14.0, 15.0, 16.0]
+}'
 
-$CURL -X POST "${BASE_URL}/${INDEX}/_refresh" >/dev/null
-ok "10 documents indexed and refreshed"
-
-# =============================================================================
-section "4 · Basic KNN search"
-# =============================================================================
-#
-# Query embedding is biased toward sci-fi + action.
-# Expected top-3: Inception, Interstellar, The Dark Knight.
-# =============================================================================
-
-info "Query vector → sci-fi/action bias: [0.8, 0.4, 0.0, 0.9, 0.0, 0.3, 0.0, 0.0]"
-
-$CURL -X POST "${BASE_URL}/${INDEX}/_search" \
-  -H "Content-Type: application/json" -d '
+# 3. Search for the nearest neighbor of a vector
+curl -X GET "localhost:9200/jvector-index/_search?pretty" -H 'Content-Type: application/json' -d'
 {
   "size": 3,
-  "_source": ["title", "genre", "year"],
   "query": {
     "knn": {
-      "embedding": {
-        "vector": [0.8, 0.4, 0.0, 0.9, 0.0, 0.3, 0.0, 0.0],
+      "my_vector": {
+        "vector": [1.0, 2.0, 3.0, 4.0],
         "k": 3
       }
     }
   }
-}' | pp
-ok "Basic KNN search done"
+}'
 
-# =============================================================================
-section "5 · Filtered KNN search (action genre only)"
-# =============================================================================
 
-info "Same query vector, restricted to genre=action"
-
-$CURL -X POST "${BASE_URL}/${INDEX}/_search" \
-  -H "Content-Type: application/json" -d '
+# 4. Search with advanced parameters such as overquery_factor, threshold, rerank_floor
+curl -X GET "localhost:9200/jvector-index/_search?pretty" -H 'Content-Type: application/json' -d'
 {
   "size": 3,
-  "_source": ["title", "genre", "year"],
   "query": {
     "knn": {
-      "embedding": {
-        "vector": [0.8, 0.4, 0.0, 0.9, 0.0, 0.3, 0.0, 0.0],
-        "k": 3,
-        "filter": {
-          "term": { "genre": "action" }
-        }
-      }
-    }
-  }
-}' | pp
-ok "Filtered search done"
-
-# =============================================================================
-section "6 · KNN search with tuning parameters"
-# =============================================================================
-#
-# overquery_factor=10 means jVector fetches 10× the requested k as internal
-# candidates before re-ranking, trading latency for recall.
-# =============================================================================
-
-info "Animation-biased query with overquery_factor=10 and rerank_floor=0.1"
-
-$CURL -X POST "${BASE_URL}/${INDEX}/_search" \
-  -H "Content-Type: application/json" -d '
-{
-  "size": 3,
-  "_source": ["title", "genre", "year"],
-  "query": {
-    "knn": {
-      "embedding": {
-        "vector": [0.1, 0.3, 0.7, 0.0, 0.4, 0.0, 0.0, 0.9],
+      "my_vector": {
+        "vector": [1.0, 2.0, 3.0, 4.0],
         "k": 3,
         "method_parameters": {
           "overquery_factor": 10,
-          "advanced.rerank_floor": 0.1
+          "advanced.threshold": 0.0,
+          "advanced.rerank_floor": 0.0
         }
       }
     }
   }
-}' | pp
-ok "Tuned search done"
+}'
 
-# =============================================================================
-section "7 · Force merge"
-# =============================================================================
-#
-# Consolidates segments and triggers jVector's incremental graph merge.
-# On a small index the effect is minimal; on millions of docs this is
-# the step that unlocks full DiskANN performance.
-# =============================================================================
-
-info "Running _forcemerge?max_num_segments=1 …"
-$CURL -X POST "${BASE_URL}/${INDEX}/_forcemerge?max_num_segments=1&wait_for_completion=true" | pp
-$CURL -X POST "${BASE_URL}/${INDEX}/_refresh" >/dev/null
-ok "Force merge complete"
-
-# =============================================================================
-section "8 · Repeat sci-fi/action search after merge"
-# =============================================================================
-
-info "Same query as step 4 — results should be consistent after merge"
-
-$CURL -X POST "${BASE_URL}/${INDEX}/_search" \
-  -H "Content-Type: application/json" -d '
-{
-  "size": 3,
-  "_source": ["title", "genre", "year"],
-  "query": {
-    "knn": {
-      "embedding": {
-        "vector": [0.8, 0.4, 0.0, 0.9, 0.0, 0.3, 0.0, 0.0],
-        "k": 3
-      }
-    }
-  }
-}' | pp
-ok "Post-merge search done"
-
-# =============================================================================
-section "9 · jVector KNN node stats"
-# =============================================================================
-#
-# knn_query_visited_nodes       — total graph nodes visited across all searches
-# knn_query_expanded_nodes      — nodes whose edges were explored
-# knn_query_expanded_base_layer_nodes — base-layer expansions
-# =============================================================================
-
-$CURL "${BASE_URL}/_plugins/_knn/stats?stat=knn_query_visited_nodes,knn_query_expanded_nodes,knn_query_expanded_base_layer_nodes,knn_graph_merge_time,knn_quantization_training_time" | pp
-ok "Stats fetched"
-
-# =============================================================================
-section "10 · Cleanup"
-# =============================================================================
-
-if [[ "$SKIP_CLEANUP" == "true" ]]; then
-  info "Index '${INDEX}' left in place (-x flag set)"
-  info "Explore it: curl '${BASE_URL}/${INDEX}/_search?pretty'"
-else
-  $CURL -X DELETE "${BASE_URL}/${INDEX}" | pp
-  ok "Demo index deleted"
-fi
-
-printf "\n\033[1;32mDemo complete!\033[0m\n\n"
-printf "Next steps:\n"
-printf "  • Full parameter reference : docs/user_guide.md\n"
-printf "  • MMR / diverse search     : docs/mmr_search.md\n"
-printf "  • Large-scale benchmarking : scripts/jvector_index_and_search/\n\n"
+# 5. Get JVector stats after query
+curl -X GET "localhost:9200/_plugins/_knn/stats?pretty&stat=knn_query_visited_nodes,knn_query_expanded_nodes,knn_query_expanded_base_layer_nodes" -H 'Content-Type: application/json'

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -1,107 +1,315 @@
-############## Demo script for jVector k-NN ##############
+#!/usr/bin/env bash
+# =============================================================================
+# OpenSearch jVector Plugin — Demo Script
+#
+# Walks through the core jVector workflow:
+#   1. Create an index with a knn_vector mapping
+#   2. Bulk-index documents that have vector + metadata fields
+#   3. Basic KNN search
+#   4. Filtered KNN search (combine vector similarity with a term filter)
+#   5. KNN search with tuning parameters (overquery_factor, rerank_floor, …)
+#   6. Force merge  ← triggers jVector's incremental graph merge
+#   7. KNN search after merge  ← verify results are consistent
+#   8. jVector node stats
+#
+# Usage:
+#   ./scripts/demo.sh [OPTIONS]
+#
+# Options:
+#   -h HOST   OpenSearch host:port   (default: localhost:9200)
+#   -u USER   Basic-auth username    (optional)
+#   -p PASS   Basic-auth password    (optional)
+#   -s        Use HTTPS              (default: HTTP)
+#   -x        Keep the demo index after the run (default: delete it)
+# =============================================================================
 
-# 1. Create an index with knn_vector mapping
-curl -X PUT "localhost:9200/jvector-index?pretty" -H 'Content-Type: application/json' -d'
+set -euo pipefail
+
+# ---------- defaults ----------------------------------------------------------
+HOST="localhost:9200"
+SCHEME="http"
+AUTH_USER=""
+AUTH_PASS=""
+SKIP_CLEANUP=false
+INDEX="jvector-demo"
+
+# ---------- argument parsing --------------------------------------------------
+while getopts "h:u:p:sx" opt; do
+  case $opt in
+    h) HOST="$OPTARG"      ;;
+    u) AUTH_USER="$OPTARG" ;;
+    p) AUTH_PASS="$OPTARG" ;;
+    s) SCHEME="https"      ;;
+    x) SKIP_CLEANUP=true   ;;
+    *) echo "Unknown option -$OPTARG" >&2; exit 1 ;;
+  esac
+done
+
+BASE_URL="${SCHEME}://${HOST}"
+CURL_FLAGS="-sk"
+[[ -n "$AUTH_USER" && -n "$AUTH_PASS" ]] && CURL_FLAGS="$CURL_FLAGS -u ${AUTH_USER}:${AUTH_PASS}"
+CURL="curl ${CURL_FLAGS}"
+
+# ---------- pretty-print helper -----------------------------------------------
+pp() {
+  if command -v python3 &>/dev/null; then
+    python3 -m json.tool 2>/dev/null || cat
+  else
+    cat
+  fi
+}
+
+# ---------- section header helper ---------------------------------------------
+section() { printf "\n\033[1;34m=== %s ===\033[0m\n" "$*"; }
+ok()      { printf "\033[1;32m  ✓ %s\033[0m\n" "$*"; }
+info()    { printf "  %s\n" "$*"; }
+
+# =============================================================================
+section "0 · Cluster health check"
+# =============================================================================
+
+health=$($CURL "${BASE_URL}/_cluster/health")
+status=$(echo "$health" | grep -o '"status":"[^"]*"' | head -1 | cut -d'"' -f4)
+version=$($CURL "${BASE_URL}" | grep -o '"number" *: *"[^"]*"' | head -1 | grep -o '[0-9][^"]*' || true)
+info "OpenSearch version : ${version:-unknown}"
+info "Cluster status     : ${status:-unknown}"
+
+plugins=$($CURL "${BASE_URL}/_cat/plugins?h=component" 2>/dev/null || true)
+if echo "$plugins" | grep -qi "jvector" 2>/dev/null; then
+  ok "jVector plugin detected"
+else
+  printf "\033[1;31m  ✗ jVector plugin not found — install it before running this demo\033[0m\n"
+  printf "  See DEVELOPER_GUIDE.md for installation instructions.\n"
+  exit 1
+fi
+
+if [[ "${status:-}" == "red" ]]; then
+  echo "Cluster is RED — aborting." >&2; exit 1
+fi
+
+# =============================================================================
+section "1 · Delete previous demo index (if any)"
+# =============================================================================
+
+$CURL -X DELETE "${BASE_URL}/${INDEX}" >/dev/null 2>&1 || true
+ok "Old index removed (or did not exist)"
+
+# =============================================================================
+section "2 · Create index"
+# =============================================================================
+#
+# This demo stores 8-dimensional embeddings for a small movie catalogue.
+# The 8 dimensions loosely represent:
+#   [action, drama, comedy, sci-fi, romance, thriller, horror, animation]
+#
+# We use cosinesimil so the ranking is based on angle, not magnitude.
+# =============================================================================
+
+$CURL -X PUT "${BASE_URL}/${INDEX}" \
+  -H "Content-Type: application/json" -d '
 {
   "settings": {
-    "index": {
-      "knn": true
-    }
+    "index.knn": true,
+    "number_of_shards": 1,
+    "number_of_replicas": 0
   },
   "mappings": {
     "properties": {
-      "my_vector": {
+      "title":    { "type": "text"    },
+      "genre":    { "type": "keyword" },
+      "year":     { "type": "integer" },
+      "embedding": {
         "type": "knn_vector",
+        "dimension": 8,
         "method": {
-          "name": "disk_ann",
-          "space_type": "l2",
-          "engine": "jvector",
-          "parameters": {}
-        },
-        "dimension": 4
-      }
-    }
-  }
-}'
-
-# Alternatively you can create the index with advanced construction parameters
-curl -X PUT "localhost:9200/jvector-index?pretty" -H 'Content-Type: application/json' -d'
-{
-  "settings": {
-    "index": {
-      "knn": true
-    }
-  },
-  "mappings": {
-    "properties": {
-      "my_vector": {
-        "type": "knn_vector",
-        "method": {
-          "name": "disk_ann",
-          "space_type": "l2",
-          "engine": "jvector",
+          "name":       "disk_ann",
+          "engine":     "jvector",
+          "space_type": "cosinesimil",
           "parameters": {
-            "m": 16,
+            "m":               16,
             "ef_construction": 100
           }
-        },
-        "dimension": 4
-      }
-    }
-  }
-}'
-
-# 2. Index 5 documents document with a vector
-curl -X PUT "localhost:9200/jvector-index/_doc/1?pretty" -H 'Content-Type: application/json' -d'
-{
-  "my_vector": [1.0, 2.0, 3.0, 4.0]
-}'
-curl -X PUT "localhost:9200/jvector-index/_doc/2?pretty" -H 'Content-Type: application/json' -d'
-{
-  "my_vector": [5.0, 6.0, 7.0, 8.0]
-}'
-curl -X PUT "localhost:9200/jvector-index/_doc/3?pretty" -H 'Content-Type: application/json' -d'
-{
-  "my_vector": [9.0, 10.0, 11.0, 12.0]
-}'
-curl -X PUT "localhost:9200/jvector-index/_doc/4?pretty" -H 'Content-Type: application/json' -d'
-{
-  "my_vector": [13.0, 14.0, 15.0, 16.0]
-}'
-
-# 3. Search for the nearest neighbor of a vector
-curl -X GET "localhost:9200/jvector-index/_search?pretty" -H 'Content-Type: application/json' -d'
-{
-  "size": 3,
-  "query": {
-    "knn": {
-      "my_vector": {
-        "vector": [1.0, 2.0, 3.0, 4.0],
-        "k": 3
-      }
-    }
-  }
-}'
-
-
-# 4. Search with advanced parameters such as overquery_factor, threshold, rerank_floor
-curl -X GET "localhost:9200/jvector-index/_search?pretty" -H 'Content-Type: application/json' -d'
-{
-  "size": 3,
-  "query": {
-    "knn": {
-      "my_vector": {
-        "vector": [1.0, 2.0, 3.0, 4.0],
-        "k": 3,
-        "method_parameters": {
-          "overquery_factor": 10,
-          "advanced.threshold": 0.0,
-          "advanced.rerank_floor": 0.0
         }
       }
     }
   }
-}'
+}' | pp
+ok "Index '${INDEX}' created"
 
-# 5. Get JVector stats after query
-curl -X GET "localhost:9200/_plugins/_knn/stats?pretty&stat=knn_query_visited_nodes,knn_query_expanded_nodes,knn_query_expanded_base_layer_nodes" -H 'Content-Type: application/json'
+# =============================================================================
+section "3 · Bulk-index 10 movie documents"
+# =============================================================================
+
+$CURL -X POST "${BASE_URL}/_bulk" \
+  -H "Content-Type: application/json" -d '
+{ "index": { "_index": "jvector-demo", "_id": "1" } }
+{ "title": "The Dark Knight",          "genre": "action",    "year": 2008, "embedding": [0.9, 0.6, 0.1, 0.2, 0.0, 0.7, 0.1, 0.0] }
+{ "index": { "_index": "jvector-demo", "_id": "2" } }
+{ "title": "Inception",                "genre": "scifi",     "year": 2010, "embedding": [0.7, 0.5, 0.1, 0.9, 0.2, 0.6, 0.0, 0.0] }
+{ "index": { "_index": "jvector-demo", "_id": "3" } }
+{ "title": "The Shawshank Redemption", "genre": "drama",     "year": 1994, "embedding": [0.1, 0.9, 0.3, 0.0, 0.4, 0.2, 0.0, 0.0] }
+{ "index": { "_index": "jvector-demo", "_id": "4" } }
+{ "title": "Toy Story",                "genre": "animation", "year": 1995, "embedding": [0.2, 0.4, 0.8, 0.1, 0.3, 0.0, 0.0, 0.9] }
+{ "index": { "_index": "jvector-demo", "_id": "5" } }
+{ "title": "Interstellar",             "genre": "scifi",     "year": 2014, "embedding": [0.5, 0.6, 0.0, 0.9, 0.1, 0.4, 0.0, 0.0] }
+{ "index": { "_index": "jvector-demo", "_id": "6" } }
+{ "title": "The Notebook",             "genre": "romance",   "year": 2004, "embedding": [0.0, 0.7, 0.4, 0.0, 0.9, 0.1, 0.0, 0.0] }
+{ "index": { "_index": "jvector-demo", "_id": "7" } }
+{ "title": "Get Out",                  "genre": "horror",    "year": 2017, "embedding": [0.3, 0.5, 0.0, 0.2, 0.0, 0.8, 0.9, 0.0] }
+{ "index": { "_index": "jvector-demo", "_id": "8" } }
+{ "title": "Mad Max: Fury Road",       "genre": "action",    "year": 2015, "embedding": [0.9, 0.3, 0.0, 0.3, 0.0, 0.5, 0.2, 0.0] }
+{ "index": { "_index": "jvector-demo", "_id": "9" } }
+{ "title": "Finding Nemo",             "genre": "animation", "year": 2003, "embedding": [0.1, 0.5, 0.7, 0.0, 0.5, 0.0, 0.0, 0.9] }
+{ "index": { "_index": "jvector-demo", "_id": "10" } }
+{ "title": "A Beautiful Mind",         "genre": "drama",     "year": 2001, "embedding": [0.1, 0.8, 0.2, 0.3, 0.3, 0.3, 0.0, 0.0] }
+' | pp
+
+$CURL -X POST "${BASE_URL}/${INDEX}/_refresh" >/dev/null
+ok "10 documents indexed and refreshed"
+
+# =============================================================================
+section "4 · Basic KNN search"
+# =============================================================================
+#
+# Query embedding is biased toward sci-fi + action.
+# Expected top-3: Inception, Interstellar, The Dark Knight.
+# =============================================================================
+
+info "Query vector → sci-fi/action bias: [0.8, 0.4, 0.0, 0.9, 0.0, 0.3, 0.0, 0.0]"
+
+$CURL -X POST "${BASE_URL}/${INDEX}/_search" \
+  -H "Content-Type: application/json" -d '
+{
+  "size": 3,
+  "_source": ["title", "genre", "year"],
+  "query": {
+    "knn": {
+      "embedding": {
+        "vector": [0.8, 0.4, 0.0, 0.9, 0.0, 0.3, 0.0, 0.0],
+        "k": 3
+      }
+    }
+  }
+}' | pp
+ok "Basic KNN search done"
+
+# =============================================================================
+section "5 · Filtered KNN search (action genre only)"
+# =============================================================================
+
+info "Same query vector, restricted to genre=action"
+
+$CURL -X POST "${BASE_URL}/${INDEX}/_search" \
+  -H "Content-Type: application/json" -d '
+{
+  "size": 3,
+  "_source": ["title", "genre", "year"],
+  "query": {
+    "knn": {
+      "embedding": {
+        "vector": [0.8, 0.4, 0.0, 0.9, 0.0, 0.3, 0.0, 0.0],
+        "k": 3,
+        "filter": {
+          "term": { "genre": "action" }
+        }
+      }
+    }
+  }
+}' | pp
+ok "Filtered search done"
+
+# =============================================================================
+section "6 · KNN search with tuning parameters"
+# =============================================================================
+#
+# overquery_factor=10 means jVector fetches 10× the requested k as internal
+# candidates before re-ranking, trading latency for recall.
+# =============================================================================
+
+info "Animation-biased query with overquery_factor=10 and rerank_floor=0.1"
+
+$CURL -X POST "${BASE_URL}/${INDEX}/_search" \
+  -H "Content-Type: application/json" -d '
+{
+  "size": 3,
+  "_source": ["title", "genre", "year"],
+  "query": {
+    "knn": {
+      "embedding": {
+        "vector": [0.1, 0.3, 0.7, 0.0, 0.4, 0.0, 0.0, 0.9],
+        "k": 3,
+        "method_parameters": {
+          "overquery_factor": 10,
+          "advanced.rerank_floor": 0.1
+        }
+      }
+    }
+  }
+}' | pp
+ok "Tuned search done"
+
+# =============================================================================
+section "7 · Force merge"
+# =============================================================================
+#
+# Consolidates segments and triggers jVector's incremental graph merge.
+# On a small index the effect is minimal; on millions of docs this is
+# the step that unlocks full DiskANN performance.
+# =============================================================================
+
+info "Running _forcemerge?max_num_segments=1 …"
+$CURL -X POST "${BASE_URL}/${INDEX}/_forcemerge?max_num_segments=1&wait_for_completion=true" | pp
+$CURL -X POST "${BASE_URL}/${INDEX}/_refresh" >/dev/null
+ok "Force merge complete"
+
+# =============================================================================
+section "8 · Repeat sci-fi/action search after merge"
+# =============================================================================
+
+info "Same query as step 4 — results should be consistent after merge"
+
+$CURL -X POST "${BASE_URL}/${INDEX}/_search" \
+  -H "Content-Type: application/json" -d '
+{
+  "size": 3,
+  "_source": ["title", "genre", "year"],
+  "query": {
+    "knn": {
+      "embedding": {
+        "vector": [0.8, 0.4, 0.0, 0.9, 0.0, 0.3, 0.0, 0.0],
+        "k": 3
+      }
+    }
+  }
+}' | pp
+ok "Post-merge search done"
+
+# =============================================================================
+section "9 · jVector KNN node stats"
+# =============================================================================
+#
+# knn_query_visited_nodes       — total graph nodes visited across all searches
+# knn_query_expanded_nodes      — nodes whose edges were explored
+# knn_query_expanded_base_layer_nodes — base-layer expansions
+# =============================================================================
+
+$CURL "${BASE_URL}/_plugins/_knn/stats?stat=knn_query_visited_nodes,knn_query_expanded_nodes,knn_query_expanded_base_layer_nodes,knn_graph_merge_time,knn_quantization_training_time" | pp
+ok "Stats fetched"
+
+# =============================================================================
+section "10 · Cleanup"
+# =============================================================================
+
+if [[ "$SKIP_CLEANUP" == "true" ]]; then
+  info "Index '${INDEX}' left in place (-x flag set)"
+  info "Explore it: curl '${BASE_URL}/${INDEX}/_search?pretty'"
+else
+  $CURL -X DELETE "${BASE_URL}/${INDEX}" | pp
+  ok "Demo index deleted"
+fi
+
+printf "\n\033[1;32mDemo complete!\033[0m\n\n"
+printf "Next steps:\n"
+printf "  • Full parameter reference : docs/user_guide.md\n"
+printf "  • MMR / diverse search     : docs/mmr_search.md\n"
+printf "  • Large-scale benchmarking : scripts/jvector_index_and_search/\n\n"

--- a/scripts/demo_full.sh
+++ b/scripts/demo_full.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+# =============================================================================
+# OpenSearch jVector Plugin — Demo Script
+#
+# Walks through the core jVector workflow:
+#   1. Create an index with a knn_vector mapping
+#   2. Bulk-index documents that have vector + metadata fields
+#   3. Basic KNN search
+#   4. Filtered KNN search (combine vector similarity with a term filter)
+#   5. KNN search with tuning parameters (overquery_factor, rerank_floor, …)
+#   6. Force merge  ← triggers jVector's incremental graph merge
+#   7. KNN search after merge  ← verify results are consistent
+#   8. jVector node stats
+#
+# Usage:
+#   ./scripts/demo.sh [OPTIONS]
+#
+# Options:
+#   -h HOST   OpenSearch host:port   (default: localhost:9200)
+#   -u USER   Basic-auth username    (optional)
+#   -p PASS   Basic-auth password    (optional)
+#   -s        Use HTTPS              (default: HTTP)
+#   -x        Keep the demo index after the run (default: delete it)
+# =============================================================================
+
+set -euo pipefail
+
+# ---------- defaults ----------------------------------------------------------
+HOST="localhost:9200"
+SCHEME="http"
+AUTH_USER=""
+AUTH_PASS=""
+SKIP_CLEANUP=false
+INDEX="jvector-demo"
+
+# ---------- argument parsing --------------------------------------------------
+while getopts "h:u:p:sx" opt; do
+  case $opt in
+    h) HOST="$OPTARG"      ;;
+    u) AUTH_USER="$OPTARG" ;;
+    p) AUTH_PASS="$OPTARG" ;;
+    s) SCHEME="https"      ;;
+    x) SKIP_CLEANUP=true   ;;
+    *) echo "Unknown option -$OPTARG" >&2; exit 1 ;;
+  esac
+done
+
+BASE_URL="${SCHEME}://${HOST}"
+CURL_FLAGS="-sk"
+[[ -n "$AUTH_USER" && -n "$AUTH_PASS" ]] && CURL_FLAGS="$CURL_FLAGS -u ${AUTH_USER}:${AUTH_PASS}"
+CURL="curl ${CURL_FLAGS}"
+
+# ---------- pretty-print helper -----------------------------------------------
+pp() {
+  if command -v python3 &>/dev/null; then
+    python3 -m json.tool 2>/dev/null || cat
+  else
+    cat
+  fi
+}
+
+# ---------- section header helper ---------------------------------------------
+section() { printf "\n\033[1;34m=== %s ===\033[0m\n" "$*"; }
+ok()      { printf "\033[1;32m  ✓ %s\033[0m\n" "$*"; }
+info()    { printf "  %s\n" "$*"; }
+
+# =============================================================================
+section "0 · Cluster health check"
+# =============================================================================
+
+health=$($CURL "${BASE_URL}/_cluster/health")
+status=$(echo "$health" | grep -o '"status":"[^"]*"' | head -1 | cut -d'"' -f4)
+version=$($CURL "${BASE_URL}" | grep -o '"number" *: *"[^"]*"' | head -1 | grep -o '[0-9][^"]*' || true)
+info "OpenSearch version : ${version:-unknown}"
+info "Cluster status     : ${status:-unknown}"
+
+plugins=$($CURL "${BASE_URL}/_cat/plugins?h=component" 2>/dev/null || true)
+if echo "$plugins" | grep -qi "jvector" 2>/dev/null; then
+  ok "jVector plugin detected"
+else
+  printf "\033[1;31m  ✗ jVector plugin not found — install it before running this demo\033[0m\n"
+  printf "  See DEVELOPER_GUIDE.md for installation instructions.\n"
+  exit 1
+fi
+
+if [[ "${status:-}" == "red" ]]; then
+  echo "Cluster is RED — aborting." >&2; exit 1
+fi
+
+# =============================================================================
+section "1 · Delete previous demo index (if any)"
+# =============================================================================
+
+$CURL -X DELETE "${BASE_URL}/${INDEX}" >/dev/null 2>&1 || true
+ok "Old index removed (or did not exist)"
+
+# =============================================================================
+section "2 · Create index"
+# =============================================================================
+#
+# This demo stores 8-dimensional embeddings for a small movie catalogue.
+# The 8 dimensions loosely represent:
+#   [action, drama, comedy, sci-fi, romance, thriller, horror, animation]
+#
+# We use cosinesimil so the ranking is based on angle, not magnitude.
+# =============================================================================
+
+$CURL -X PUT "${BASE_URL}/${INDEX}" \
+  -H "Content-Type: application/json" -d '
+{
+  "settings": {
+    "index.knn": true,
+    "number_of_shards": 1,
+    "number_of_replicas": 0
+  },
+  "mappings": {
+    "properties": {
+      "title":    { "type": "text"    },
+      "genre":    { "type": "keyword" },
+      "year":     { "type": "integer" },
+      "embedding": {
+        "type": "knn_vector",
+        "dimension": 8,
+        "method": {
+          "name":       "disk_ann",
+          "engine":     "jvector",
+          "space_type": "cosinesimil",
+          "parameters": {
+            "m":               16,
+            "ef_construction": 100
+          }
+        }
+      }
+    }
+  }
+}' | pp
+ok "Index '${INDEX}' created"
+
+# =============================================================================
+section "3 · Bulk-index 10 movie documents"
+# =============================================================================
+
+$CURL -X POST "${BASE_URL}/_bulk" \
+  -H "Content-Type: application/json" -d '
+{ "index": { "_index": "jvector-demo", "_id": "1" } }
+{ "title": "The Dark Knight",          "genre": "action",    "year": 2008, "embedding": [0.9, 0.6, 0.1, 0.2, 0.0, 0.7, 0.1, 0.0] }
+{ "index": { "_index": "jvector-demo", "_id": "2" } }
+{ "title": "Inception",                "genre": "scifi",     "year": 2010, "embedding": [0.7, 0.5, 0.1, 0.9, 0.2, 0.6, 0.0, 0.0] }
+{ "index": { "_index": "jvector-demo", "_id": "3" } }
+{ "title": "The Shawshank Redemption", "genre": "drama",     "year": 1994, "embedding": [0.1, 0.9, 0.3, 0.0, 0.4, 0.2, 0.0, 0.0] }
+{ "index": { "_index": "jvector-demo", "_id": "4" } }
+{ "title": "Toy Story",                "genre": "animation", "year": 1995, "embedding": [0.2, 0.4, 0.8, 0.1, 0.3, 0.0, 0.0, 0.9] }
+{ "index": { "_index": "jvector-demo", "_id": "5" } }
+{ "title": "Interstellar",             "genre": "scifi",     "year": 2014, "embedding": [0.5, 0.6, 0.0, 0.9, 0.1, 0.4, 0.0, 0.0] }
+{ "index": { "_index": "jvector-demo", "_id": "6" } }
+{ "title": "The Notebook",             "genre": "romance",   "year": 2004, "embedding": [0.0, 0.7, 0.4, 0.0, 0.9, 0.1, 0.0, 0.0] }
+{ "index": { "_index": "jvector-demo", "_id": "7" } }
+{ "title": "Get Out",                  "genre": "horror",    "year": 2017, "embedding": [0.3, 0.5, 0.0, 0.2, 0.0, 0.8, 0.9, 0.0] }
+{ "index": { "_index": "jvector-demo", "_id": "8" } }
+{ "title": "Mad Max: Fury Road",       "genre": "action",    "year": 2015, "embedding": [0.9, 0.3, 0.0, 0.3, 0.0, 0.5, 0.2, 0.0] }
+{ "index": { "_index": "jvector-demo", "_id": "9" } }
+{ "title": "Finding Nemo",             "genre": "animation", "year": 2003, "embedding": [0.1, 0.5, 0.7, 0.0, 0.5, 0.0, 0.0, 0.9] }
+{ "index": { "_index": "jvector-demo", "_id": "10" } }
+{ "title": "A Beautiful Mind",         "genre": "drama",     "year": 2001, "embedding": [0.1, 0.8, 0.2, 0.3, 0.3, 0.3, 0.0, 0.0] }
+' | pp
+
+$CURL -X POST "${BASE_URL}/${INDEX}/_refresh" >/dev/null
+ok "10 documents indexed and refreshed"
+
+# =============================================================================
+section "4 · Basic KNN search"
+# =============================================================================
+#
+# Query embedding is biased toward sci-fi + action.
+# Expected top-3: Inception, Interstellar, The Dark Knight.
+# =============================================================================
+
+info "Query vector → sci-fi/action bias: [0.8, 0.4, 0.0, 0.9, 0.0, 0.3, 0.0, 0.0]"
+
+$CURL -X POST "${BASE_URL}/${INDEX}/_search" \
+  -H "Content-Type: application/json" -d '
+{
+  "size": 3,
+  "_source": ["title", "genre", "year"],
+  "query": {
+    "knn": {
+      "embedding": {
+        "vector": [0.8, 0.4, 0.0, 0.9, 0.0, 0.3, 0.0, 0.0],
+        "k": 3
+      }
+    }
+  }
+}' | pp
+ok "Basic KNN search done"
+
+# =============================================================================
+section "5 · Filtered KNN search (action genre only)"
+# =============================================================================
+
+info "Same query vector, restricted to genre=action"
+
+$CURL -X POST "${BASE_URL}/${INDEX}/_search" \
+  -H "Content-Type: application/json" -d '
+{
+  "size": 3,
+  "_source": ["title", "genre", "year"],
+  "query": {
+    "knn": {
+      "embedding": {
+        "vector": [0.8, 0.4, 0.0, 0.9, 0.0, 0.3, 0.0, 0.0],
+        "k": 3,
+        "filter": {
+          "term": { "genre": "action" }
+        }
+      }
+    }
+  }
+}' | pp
+ok "Filtered search done"
+
+# =============================================================================
+section "6 · KNN search with tuning parameters"
+# =============================================================================
+#
+# overquery_factor=10 means jVector fetches 10× the requested k as internal
+# candidates before re-ranking, trading latency for recall.
+# =============================================================================
+
+info "Animation-biased query with overquery_factor=10 and rerank_floor=0.1"
+
+$CURL -X POST "${BASE_URL}/${INDEX}/_search" \
+  -H "Content-Type: application/json" -d '
+{
+  "size": 3,
+  "_source": ["title", "genre", "year"],
+  "query": {
+    "knn": {
+      "embedding": {
+        "vector": [0.1, 0.3, 0.7, 0.0, 0.4, 0.0, 0.0, 0.9],
+        "k": 3,
+        "method_parameters": {
+          "overquery_factor": 10,
+          "advanced.rerank_floor": 0.1
+        }
+      }
+    }
+  }
+}' | pp
+ok "Tuned search done"
+
+# =============================================================================
+section "7 · Force merge"
+# =============================================================================
+#
+# Consolidates segments and triggers jVector's incremental graph merge.
+# On a small index the effect is minimal; on millions of docs this is
+# the step that unlocks full DiskANN performance.
+# =============================================================================
+
+info "Running _forcemerge?max_num_segments=1 …"
+$CURL -X POST "${BASE_URL}/${INDEX}/_forcemerge?max_num_segments=1&wait_for_completion=true" | pp
+$CURL -X POST "${BASE_URL}/${INDEX}/_refresh" >/dev/null
+ok "Force merge complete"
+
+# =============================================================================
+section "8 · Repeat sci-fi/action search after merge"
+# =============================================================================
+
+info "Same query as step 4 — results should be consistent after merge"
+
+$CURL -X POST "${BASE_URL}/${INDEX}/_search" \
+  -H "Content-Type: application/json" -d '
+{
+  "size": 3,
+  "_source": ["title", "genre", "year"],
+  "query": {
+    "knn": {
+      "embedding": {
+        "vector": [0.8, 0.4, 0.0, 0.9, 0.0, 0.3, 0.0, 0.0],
+        "k": 3
+      }
+    }
+  }
+}' | pp
+ok "Post-merge search done"
+
+# =============================================================================
+section "9 · jVector KNN node stats"
+# =============================================================================
+#
+# knn_query_visited_nodes       — total graph nodes visited across all searches
+# knn_query_expanded_nodes      — nodes whose edges were explored
+# knn_query_expanded_base_layer_nodes — base-layer expansions
+# =============================================================================
+
+$CURL "${BASE_URL}/_plugins/_knn/stats?stat=knn_query_visited_nodes,knn_query_expanded_nodes,knn_query_expanded_base_layer_nodes,knn_graph_merge_time,knn_quantization_training_time" | pp
+ok "Stats fetched"
+
+# =============================================================================
+section "10 · Cleanup"
+# =============================================================================
+
+if [[ "$SKIP_CLEANUP" == "true" ]]; then
+  info "Index '${INDEX}' left in place (-x flag set)"
+  info "Explore it: curl '${BASE_URL}/${INDEX}/_search?pretty'"
+else
+  $CURL -X DELETE "${BASE_URL}/${INDEX}" | pp
+  ok "Demo index deleted"
+fi
+
+printf "\n\033[1;32mDemo complete!\033[0m\n\n"
+printf "Next steps:\n"
+printf "  • Full parameter reference : docs/user_guide.md\n"
+printf "  • MMR / diverse search     : docs/mmr_search.md\n"
+printf "  • Large-scale benchmarking : scripts/jvector_index_and_search/\n\n"


### PR DESCRIPTION
### Description
This PR adds user-facing documentation and a runnable demo script to help users get started with the OpenSearch jVector plugin. Previously, the docs/ folder only contained advanced internal feature docs (MMR search), with no guidance on basic usage such as creating an index, indexing documents, or running a search.

#### Changes
docs/user_guide.md (new file) — A complete reference guide covering:
- Index creation (minimal, full config, and quantized/on-disk variants)
- Bulk indexing documents with vector fields
- KNN search, filtered KNN search, and query-time tuning parameters (overquery_factor, rerank_floor, threshold)
- Force merge behaviour and jVector's incremental merge model
- All supported space types (l2, cosinesimil, innerproduct, l1, linf)
- Advanced topics: Product Quantization, DiskANN mode, link to MMR docs
- Full mapping parameters and index settings reference tables
- Running the Demo section — step-by-step instructions for starting a local cluster and executing the demo script

scripts/demo.sh (rewritten) — Replaced the flat list of uncommented curl snippets with a proper executable script that:

- Accepts CLI flags (-h, -u, -p, -s, -x) for flexible cluster targeting
- Hard-fails with a clear error if the jVector plugin is not installed (previously only printed a warning and continued)
- Walks through 9 steps: create index → bulk index → basic KNN search → filtered search → tuned search → force merge → post-merge search → node stats → cleanup
- Pretty-prints all JSON responses
- Verified end-to-end against a live OpenSearch 3.6.0-SNAPSHOT cluster

#### Test plan

-  Run ./scripts/demo.sh against a local cluster started with ./gradlew run — all 10 steps should complete with green checkmarks
-  Run ./scripts/demo.sh without the jVector plugin installed — script should exit at step 0 with a red error message
-  Run ./scripts/demo.sh -x and confirm the jvector-demo index is retained after the run
-  Run ./scripts/demo.sh -h <remote> -u admin -p <pass> -s against a secured HTTPS cluster
-  Review docs/user_guide.md for accuracy against current mapping/query parameter source code

### Related Issues
Resolves #193 
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
