### PR TITLE
Fix memory leak in JVectorRandomAccessReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Remove usage of the commons-lang 2.6 [317] (https://github.com/opensearch-project/opensearch-jvector/pull/317)
 * Fixing guava dependency scope, since the dependency is provided by transport-grpc plugin [344] (https://github.com/opensearch-project/opensearch-jvector/pull/344)
 * Remove manual ref counting and simplify DeriveSourceReaders [397] (https://github.com/opensearch-project/opensearch-jvector/pull/397)
+* Fix Hash map memory leak in JVectorRandomAccessReader.java (https://github.com/opensearch-project/opensearch-jvector/pull/401)
 ### Infrastructure
 * Upgrade Lucene to 10.4.0 [292] (https://github.com/opensearch-project/opensearch-jvector/pull/292)
 * Upgrade jvector from 4.0.0-rc.6 to 4.0.0-rc.8 [370](https://github.com/opensearch-project/opensearch-jvector/pull/370)

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorRandomAccessReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorRandomAccessReader.java
@@ -15,8 +15,6 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
 @Log4j2
 public class JVectorRandomAccessReader implements RandomAccessReader {

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorRandomAccessReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorRandomAccessReader.java
@@ -128,12 +128,10 @@ public class JVectorRandomAccessReader implements RandomAccessReader {
      * The header offset, on the other hand, is flexible because we can provide it as a parameter to {@link io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex#load(ReaderSupplier, long)}
      */
     public static class Supplier implements ReaderSupplier {
-        private final AtomicInteger readerCount = new AtomicInteger(0);
         private final IndexInput currentInput;
         private final long sliceStartOffset;
         private final long sliceLength;
-        private final ConcurrentHashMap<Integer, RandomAccessReader> readers = new ConcurrentHashMap<>();
-
+ 
         public Supplier(IndexInput indexInput) throws IOException {
             this(indexInput, indexInput.getFilePointer(), indexInput.length() - indexInput.getFilePointer());
         }
@@ -149,26 +147,14 @@ public class JVectorRandomAccessReader implements RandomAccessReader {
             synchronized (this) {
                 final IndexInput input = currentInput.slice("Input Slice for the jVector graph or PQ", sliceStartOffset, sliceLength)
                     .clone();
-
-                var reader = new JVectorRandomAccessReader(input);
-                int readerId = readerCount.getAndIncrement();
-                readers.put(readerId, reader);
-                return reader;
+                return new JVectorRandomAccessReader(input);
             }
-
         }
 
         @Override
         public void close() throws IOException {
-            // Close source of all cloned inputs
+            // Readers are closed by their users via try-with-resources
             IOUtils.closeWhileHandlingException(currentInput);
-
-            // Close all readers
-            for (RandomAccessReader reader : readers.values()) {
-                IOUtils.closeWhileHandlingException(reader::close);
-            }
-            readers.clear();
-            readerCount.set(0);
         }
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorRandomAccessReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorRandomAccessReader.java
@@ -153,8 +153,8 @@ public class JVectorRandomAccessReader implements RandomAccessReader {
 
         @Override
         public void close() throws IOException {
-            // Readers are closed by their users via try-with-resources
             IOUtils.closeWhileHandlingException(currentInput);
+            // Readers are closed by their users via try-with-resources
         }
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorRandomAccessReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorRandomAccessReader.java
@@ -129,7 +129,7 @@ public class JVectorRandomAccessReader implements RandomAccessReader {
         private final IndexInput currentInput;
         private final long sliceStartOffset;
         private final long sliceLength;
- 
+
         public Supplier(IndexInput indexInput) throws IOException {
             this(indexInput, indexInput.getFilePointer(), indexInput.length() - indexInput.getFilePointer());
         }

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorRandomAccessReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorRandomAccessReader.java
@@ -19,7 +19,6 @@ import java.nio.FloatBuffer;
 @Log4j2
 public class JVectorRandomAccessReader implements RandomAccessReader {
     private final byte[] internalBuffer = new byte[Long.BYTES];
-    private final byte[] internalFloatBuffer = new byte[Float.BYTES];
     private final IndexInput indexInputDelegate;
     private volatile boolean closed = false;
 
@@ -107,6 +106,10 @@ public class JVectorRandomAccessReader implements RandomAccessReader {
 
     @Override
     public void close() throws IOException {
+        if (this.closed == true) {
+            log.debug("JVectorRandomAccessReader already closed for file: {}", indexInputDelegate);
+            return;
+        }
         log.debug("Closing JVectorRandomAccessReader for file: {}", indexInputDelegate);
         this.closed = true;
         // no need to really close the index input delegate since it is a clone
@@ -152,7 +155,6 @@ public class JVectorRandomAccessReader implements RandomAccessReader {
         @Override
         public void close() throws IOException {
             IOUtils.closeWhileHandlingException(currentInput);
-            // Readers are closed by their users via try-with-resources
         }
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -1011,163 +1011,172 @@ public class JVectorWriter extends KnnVectorsWriter {
 
             var leadingFieldsReader = (PerFieldKnnVectorsFormat.FieldsReader) readers[LEADING_READER_IDX];
             var leadingReader = (JVectorReader) leadingFieldsReader.getFieldReader(fieldInfo.name);
-            var graphReader = leadingReader.getNeighborsScoreCacheForField(fieldInfo.name);
+            try (var graphReader = leadingReader.getNeighborsScoreCacheForField(fieldInfo.name)) {
 
-            // A diversity provider is a required argument to OnHeapGraphIndex::load,
-            // however creating a VamanaDiversityProvider requires a buildScore provider
-            // which in turn requires knowledge of the ordinal -> vector mapping.
-            // Since the heap graph can contain ordinal "holes", this information
-            // is not available until AFTER the graph is loaded.
-            // Using a DelayedInitDiversityProvider avoids this chicken-and-egg problem.
-            // This is okay since the diversity provider is only used during mutations.
-            var diversityProvider = new DelayedInitDiversityProvider();
+                // A diversity provider is a required argument to OnHeapGraphIndex::load,
+                // however creating a VamanaDiversityProvider requires a buildScore provider
+                // which in turn requires knowledge of the ordinal -> vector mapping.
+                // Since the heap graph can contain ordinal "holes", this information
+                // is not available until AFTER the graph is loaded.
+                // Using a DelayedInitDiversityProvider avoids this chicken-and-egg problem.
+                // This is okay since the diversity provider is only used during mutations.
+                var diversityProvider = new DelayedInitDiversityProvider();
 
-            var numBaseVectors = leadingReader.getFloatVectorValues(fieldInfo.name).size();
+                var numBaseVectors = leadingReader.getFloatVectorValues(fieldInfo.name).size();
 
-            try (OnHeapGraphIndex leadingGraph = OnHeapGraphIndex.load(graphReader, this.dimension(), degreeOverflow, diversityProvider)) {
-                // Since we're performing leading segment merge, we need to load the OnHeapGraphIndex
-                // corresponding to the leading segment, then mutate it.
-                // Since ordinals of OnHeapGraphIndex cannot be compacted, holes in the ordinals
-                // will build up over time.
+                try (
+                    OnHeapGraphIndex leadingGraph = OnHeapGraphIndex.load(graphReader, this.dimension(), degreeOverflow, diversityProvider)
+                ) {
+                    // Since we're performing leading segment merge, we need to load the OnHeapGraphIndex
+                    // corresponding to the leading segment, then mutate it.
+                    // Since ordinals of OnHeapGraphIndex cannot be compacted, holes in the ordinals
+                    // will build up over time.
 
-                int leadingGraphIdUpperBound = leadingGraph.getIdUpperBound();
-                long heapOrdUpperBoundLong = leadingGraphIdUpperBound + (long) totalLiveVectorsInOtherReaders;
+                    int leadingGraphIdUpperBound = leadingGraph.getIdUpperBound();
+                    long heapOrdUpperBoundLong = leadingGraphIdUpperBound + (long) totalLiveVectorsInOtherReaders;
 
-                // even though Lucene should ensure that the sum of maxDoc across all segments
-                // is under IndexWriter.MAX_DOCS, our leading segment heap graph has holes
-                // that Lucene won't know about, which may push heapOrdUpperBound out of range.
-                // IndexWriter.MAX_DOCS = Integer.MAX_VALUE - 128
-                if (heapOrdUpperBoundLong > IndexWriter.MAX_DOCS) {
-                    log.warn(
-                        "New ordinal upper bound for neighbor score cache is too large. "
-                            + "This may indicate many deletes, or that you're approaching the maximum segment size. "
-                            + "Will skip leading segment merge."
-                    );
-                    return false; // indicate skipped
-                }
-
-                var heapGraphOrdinalDensity = totalLiveVectorsCount / (double) heapOrdUpperBoundLong;
-                if (heapGraphOrdinalDensity < MIN_HEAP_GRAPH_ORDINAL_DENSITY) {
-                    log.warn(
-                        "Heap ordinals will be insufficiently dense ({} < {}). "
-                            + "Will skip leading segment merge. (totalLiveVectors={}, heapOrdUpperBound={})",
-                        heapGraphOrdinalDensity,
-                        MIN_HEAP_GRAPH_ORDINAL_DENSITY,
-                        totalLiveVectorsCount,
-                        heapOrdUpperBoundLong
-                    );
-                    return false;
-                }
-
-                log.info("Starting leading segment merge for segment {} on field {}", segmentWriteState.segmentInfo.name, fieldInfo.name);
-
-                // we already checked that heapOrdUpperBoundLong <= IndexWriter.MAX_DOCS < Integer.MAX_VALUE
-                int heapOrdUpperBound = Math.toIntExact(heapOrdUpperBoundLong);
-
-                // While creating score providers and updating the graph, we need to supply a RAVV that
-                // takes account the accumulated holes in the OnHeapGraph, so we need some mappings
-                // to and from the ordinal space of the OnHeapGraphIndex (the heap ordinals)
-
-                // The "mid" ordinal space is the same as the "graphNodeId" ordinal space
-                // which includes all vectors from the leading segment and live vectors from other segments.
-                // We need this mapping to delete vectors later.
-                var midToHeapOrds = new int[graphNodeIdsToRavvOrds.length];
-                var heapToGlobalRavvOrds = new int[heapOrdUpperBound];
-                Arrays.fill(midToHeapOrds, -1);
-                Arrays.fill(heapToGlobalRavvOrds, -1);
-
-                // The "final" ord space is what happens to the ordinals on the heap graph
-                // on being written as an OnDiskGraphIndex.
-                // JVector automatically compacts the ordinals while preserving the order.
-                // Note that this may NOT be the same as the "compact" ordinal space calculated earler,
-                // (although it is also compact)
-                var finalOrdToDocId = new int[totalLiveVectorsCount];
-
-                int midOrd = 0;
-                int finalOrd = 0;
-                for (int heapOrd = 0; heapOrd < leadingGraphIdUpperBound; heapOrd++) {
-                    if (!leadingGraph.containsNode(heapOrd)) {
-                        continue;
+                    // even though Lucene should ensure that the sum of maxDoc across all segments
+                    // is under IndexWriter.MAX_DOCS, our leading segment heap graph has holes
+                    // that Lucene won't know about, which may push heapOrdUpperBound out of range.
+                    // IndexWriter.MAX_DOCS = Integer.MAX_VALUE - 128
+                    if (heapOrdUpperBoundLong > IndexWriter.MAX_DOCS) {
+                        log.warn(
+                            "New ordinal upper bound for neighbor score cache is too large. "
+                                + "This may indicate many deletes, or that you're approaching the maximum segment size. "
+                                + "Will skip leading segment merge."
+                        );
+                        return false; // indicate skipped
                     }
-                    midToHeapOrds[midOrd] = heapOrd;
-                    heapToGlobalRavvOrds[heapOrd] = graphNodeIdsToRavvOrds[midOrd];
-                    // the old ordinal space of the leading reader is not exactly the "mid" ordinal space
-                    // but by definition they match for the leading reader, so `.get(midOrd)` is valid
-                    if (liveGraphNodesPerReader[LEADING_READER_IDX].get(midOrd)) {
+
+                    var heapGraphOrdinalDensity = totalLiveVectorsCount / (double) heapOrdUpperBoundLong;
+                    if (heapGraphOrdinalDensity < MIN_HEAP_GRAPH_ORDINAL_DENSITY) {
+                        log.warn(
+                            "Heap ordinals will be insufficiently dense ({} < {}). "
+                                + "Will skip leading segment merge. (totalLiveVectors={}, heapOrdUpperBound={})",
+                            heapGraphOrdinalDensity,
+                            MIN_HEAP_GRAPH_ORDINAL_DENSITY,
+                            totalLiveVectorsCount,
+                            heapOrdUpperBoundLong
+                        );
+                        return false;
+                    }
+
+                    log.info(
+                        "Starting leading segment merge for segment {} on field {}",
+                        segmentWriteState.segmentInfo.name,
+                        fieldInfo.name
+                    );
+
+                    // we already checked that heapOrdUpperBoundLong <= IndexWriter.MAX_DOCS < Integer.MAX_VALUE
+                    int heapOrdUpperBound = Math.toIntExact(heapOrdUpperBoundLong);
+
+                    // While creating score providers and updating the graph, we need to supply a RAVV that
+                    // takes account the accumulated holes in the OnHeapGraph, so we need some mappings
+                    // to and from the ordinal space of the OnHeapGraphIndex (the heap ordinals)
+
+                    // The "mid" ordinal space is the same as the "graphNodeId" ordinal space
+                    // which includes all vectors from the leading segment and live vectors from other segments.
+                    // We need this mapping to delete vectors later.
+                    var midToHeapOrds = new int[graphNodeIdsToRavvOrds.length];
+                    var heapToGlobalRavvOrds = new int[heapOrdUpperBound];
+                    Arrays.fill(midToHeapOrds, -1);
+                    Arrays.fill(heapToGlobalRavvOrds, -1);
+
+                    // The "final" ord space is what happens to the ordinals on the heap graph
+                    // on being written as an OnDiskGraphIndex.
+                    // JVector automatically compacts the ordinals while preserving the order.
+                    // Note that this may NOT be the same as the "compact" ordinal space calculated earler,
+                    // (although it is also compact)
+                    var finalOrdToDocId = new int[totalLiveVectorsCount];
+
+                    int midOrd = 0;
+                    int finalOrd = 0;
+                    for (int heapOrd = 0; heapOrd < leadingGraphIdUpperBound; heapOrd++) {
+                        if (!leadingGraph.containsNode(heapOrd)) {
+                            continue;
+                        }
+                        midToHeapOrds[midOrd] = heapOrd;
+                        heapToGlobalRavvOrds[heapOrd] = graphNodeIdsToRavvOrds[midOrd];
+                        // the old ordinal space of the leading reader is not exactly the "mid" ordinal space
+                        // but by definition they match for the leading reader, so `.get(midOrd)` is valid
+                        if (liveGraphNodesPerReader[LEADING_READER_IDX].get(midOrd)) {
+                            finalOrdToDocId[finalOrd] = graphNodeIdToDocMap.getLuceneDocId(midOrd);
+                            finalOrd++;
+                        }
+                        midOrd++;
+                    }
+
+                    for (int heapOrd = leadingGraphIdUpperBound; heapOrd < heapOrdUpperBound; heapOrd++) {
+                        midToHeapOrds[midOrd] = heapOrd;
+                        heapToGlobalRavvOrds[heapOrd] = graphNodeIdsToRavvOrds[midOrd];
                         finalOrdToDocId[finalOrd] = graphNodeIdToDocMap.getLuceneDocId(midOrd);
                         finalOrd++;
+                        midOrd++;
                     }
-                    midOrd++;
-                }
 
-                for (int heapOrd = leadingGraphIdUpperBound; heapOrd < heapOrdUpperBound; heapOrd++) {
-                    midToHeapOrds[midOrd] = heapOrd;
-                    heapToGlobalRavvOrds[heapOrd] = graphNodeIdsToRavvOrds[midOrd];
-                    finalOrdToDocId[finalOrd] = graphNodeIdToDocMap.getLuceneDocId(midOrd);
-                    finalOrd++;
-                    midOrd++;
-                }
+                    if (midOrd != midToHeapOrds.length || finalOrd != finalOrdToDocId.length) {
+                        log.error(
+                            "Got midOrd_limit={} (wanted {}), finalOrd_limit={} (wanted {})",
+                            midOrd,
+                            midToHeapOrds.length,
+                            finalOrd,
+                            finalOrdToDocId.length
+                        );
+                        throw new IllegalStateException("failed to fill one of the maps, this is a bug");
+                    }
 
-                if (midOrd != midToHeapOrds.length || finalOrd != finalOrdToDocId.length) {
-                    log.error(
-                        "Got midOrd_limit={} (wanted {}), finalOrd_limit={} (wanted {})",
-                        midOrd,
-                        midToHeapOrds.length,
-                        finalOrd,
-                        finalOrdToDocId.length
-                    );
-                    throw new IllegalStateException("failed to fill one of the maps, this is a bug");
-                }
+                    var heapRavv = new RemappedRandomAccessVectorValues(this, heapToGlobalRavvOrds);
 
-                var heapRavv = new RemappedRandomAccessVectorValues(this, heapToGlobalRavvOrds);
+                    var leadingBsp = BuildScoreProvider.randomAccessScoreProvider(heapRavv, getVectorSimilarityFunction(fieldInfo));
 
-                var leadingBsp = BuildScoreProvider.randomAccessScoreProvider(heapRavv, getVectorSimilarityFunction(fieldInfo));
+                    // we left this uninitialized earlier, but we're ready to set it up now
+                    // just in time to mutate the graph
+                    diversityProvider.initialize(new VamanaDiversityProvider(leadingBsp, alpha));
 
-                // we left this uninitialized earlier, but we're ready to set it up now
-                // just in time to mutate the graph
-                diversityProvider.initialize(new VamanaDiversityProvider(leadingBsp, alpha));
+                    OnHeapGraphIndex graph;
+                    try (
+                        GraphIndexBuilder builder = new GraphIndexBuilder(
+                            leadingBsp,
+                            heapRavv.dimension(),
+                            leadingGraph,
+                            beamWidth,
+                            degreeOverflow,
+                            alpha,
+                            true,
+                            simdPoolMerge,
+                            parallelismPool
+                        )
+                    ) {
+                        var vv = heapRavv.threadLocalSupplier();
 
-                OnHeapGraphIndex graph;
-                try (
-                    GraphIndexBuilder builder = new GraphIndexBuilder(
-                        leadingBsp,
-                        heapRavv.dimension(),
-                        leadingGraph,
-                        beamWidth,
-                        degreeOverflow,
-                        alpha,
-                        true,
-                        simdPoolMerge,
-                        parallelismPool
-                    )
-                ) {
-                    var vv = heapRavv.threadLocalSupplier();
+                        // parallel graph construction from the merge documents Ids
+                        simdPoolMerge.submit(
+                            () -> IntStream.range(leadingGraph.getIdUpperBound(), heapRavv.size()).parallel().forEach(ord -> {
+                                assert heapToGlobalRavvOrds[ord] != GraphNodeIdToDocMap.NO_VECTOR_OR_DELETED_DOC
+                                    : "Should be a valid graph node / vector";
+                                builder.addGraphNode(ord, vv.get().getVector(ord));
+                            })
+                        ).join();
 
-                    // parallel graph construction from the merge documents Ids
-                    simdPoolMerge.submit(() -> IntStream.range(leadingGraph.getIdUpperBound(), heapRavv.size()).parallel().forEach(ord -> {
-                        assert heapToGlobalRavvOrds[ord] != GraphNodeIdToDocMap.NO_VECTOR_OR_DELETED_DOC
-                            : "Should be a valid graph node / vector";
-                        builder.addGraphNode(ord, vv.get().getVector(ord));
-                    })).join();
-
-                    // mark deleted nodes
-                    for (int i = 0; i < numBaseVectors; i++) {
-                        if (!liveGraphNodesPerReader[LEADING_READER_IDX].get(i)) {
-                            // we need to convert from the "mid" to the "heap" ordinal space to avoid errors
-                            builder.markNodeDeleted(midToHeapOrds[i]);
+                        // mark deleted nodes
+                        for (int i = 0; i < numBaseVectors; i++) {
+                            if (!liveGraphNodesPerReader[LEADING_READER_IDX].get(i)) {
+                                // we need to convert from the "mid" to the "heap" ordinal space to avoid errors
+                                builder.markNodeDeleted(midToHeapOrds[i]);
+                            }
                         }
+
+                        builder.cleanup();
+
+                        graph = (OnHeapGraphIndex) builder.getGraph();
                     }
 
-                    builder.cleanup();
-
-                    graph = (OnHeapGraphIndex) builder.getGraph();
+                    // Note that the ordinals for the OnDiskGraphIndex will automatically be compacted
+                    // But the OnHeapGraphIndex will not
+                    var finalOrdToDocMap = new GraphNodeIdToDocMap(finalOrdToDocId);
+                    writeField(fieldInfo, heapRavv, null, finalOrdToDocMap, graph);
+                    return true;
                 }
-
-                // Note that the ordinals for the OnDiskGraphIndex will automatically be compacted
-                // But the OnHeapGraphIndex will not
-                var finalOrdToDocMap = new GraphNodeIdToDocMap(finalOrdToDocId);
-                writeField(fieldInfo, heapRavv, null, finalOrdToDocMap, graph);
-                return true;
             }
         }
 

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
@@ -655,6 +655,41 @@ public class KNNJVectorTests extends LuceneTestCase {
                 Assert.assertEquals(1, reader.getContext().leaves().size());
                 Assert.assertEquals(totalNumberOfDocs, reader.numDocs());
 
+                for (LeafReaderContext context : reader.leaves()) {
+                    FloatVectorValues vectorValues = context.reader().getFloatVectorValues(TEST_FIELD);
+                    final var docIdSetIterator = vectorValues.iterator(); // iterator for all the vectors with values
+                    int docId = -1;
+                    while ((docId = docIdSetIterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+                        final int luceneDocId = context.docBase + docId;
+                        float[] vectorValue = vectorValues.vectorValue(docIdSetIterator.index());
+                        float[] expectedVectorValue = source[docId];
+
+                        // if the vectors do not match, also look which source vector should be the right result
+                        if (!Arrays.equals(expectedVectorValue, vectorValue)) {
+                            for (int i = 0; i < source.length; i++) {
+                                if (Arrays.equals(source[i], vectorValue)) {
+                                    log.error(
+                                        "found vector with global id: {}, in docId: {}, however the actual position of the vector in source is: {}",
+                                        docId,
+                                        luceneDocId,
+                                        i
+                                    );
+                                }
+                            }
+                        }
+                        Assert.assertArrayEquals(
+                            "vector with global id "
+                                + docId
+                                + " in source doesn't match vector value in lucene docID "
+                                + luceneDocId
+                                + " on the index",
+                            expectedVectorValue,
+                            vectorValue,
+                            0.0f
+                        );
+                    }
+                }
+
                 final Query filterQuery = new MatchAllDocsQuery();
                 final IndexSearcher searcher = newSearcher(reader);
                 KnnFloatVectorQuery knnFloatVectorQuery = getJVectorKnnFloatVectorQuery(TEST_FIELD, target, k, filterQuery);


### PR DESCRIPTION
### Description
Under continuous query load opensearch (with jvector plugin) runs out of memory and starts issuing circuit-breaker exceptions

### Related Issues
Resolves #[Unknown]
Additional info below

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

### Additional Information

When running continuous queries, eventually queries received circuit-breaker exceptions.  This was detected on various size java Xmx settings.  

Working with an AI, after a number of iterations, we were able to find the leak.  This was a combination of source scanning, simultaneous review of Eclipse MAT heap dumps and testing fix attempts.  In the end, this is what was found

```
# FOUND THE LEAK! 🎯

## The Root Cause

**Line 135 in JVectorRandomAccessReader.java:**
```java
private final ConcurrentHashMap<Integer, RandomAccessReader> readers = new ConcurrentHashMap<>();
```

**Line 154-156:**
```java
var reader = new JVectorRandomAccessReader(input);
int readerId = readerCount.getAndIncrement();
readers.put(readerId, reader);  // ← NEVER REMOVED!
```

## The Problem

Every time `Supplier.get()` is called, it:
1. Creates a new `JVectorRandomAccessReader`
2. Adds it to the `readers` ConcurrentHashMap
3. **NEVER removes it** (except on close)

## The Math

From MAT analysis:
- **27,621,137 ConcurrentHashMap$Node entries**
- **199 segments** = 199 FieldEntry instances
- Each FieldEntry has **2 Supplier instances** (one for graph, one for PQ vectors)
- **27,621,137 ÷ (199 × 2) = ~69,400 readers per Supplier**

This means **each Supplier has created ~69,400 readers** and they're all still in the HashMap!

##Why This Happens

Looking at your code flow:

1. **Query comes in** → calls `fieldEntry.getPQVectors()`
2. **getPQVectors()** → calls `pqCodebooksReaderSupplier.get()` 
3. **Supplier.get()** → creates reader, adds to HashMap (line 155)
4. **Reader is used** → loads PQ vectors
5. **Query completes** → reader goes out of scope
6. **BUT**: Reader is still in the HashMap! ← **LEAK**

With thousands of queries, you accumulate millions of readers in memory.


## Here is a plot of a test with and without the fix

<img width="1125" height="639" alt="image" src="https://github.com/user-attachments/assets/b5701c8d-e2b6-4cdf-9ead-16586bb69f1c" />

Blue lines are "main", Orange lines are "FIX"

The thicker lines are plots of gc.log.  Normally I would use "Pause Cleanup" for the GC statistics, because it is slightly higher in memory than "Pause Young".  However the FIXED run rarely invokes "Pause Cleanup", so I am using "Pause Young" for this plot.  The plot is the "ending memory usage" of the cleanup (the amount of pinned memory after the GC ran)

The lighter lines are query response times in seconds, mostly to show the query activity on the server.  Without the fix, on this system (24G Xmx) (blue lines) you can see that after running a continuous query load for around 1700 seconds, the server starts responding with "circuit-breaker" exceptions.  The red dot indicates when the first error is returned

With the fix applied, the memory (thick orange line) is essentially flat.  Although not shown on this graph, it continued to stay flat for the 10 hour duration of the continuous query run.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
