### PR TITLE
Migrate NormalizeVectorTransformer, OriginalMappingParameters and VectorTransformerFactory tests

### DIFF
--- a/src/test/java/org/opensearch/knn/index/mapper/NormalizeVectorTransformerTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/NormalizeVectorTransformerTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.knn.index.mapper;
+
+import org.opensearch.knn.KNNTestCase;
+
+public class NormalizeVectorTransformerTests extends KNNTestCase {
+    private final NormalizeVectorTransformer transformer = new NormalizeVectorTransformer();
+    private static final float DELTA = 0.001f; // Delta for floating point comparisons
+
+    public void testNormalizeTransformer_withNullVector_thenThrowsException() {
+        assertThrows(IllegalArgumentException.class, () -> transformer.transform((float[]) null));
+    }
+
+    public void testNormalizeTransformer_withEmptyVector_thenThrowsException() {
+        assertThrows(IllegalArgumentException.class, () -> transformer.transform(new float[0]));
+    }
+
+    public void testNormalizeTransformer_withByteVector_thenThrowsException() {
+        assertThrows(UnsupportedOperationException.class, () -> transformer.transform(new byte[0]));
+    }
+
+    public void testNormalizeTransformer_withValidVector_thenSuccess() {
+        float[] input = { -3.0f, 4.0f };
+        transformer.transform(input);
+        assertEquals(-0.6f, input[0], DELTA);
+        assertEquals(0.8f, input[1], DELTA);
+        // Verify the magnitude is 1
+        assertEquals(1.0f, calculateMagnitude(input), DELTA);
+    }
+
+    private float calculateMagnitude(float[] vector) {
+        float magnitude = 0.0f;
+        for (float value : vector) {
+            magnitude += value * value;
+        }
+        return (float) Math.sqrt(magnitude);
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/mapper/OriginalMappingParametersTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/OriginalMappingParametersTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.mapper;
+
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.engine.KNNMethodContext;
+import org.opensearch.knn.index.engine.MethodComponentContext;
+
+import java.util.Collections;
+
+public class OriginalMappingParametersTests extends KNNTestCase {
+
+    public void testIsLegacy() {
+        assertTrue(
+            new OriginalMappingParameters(VectorDataType.DEFAULT, 123, null, null, null, SpaceType.UNDEFINED.getValue()).isLegacyMapping()
+        );
+
+        assertFalse(
+            new OriginalMappingParameters(VectorDataType.DEFAULT, 123, null, Mode.ON_DISK.getName(), null, SpaceType.UNDEFINED.getValue())
+                .isLegacyMapping()
+        );
+        assertFalse(
+            new OriginalMappingParameters(
+                VectorDataType.DEFAULT,
+                123,
+                null,
+                null,
+                CompressionLevel.x2.getName(),
+                SpaceType.UNDEFINED.getValue()
+            ).isLegacyMapping()
+        );
+        assertFalse(
+            new OriginalMappingParameters(
+                VectorDataType.DEFAULT,
+                123,
+                new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.L2, new MethodComponentContext(null, Collections.emptyMap())),
+                null,
+                null,
+                SpaceType.UNDEFINED.getValue()
+            ).isLegacyMapping()
+        );
+    }
+
+}

--- a/src/test/java/org/opensearch/knn/index/mapper/VectorTransformerFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/VectorTransformerFactoryTests.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.knn.index.mapper;
+
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.engine.KNNEngine;
+
+public class VectorTransformerFactoryTests extends KNNTestCase {
+    public void testAllSpaceTypes_withLucene() {
+        for (SpaceType spaceType : SpaceType.values()) {
+            VectorTransformer transformer = VectorTransformerFactory.getVectorTransformer(KNNEngine.LUCENE, spaceType);
+            validateTransformer(spaceType, KNNEngine.LUCENE, transformer);
+        }
+    }
+
+    public void testAllSpaceTypes_withJVector() {
+        for (SpaceType spaceType : SpaceType.values()) {
+            VectorTransformer transformer = VectorTransformerFactory.getVectorTransformer(KNNEngine.JVECTOR, spaceType);
+            validateTransformer(spaceType, KNNEngine.JVECTOR, transformer);
+        }
+    }
+
+    private static void validateTransformer(SpaceType spaceType, KNNEngine engine, VectorTransformer transformer) {
+        assertSame(
+            "Should return NOOP transformer for " + engine + " with " + spaceType,
+            VectorTransformerFactory.NOOP_VECTOR_TRANSFORMER,
+            transformer
+        );
+    }
+}


### PR DESCRIPTION
### Description

Migrated selected tests from https://github.com/opensearch-project/k-NN/tree/main/src/test/java/org/opensearch/knn/index/mapper
Selected a version for matching version of code + made required adjustments.
I noted down PRs that were delivered after migration of code, so we can consider migrating them as well if they are valid for jvector case.

1. NormalizeVectorTransformerTests: migrated version for matching state of code from before PR: https://github.com/opensearch-project/k-NN/pull/2974
migrated: https://github.com/opensearch-project/k-NN/blob/5388ea3171664929c78536775d5dda337efef9ab/src/test/java/org/opensearch/knn/index/mapper/NormalizeVectorTransformerTests.java

2. OriginalMappingParametersTests: migrated version for matching state of code from before PR: https://github.com/opensearch-project/k-NN/pull/2736
Migrated from: https://github.com/opensearch-project/k-NN/blob/49ff9a8e63588679949ae6f2a6fd5e62fd81f123/src/test/java/org/opensearch/knn/index/mapper/OriginalMappingParametersTests.java
Removed modelId parameter from tests as it's not existing in jvector version.

3. VectorTransformerFactoryTests: migrated version for matching state of code from before PR: https://github.com/opensearch-project/k-NN/pull/3245
Migrated from: https://github.com/opensearch-project/k-NN/blob/8033b83ba93f94f230946ff69ddb5062f54eaed0/src/test/java/org/opensearch/knn/index/mapper/VectorTransformerFactoryTests.java
- added testAllSpaceTypes for supported engines: LUCENE and JVECTOR
- removed testAllEngines_withCosine as it makes no sense
- validateTransformer now expects always NOOP transformer.

### Related Issues
Part of https://github.com/opensearch-project/opensearch-jvector/issues/393

<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
