### PR TITLE
Block derived sources on nested documents

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorTransformer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorTransformer.java
@@ -7,6 +7,7 @@ package org.opensearch.knn.index.codec.derivedsource;
 
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.index.SegmentReadState;
+import org.opensearch.common.ValidationException;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentHelper;
@@ -19,12 +20,10 @@ import org.opensearch.common.regex.Regex;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Function;
-import java.util.HashSet;
-import java.util.Set;
+
+import static org.opensearch.knn.index.KNNSettings.KNN_DERIVED_SOURCE_ENABLED;
 
 @Log4j2
 public class DerivedSourceVectorTransformer {
@@ -148,10 +147,15 @@ public class DerivedSourceVectorTransformer {
         // Have to create a copy of the map here to ensure that is mutable
         Map<String, Object> sourceAsMap = mapTuple.v2();
 
-        // We only need the offset for the nested fields. If there arent any, we can skip
+        // We only need the offset for the nested fields. If there aren't any, we can skip
         int offset = 0;
         if (isNested) {
-            offset = derivedSourceLuceneHelper.getFirstChild(docId);
+            ValidationException validationException = new ValidationException();
+            validationException.addValidationError(String.format("Nested fields are not supported when [%s] is true.", KNN_DERIVED_SOURCE_ENABLED));
+            throw validationException;
+
+            // TODO: Uncomment this when derived source nested field is fixed.
+            // offset = derivedSourceLuceneHelper.getFirstChild(docId);
         }
 
         // For each vector field, add in the source. The per field injectors are responsible for skipping if

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorTransformer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorTransformer.java
@@ -151,7 +151,9 @@ public class DerivedSourceVectorTransformer {
         int offset = 0;
         if (isNested) {
             ValidationException validationException = new ValidationException();
-            validationException.addValidationError(String.format("Nested fields are not supported when [%s] is true.", KNN_DERIVED_SOURCE_ENABLED));
+            validationException.addValidationError(
+                String.format("Nested fields are not supported when [%s] is true.", KNN_DERIVED_SOURCE_ENABLED)
+            );
             throw validationException;
 
             // TODO: Uncomment this when derived source nested field is fixed.

--- a/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
+++ b/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.*;
 
 import static org.opensearch.knn.DerivedSourceUtils.*;
+import static org.opensearch.knn.index.KNNSettings.KNN_DERIVED_SOURCE_ENABLED;
 
 /**
  * Integration tests for derived source feature for vector fields. Currently, with derived source, there are
@@ -91,10 +92,16 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
     }
 
     @SneakyThrows
-    @Ignore
     public void testNestedField() {
-        List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts = getNestedIndexContexts("derivedit", true);
-        testDerivedSourceE2E(indexConfigContexts);
+        try {
+            List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts = getNestedIndexContexts("derivedit", true);
+            testDerivedSourceE2E(indexConfigContexts);
+        }
+        catch (Exception excp) {
+            // TODO: Remove this check when nested fields are supported with derived sources.
+            assertTrue(excp.getMessage().contains("validation_exception"));
+            assertTrue(excp.getMessage().contains(String.format("Nested fields are not supported when [%s] is true.", KNN_DERIVED_SOURCE_ENABLED)));
+        }
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
+++ b/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
@@ -7,7 +7,6 @@ package org.opensearch.knn.integ;
 
 import lombok.SneakyThrows;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.opensearch.client.ResponseException;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.settings.Settings;
@@ -96,11 +95,12 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
         try {
             List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts = getNestedIndexContexts("derivedit", true);
             testDerivedSourceE2E(indexConfigContexts);
-        }
-        catch (Exception excp) {
+        } catch (Exception excp) {
             // TODO: Remove this check when nested fields are supported with derived sources.
             assertTrue(excp.getMessage().contains("validation_exception"));
-            assertTrue(excp.getMessage().contains(String.format("Nested fields are not supported when [%s] is true.", KNN_DERIVED_SOURCE_ENABLED)));
+            assertTrue(
+                excp.getMessage().contains(String.format("Nested fields are not supported when [%s] is true.", KNN_DERIVED_SOURCE_ENABLED))
+            );
         }
     }
 


### PR DESCRIPTION
### Description
Block nested documents when derived sources is enabled. 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
