### PR TITLE
Fix flaky org.opensearch.knn.index.engine.InternalKNNEngineTests.testQuantizationWithOverQueryParameter (second attempt)

### DIFF
--- a/src/test/java/org/opensearch/knn/index/engine/InternalKNNEngineTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/InternalKNNEngineTests.java
@@ -645,7 +645,9 @@ public class InternalKNNEngineTests extends OpenSearchIntegTestCase {
                 + ") to be significantly better than low overquery recall ("
                 + recallLowOverquery
                 + ")",
-            recallHighOverquery > recallLowOverquery + 0.05
+            // At rare conditions, the recallLowOverquery covers the same docs / vectors as recallHighOverquery,
+            // so both metrics are equal to 1.0f
+            recallHighOverquery >= Math.min(1.0f, recallLowOverquery + 0.05)
         );
     }
 


### PR DESCRIPTION
### Description
Fix flaky org.opensearch.knn.index.engine.InternalKNNEngineTests.test.JVectorSearchStatsIncrement (second attempt). At rare conditions, the recallLowOverquery covers the same docs / vectors as recallHighOverquery, so both metrics are equal to `1.0f`.

Most recent failure:
 - https://github.com/opensearch-project/opensearch-jvector/actions/runs/24320357436/job/71005293664

### Related Issues
Follow up on https://github.com/opensearch-project/opensearch-jvector/pull/359

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
