### PR TITLE
Fix NPE while storing the graph with no nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Remove usage of the commons-lang 2.6 [317] (https://github.com/opensearch-project/opensearch-jvector/pull/317)
 * Fixing guava dependency scope, since the dependency is provided by transport-grpc plugin [344] (https://github.com/opensearch-project/opensearch-jvector/pull/344)
 * Remove manual ref counting and simplify DeriveSourceReaders [397] (https://github.com/opensearch-project/opensearch-jvector/pull/397)
-* Fix Hash map memory leak in JVectorRandomAccessReader.java (https://github.com/opensearch-project/opensearch-jvector/pull/401)
+* Fix Hash map memory leak in JVectorRandomAccessReader [401] (https://github.com/opensearch-project/opensearch-jvector/pull/401)
+* Fix NullPointerException/IllegalStateException if merge ends up with no vectors for a field (empty graph) [417] (https://github.com/opensearch-project/opensearch-jvector/pull/417)
 ### Infrastructure
 * Upgrade Lucene to 10.4.0 [292] (https://github.com/opensearch-project/opensearch-jvector/pull/292)
 * Upgrade jvector from 4.0.0-rc.6 to 4.0.0-rc.8 [370](https://github.com/opensearch-project/opensearch-jvector/pull/370)

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -913,6 +913,13 @@ public class JVectorWriter extends KnnVectorsWriter {
             PerFieldKnnVectorsFormat.FieldsReader fieldsReader = (PerFieldKnnVectorsFormat.FieldsReader) readers[LEADING_READER_IDX];
             JVectorReader leadingReader = (JVectorReader) fieldsReader.getFieldReader(fieldName);
             final RemappedRandomAccessVectorValues compactRavv = new RemappedRandomAccessVectorValues(this, compactOrdsToRavvOrds);
+
+            // The merged segments ends up with no vectors (empty graph), nothing to merge there
+            if (compactRavv.size() == 0) {
+                log.info("No vectors for field {} in segment {}", fieldName, mergeState.segmentInfo.name);
+                return;
+            }
+
             // Check if the leading reader has pre-existing PQ codebooks and if so, refine them with the remaining vectors
             if (leadingReader.getProductQuantizationForField(fieldInfo.name).isEmpty()) {
                 // No pre-existing codebooks, check if we have enough vectors to trigger quantization

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/JVectorMergeWithDeletedDocsTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/JVectorMergeWithDeletedDocsTests.java
@@ -381,6 +381,70 @@ public class JVectorMergeWithDeletedDocsTests extends LuceneTestCase {
 
     /**
      * Comprehensive test combining merges with documents that
+     * have no vector fields populated, multiple segments with deletes
+     * which lead to merges with no vectors (empty graph).
+     */
+    @Test
+    public void testMergesWithNoVectors() throws IOException {
+        final int dimension = 64;
+        final int k = 10;
+
+        IndexWriterConfig config = newIndexWriterConfig();
+        config.setUseCompoundFile(false);
+        config.setCodec(getCodec(random().nextBoolean() ? 1 : 10)); /* 1 to check empty PQ vectors, 10 to check empty graph */
+        config.setMergePolicy(new ForceMergesOnlyMergePolicy());
+        config.setMergeScheduler(new SerialMergeScheduler());
+
+        final Path indexPath = createTempDir();
+
+        try (FSDirectory dir = FSDirectory.open(indexPath); IndexWriter writer = new IndexWriter(dir, config)) {
+            int docId = 0;
+
+            // Segment 1: 2 documents with one document having no vector field populated
+            log.info("Creating segment 1: 2 docs");
+            for (int i = 0; i < 2; i++) {
+                Document doc = new Document();
+                if (i == 0) {
+                    float[] vector = new float[dimension];
+                    Arrays.fill(vector, docId * random().nextFloat(1.0f));
+                    doc.add(new KnnFloatVectorField(TEST_FIELD, vector, VectorSimilarityFunction.EUCLIDEAN));
+                }
+                doc.add(new StringField(TEST_ID_FIELD, String.valueOf(docId), Field.Store.YES));
+                writer.addDocument(doc);
+                docId++;
+            }
+            writer.commit();
+
+            // Segment 2: delete one document with vectors
+            writer.deleteDocuments(new Term(TEST_ID_FIELD, String.valueOf(0)));
+            writer.commit();
+
+            // Merge ends up with segment with no vector fields (empty graph)
+            log.info("Performing intermediate merge after segment 2");
+            writer.forceMerge(1);
+        }
+
+        // Verify the merged index
+        try (FSDirectory dir = FSDirectory.open(indexPath); IndexReader reader = DirectoryReader.open(dir)) {
+            Assert.assertEquals("Should have 1 segment after merge", 1, reader.getContext().leaves().size());
+            Assert.assertEquals("Should have correct number of live docs", 1, reader.numDocs());
+
+            // Verify search works correctly
+            final IndexSearcher searcher = newSearcher(reader);
+            TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), k);
+            Assert.assertEquals("Should return k results", 1, topDocs.totalHits.value());
+
+            for (int i = 0; i < topDocs.scoreDocs.length; i++) {
+                Document doc = reader.storedFields().document(topDocs.scoreDocs[i].doc);
+                String id = doc.get(TEST_ID_FIELD);
+                log.info("Result {}: doc ID = {}", i, id);
+            }
+        }
+
+    }
+
+    /**
+     * Comprehensive test combining merges and deletes with documents that
      * have no vector fields populated.
      */
     @Test
@@ -396,7 +460,6 @@ public class JVectorMergeWithDeletedDocsTests extends LuceneTestCase {
         config.setMergeScheduler(new SerialMergeScheduler());
 
         final Path indexPath = createTempDir();
-
         try (FSDirectory dir = FSDirectory.open(indexPath); IndexWriter writer = new IndexWriter(dir, config)) {
             int docId = 0;
 


### PR DESCRIPTION
### Description
Fix NPE while storing the graph with no nodes / IllegalArgumentException while creating PQ vectors:

### Related Issues
```
 2> java.lang.NullPointerException: Cannot read field "node" because the return value of "io.github.jbellis.jvector.graph.ImmutableGraphIndex$View.entryNode()" is null
        at __randomizedtesting.SeedInfo.seed([C641FBB76B2AE9DB:A4F4B3D293E3126B]:0)
        at io.github.jbellis.jvector.graph.disk.AbstractGraphIndexWriter.writeHeader(AbstractGraphIndexWriter.java:159)
        at io.github.jbellis.jvector.graph.disk.OnDiskSequentialGraphIndexWriter.write(OnDiskSequentialGraphIndexWriter.java:104)
        at org.opensearch.knn.index.codec.jvector.JVectorWriter.writeGraph(JVectorWriter.java:356)
        at org.opensearch.knn.index.codec.jvector.JVectorWriter.writeField(JVectorWriter.java:277)
        at org.opensearch.knn.index.codec.jvector.JVectorWriter$RandomAccessMergedFloatVectorValues.merge(JVectorWriter.java:991)
        at org.opensearch.knn.index.codec.jvector.JVectorWriter.mergeOneField(JVectorWriter.java:198)
        at org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat$FieldsWriter.mergeOneField(PerFieldKnnVectorsFormat.java:126)
        at org.apache.lucene.codecs.KnnVectorsWriter.merge(KnnVectorsWriter.java:105)
        at org.apache.lucene.index.SegmentMerger.mergeVectorValues(SegmentMerger.java:271)
        at org.apache.lucene.index.SegmentMerger.mergeWithLogging(SegmentMerger.java:314)
        at org.apache.lucene.index.SegmentMerger.merge(SegmentMerger.java:158)
        at org.apache.lucene.index.IndexWriter.mergeMiddle(IndexWriter.java:5317)
        at org.apache.lucene.index.IndexWriter.merge(IndexWriter.java:4778)
        at org.apache.lucene.index.IndexWriter$IndexWriterMergeSource.merge(IndexWriter.java:6601)
        at org.apache.lucene.index.SerialMergeScheduler.merge(SerialMergeScheduler.java:38)
        at org.apache.lucene.index.IndexWriter.executeMerge(IndexWriter.java:2338)
        at org.apache.lucene.index.IndexWriter.maybeMerge(IndexWriter.java:2333)
        at org.apache.lucene.index.IndexWriter.forceMerge(IndexWriter.java:2174)
        at org.apache.lucene.index.IndexWriter.forceMerge(IndexWriter.java:2122)
        at org.opensearch.knn.index.codec.jvector.JVectorMergeWithDeletedDocsTests.testMergesWithOnlyNullVectors(JVectorMergeWithDeletedDocsTests.java:423)
```

```
java.lang.IllegalArgumentException: Invalid vector count 0
        at __randomizedtesting.SeedInfo.seed([8F969FAF1771281B:863FD80A95A674D1]:0)
        at io.github.jbellis.jvector.quantization.PQVectors$PQLayout.<init>(PQVectors.java:484)
        at io.github.jbellis.jvector.quantization.PQVectors.encodeAndBuild(PQVectors.java:122)
        at io.github.jbellis.jvector.quantization.PQVectors.encodeAndBuild(PQVectors.java:93)
        at org.opensearch.knn.index.codec.jvector.JVectorWriter$RandomAccessMergedFloatVectorValues.merge(JVectorWriter.java:971)
        at org.opensearch.knn.index.codec.jvector.JVectorWriter.mergeOneField(JVectorWriter.java:198)
        at org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat$FieldsWriter.mergeOneField(PerFieldKnnVectorsFormat.java:126)
        at org.apache.lucene.codecs.KnnVectorsWriter.merge(KnnVectorsWriter.java:105)
        at org.apache.lucene.index.SegmentMerger.mergeVectorValues(SegmentMerger.java:271)
        at org.apache.lucene.index.SegmentMerger.mergeWithLogging(SegmentMerger.java:314)
        at org.apache.lucene.index.SegmentMerger.merge(SegmentMerger.java:158)
        at org.apache.lucene.index.IndexWriter.mergeMiddle(IndexWriter.java:5323)
        at org.apache.lucene.index.IndexWriter.merge(IndexWriter.java:4784)
        at org.apache.lucene.index.IndexWriter$IndexWriterMergeSource.merge(IndexWriter.java:6607)
        at org.apache.lucene.index.SerialMergeScheduler.merge(SerialMergeScheduler.java:38)
        at org.apache.lucene.index.IndexWriter.executeMerge(IndexWriter.java:2344)
        at org.apache.lucene.index.IndexWriter.maybeMerge(IndexWriter.java:2339)
        at org.apache.lucene.index.IndexWriter.forceMerge(IndexWriter.java:2174)
        at org.apache.lucene.index.IndexWriter.forceMerge(IndexWriter.java:2122)
```

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
