### PR TITLE
fixes to remove ref counting in DerivedSourceReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * The KNN1030Codec does not properly support delegation for non-default codec(s). [310] (https://github.com/opensearch-project/opensearch-jvector/pull/310)
 * Remove usage of the commons-lang 2.6 [317] (https://github.com/opensearch-project/opensearch-jvector/pull/317)
 * Fixing guava dependency scope, since the dependency is provided by transport-grpc plugin [344] (https://github.com/opensearch-project/opensearch-jvector/pull/344)
+* Remove manual ref counting and simplify DeriveSourceReaders [397] (https://github.com/opensearch-project/opensearch-jvector/pull/397)
 ### Infrastructure
 * Upgrade Lucene to 10.4.0 [292] (https://github.com/opensearch-project/opensearch-jvector/pull/292)
 * Upgrade jvector from 4.0.0-rc.6 to 4.0.0-rc.8 [370](https://github.com/opensearch-project/opensearch-jvector/pull/370)

--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsReader.java
@@ -99,7 +99,7 @@ public class KNN10010DerivedSourceStoredFieldsReader extends StoredFieldsReader 
             return new KNN10010DerivedSourceStoredFieldsReader(
                 delegate.clone(),
                 derivedVectorFields,
-                derivedSourceReaders.cloneWithMerge(),
+                derivedSourceReaders.clone(),
                 segmentReadState,
                 shouldInject
             );
@@ -130,7 +130,7 @@ public class KNN10010DerivedSourceStoredFieldsReader extends StoredFieldsReader 
             return new KNN10010DerivedSourceStoredFieldsReader(
                 delegate.getMergeInstance(),
                 derivedVectorFields,
-                derivedSourceReaders.cloneWithMerge(),
+                derivedSourceReaders.clone(),
                 segmentReadState,
                 false
             );

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceReaders.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceReaders.java
@@ -6,7 +6,6 @@
 package org.opensearch.knn.index.codec.derivedsource;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.store.AlreadyClosedException;
@@ -15,61 +14,104 @@ import org.opensearch.common.Nullable;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Class holds the readers necessary to implement derived source. Important to note that if a segment does not have
- * any of these fields, the values will be null. Caller needs to check if these are null before using.
+ * Holds the Lucene readers required to reconstruct vector fields for derived source.
+ *
+ * <p>Derived source allows OpenSearch to reconstruct the original {@code _source} document from
+ * stored field data rather than persisting raw source bytes. This class bundles the two readers
+ * needed for that reconstruction:
+ * <ul>
+ *   <li>{@link KnnVectorsReader} - reads raw vector values from the segment.</li>
+ *   <li>{@link DocValuesProducer} - reads doc-values (e.g. quantized or nested vector data).
+ *   This is needed for backward compatibility for indices created before 2.17 </li>
+ * </ul>
+ *
+ * <p>Either reader may be {@code null} when the corresponding field type is absent in a segment;
+ * callers must null-check before use.
+ *
+ * <p><b>Lifecycle:</b> The owning instance (created via the public constructor) is responsible for
+ * closing both underlying readers. Cloned instances (via {@link #clone()}) and merge instances
+ * (via {@link #getMergeInstance()}) are non-owning: their {@link #close()} is a no-op, so only
+ * the original instance drives resource cleanup. Calling {@link #clone()} or
+ * {@link #getMergeInstance()} on a closed owning instance throws
+ * {@link org.apache.lucene.store.AlreadyClosedException}.
  */
-@RequiredArgsConstructor
 @Getter
-public final class DerivedSourceReaders implements Closeable {
+public final class DerivedSourceReaders implements Cloneable, Closeable {
     @Nullable
     private final KnnVectorsReader knnVectorsReader;
     @Nullable
     private final DocValuesProducer docValuesProducer;
-
-    // Copied from lucene (https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/index/SegmentCoreReaders.java):
-    // We need to reference count these readers because they may be shared amongst different instances.
-    // "Counts how many other readers share the core objects
-    // (freqStream, proxStream, tis, etc.) of this reader;
-    // when coreRef drops to 0, these core objects may be
-    // closed. A given instance of SegmentReader may be
-    // closed, even though it shares core objects with other
-    // SegmentReaders":
-    private final AtomicInteger ref = new AtomicInteger(1);
+    private final Closeable onClose;
+    private boolean closed;
 
     /**
-     * Returns this DerivedSourceReaders object with incremented reference count
+     * Creates an owning instance. Closing this instance will close both underlying readers.
      *
-     * @return DerivedSourceReaders object with incremented reference count
+     * @param knnVectorsReader  reader for raw vector values; may be {@code null}.
+     * @param docValuesProducer reader for doc-values; may be {@code null}.
      */
-    public DerivedSourceReaders cloneWithMerge() {
-        // For cloning, we don't need to reference count. In Lucene, the merging will actually not close any of the
-        // readers, so it should only be handled by the original code. See
-        // https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java#L3372
-        // for more details
-        return this;
+    public DerivedSourceReaders(KnnVectorsReader knnVectorsReader, DocValuesProducer docValuesProducer) {
+        this(knnVectorsReader, docValuesProducer, () -> IOUtils.close(knnVectorsReader, docValuesProducer));
     }
 
+    private DerivedSourceReaders(KnnVectorsReader knnVectorsReader, DocValuesProducer docValuesProducer, Closeable onClose) {
+        assert knnVectorsReader != null || docValuesProducer != null : "At least one reader must be non-null";
+        this.knnVectorsReader = knnVectorsReader;
+        this.docValuesProducer = docValuesProducer;
+        this.onClose = onClose;
+    }
+
+    /**
+     * Returns a non-owning view of this instance for use during Lucene segment merges.
+     * The returned instance's {@link #close()} is a no-op; the original instance retains
+     * ownership of the underlying readers. See
+     * <a href="https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java#L3372">IndexWriter</a>
+     * for context on why merging does not close readers.
+     *
+     * {@link #clone()} and {@link #getMergeInstance()} are kept separate to avoid any side effects between the two
+     * if the behavior ever changes
+     *
+     * @return a non-owning {@code DerivedSourceReaders} sharing the same underlying readers.
+     */
+    public DerivedSourceReaders getMergeInstance() {
+        ensureOpen();
+        return new DerivedSourceReaders(knnVectorsReader, docValuesProducer, () -> {});
+    }
+
+    /**
+     * Returns a non-owning shallow clone sharing the same underlying readers.
+     * The cloned instance's {@link #close()} is a no-op.
+     *
+     * {@link #clone()} and {@link #getMergeInstance()} are kept separate to avoid any side effects between the two
+     * if the behavior ever changes
+     *
+     * @return a non-owning {@code DerivedSourceReaders} sharing the same underlying readers.
+     */
+    @Override
+    public DerivedSourceReaders clone() {
+        ensureOpen();
+        return new DerivedSourceReaders(knnVectorsReader, docValuesProducer, () -> {});
+    }
+
+    /**
+     * Closes the underlying readers if this is an owning instance. No-op for cloned or merge instances.
+     */
     @Override
     public void close() throws IOException {
-        decRef();
-    }
-
-    private void incRef() {
-        int count;
-        while ((count = ref.get()) > 0) {
-            if (ref.compareAndSet(count, count + 1)) {
-                return;
-            }
+        if (!closed) {
+            onClose.close();
+            closed = true;
         }
-        throw new AlreadyClosedException("DerivedSourceReaders is already closed");
     }
 
-    private void decRef() throws IOException {
-        if (ref.decrementAndGet() == 0) {
-            IOUtils.close(knnVectorsReader, docValuesProducer);
+    /**
+     * Throws {@link AlreadyClosedException} if this instance has been closed.
+     */
+    private void ensureOpen() {
+        if (closed) {
+            throw new AlreadyClosedException("DerivedSourceReader is closed");
         }
     }
 }


### PR DESCRIPTION
### Description
Similar change as https://github.com/opensearch-project/k-NN/pull/3138 

Since reference counting is handled by Lucene SegmentReader, DerivedSourceReaders doesn't need to do its own. 

### Related Issues
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
