### PR TITLE
MockMaker support, migrate tests for VectorValues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -201,6 +201,7 @@ allprojects {
 
 configurations {
     zipArchive
+    mockitoAgent
 }
 
 publishing {
@@ -308,6 +309,7 @@ task release(type: Copy, group: 'build') {
 //****************************************************************************/
 // Dependencies
 //****************************************************************************/
+
 dependencies {
     api "org.opensearch:opensearch:${opensearch_version}"
     compileOnly "org.opensearch.plugin:opensearch-scripting-painless-spi:${versions.opensearch}"
@@ -315,6 +317,7 @@ dependencies {
     compileOnly group: 'com.google.guava', name: 'guava', version: "${versions.guava}"
     api "org.apache.commons:commons-lang3:${versions.commonslang}"
     testFixturesImplementation "org.opensearch.test:framework:${opensearch_version}"
+    mockitoAgent("org.mockito:mockito-core:${versions.mockito}") { transitive = false }
     // Add the high-level client dependency
     testImplementation "org.opensearch.client:opensearch-rest-high-level-client:${opensearch_version}"
     // Add netty dependency so we can use it within internal test clusters (not just external ones)
@@ -361,7 +364,8 @@ test {
             '-Djdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK=0',
             '--enable-native-access=ALL-UNNAMED',
             '-Dio.netty.tryReflectionSetAccessible=true',
-            '--enable-preview'
+            '--enable-preview',
+            "-javaagent:${configurations.mockitoAgent.asPath}"
     ]
 
 

--- a/src/test/java/org/opensearch/knn/index/vectorvalues/KNNVectorValuesFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/vectorvalues/KNNVectorValuesFactoryTests.java
@@ -42,25 +42,25 @@ public class KNNVectorValuesFactoryTests extends KNNTestCase {
         docsWithFieldSet.add(1);
         final Map<Integer, float[]> floatVectorMap = Map.of(0, new float[] { 1, 2 }, 1, new float[] { 2, 3 });
         final KNNVectorValues<float[]> floatVectorValues = KNNVectorValuesFactory.getVectorValues(
-                VectorDataType.FLOAT,
-                docsWithFieldSet,
-                floatVectorMap
+            VectorDataType.FLOAT,
+            docsWithFieldSet,
+            floatVectorMap
         );
         Assert.assertNotNull(floatVectorValues);
 
         final Map<Integer, byte[]> byteVectorMap = Map.of(0, new byte[] { 4, 5 }, 1, new byte[] { 6, 7 });
 
         final KNNVectorValues<byte[]> byteVectorValues = KNNVectorValuesFactory.getVectorValues(
-                VectorDataType.BYTE,
-                docsWithFieldSet,
-                byteVectorMap
+            VectorDataType.BYTE,
+            docsWithFieldSet,
+            byteVectorMap
         );
         Assert.assertNotNull(byteVectorValues);
 
         final KNNVectorValues<byte[]> binaryVectorValues = KNNVectorValuesFactory.getVectorValues(
-                VectorDataType.BINARY,
-                docsWithFieldSet,
-                byteVectorMap
+            VectorDataType.BINARY,
+            docsWithFieldSet,
+            byteVectorMap
         );
         Assert.assertNotNull(binaryVectorValues);
     }
@@ -88,7 +88,7 @@ public class KNNVectorValuesFactoryTests extends KNNTestCase {
         Mockito.when(fieldInfo.getVectorEncoding()).thenReturn(VectorEncoding.FLOAT32);
         Mockito.when(fieldInfo.getAttribute(KNNConstants.VECTOR_DATA_TYPE_FIELD)).thenReturn(VectorDataType.FLOAT.getValue());
         Mockito.when(reader.getFloatVectorValues("test_field"))
-                .thenReturn(new TestVectorValues.PreDefinedFloatVectorValues(floatArrayList));
+            .thenReturn(new TestVectorValues.PreDefinedFloatVectorValues(floatArrayList));
         final KNNVectorValues<float[]> floatVectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, reader);
         floatVectorValues.nextDoc();
         Assert.assertArrayEquals(floatArrayList.getFirst(), floatVectorValues.getVector(), 0.0f);
@@ -98,7 +98,7 @@ public class KNNVectorValuesFactoryTests extends KNNTestCase {
         Mockito.when(fieldInfo.getVectorEncoding()).thenReturn(VectorEncoding.BYTE);
         Mockito.when(fieldInfo.getAttribute(KNNConstants.VECTOR_DATA_TYPE_FIELD)).thenReturn(VectorDataType.BINARY.getValue());
         Mockito.when(reader.getByteVectorValues("test_field"))
-                .thenReturn(new TestVectorValues.PreDefinedBinaryVectorValues(binaryArrayList));
+            .thenReturn(new TestVectorValues.PreDefinedBinaryVectorValues(binaryArrayList));
         final KNNVectorValues<byte[]> binaryVectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, reader);
         binaryVectorValues.nextDoc();
         Assert.assertArrayEquals(binaryArrayList.getFirst(), binaryVectorValues.getVector());
@@ -119,7 +119,7 @@ public class KNNVectorValuesFactoryTests extends KNNTestCase {
         // Checking for ByteVectorValues
         Mockito.when(fieldInfo.getAttribute(KNNConstants.VECTOR_DATA_TYPE_FIELD)).thenReturn(VectorDataType.BYTE.getValue());
         Mockito.when(reader.getBinaryDocValues("test_field"))
-                .thenReturn(new TestVectorValues.PredefinedByteVectorBinaryDocValues(byteArrayList));
+            .thenReturn(new TestVectorValues.PredefinedByteVectorBinaryDocValues(byteArrayList));
 
         final KNNVectorValues<byte[]> byteVectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, reader);
         byteVectorValues.nextDoc();
@@ -129,7 +129,7 @@ public class KNNVectorValuesFactoryTests extends KNNTestCase {
         // Checking for Floats with BinaryDocValues
         Mockito.when(fieldInfo.getAttribute(KNNConstants.VECTOR_DATA_TYPE_FIELD)).thenReturn(VectorDataType.FLOAT.getValue());
         Mockito.when(reader.getBinaryDocValues("test_field"))
-                .thenReturn(new TestVectorValues.PredefinedFloatVectorBinaryDocValues(floatArrayList));
+            .thenReturn(new TestVectorValues.PredefinedFloatVectorBinaryDocValues(floatArrayList));
 
         final KNNVectorValues<float[]> floatVectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, reader);
         floatVectorValues.nextDoc();
@@ -139,7 +139,7 @@ public class KNNVectorValuesFactoryTests extends KNNTestCase {
         // Checking for BinaryVectorValues
         Mockito.when(fieldInfo.getAttribute(KNNConstants.VECTOR_DATA_TYPE_FIELD)).thenReturn(VectorDataType.BINARY.getValue());
         Mockito.when(reader.getBinaryDocValues("test_field"))
-                .thenReturn(new TestVectorValues.PredefinedByteVectorBinaryDocValues(binaryArrayList));
+            .thenReturn(new TestVectorValues.PredefinedByteVectorBinaryDocValues(binaryArrayList));
 
         final KNNVectorValues<byte[]> binaryVectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, reader);
         binaryVectorValues.nextDoc();

--- a/src/test/java/org/opensearch/knn/index/vectorvalues/KNNVectorValuesFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/vectorvalues/KNNVectorValuesFactoryTests.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.vectorvalues;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocsWithFieldSet;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.index.VectorEncoding;
+import org.junit.Assert;
+import org.mockito.Mockito;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.VectorDataType;
+
+import java.util.List;
+import java.util.Map;
+
+public class KNNVectorValuesFactoryTests extends KNNTestCase {
+    private static final int COUNT = 10;
+    private static final int DIMENSION = 10;
+
+    public void testGetVectorValuesFromDISI_whenValidInput_thenSuccess() {
+        final BinaryDocValues binaryDocValues = new TestVectorValues.RandomVectorBinaryDocValues(COUNT, DIMENSION);
+        final KNNVectorValues<float[]> floatVectorValues = KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, binaryDocValues);
+        Assert.assertNotNull(floatVectorValues);
+
+        final KNNVectorValues<byte[]> byteVectorValues = KNNVectorValuesFactory.getVectorValues(VectorDataType.BYTE, binaryDocValues);
+        Assert.assertNotNull(byteVectorValues);
+
+        final KNNVectorValues<byte[]> binaryVectorValues = KNNVectorValuesFactory.getVectorValues(VectorDataType.BINARY, binaryDocValues);
+        Assert.assertNotNull(binaryVectorValues);
+    }
+
+    public void testGetVectorValuesUsingDocWithFieldSet_whenValidInput_thenSuccess() {
+        final DocsWithFieldSet docsWithFieldSet = new DocsWithFieldSet();
+        docsWithFieldSet.add(0);
+        docsWithFieldSet.add(1);
+        final Map<Integer, float[]> floatVectorMap = Map.of(0, new float[] { 1, 2 }, 1, new float[] { 2, 3 });
+        final KNNVectorValues<float[]> floatVectorValues = KNNVectorValuesFactory.getVectorValues(
+                VectorDataType.FLOAT,
+                docsWithFieldSet,
+                floatVectorMap
+        );
+        Assert.assertNotNull(floatVectorValues);
+
+        final Map<Integer, byte[]> byteVectorMap = Map.of(0, new byte[] { 4, 5 }, 1, new byte[] { 6, 7 });
+
+        final KNNVectorValues<byte[]> byteVectorValues = KNNVectorValuesFactory.getVectorValues(
+                VectorDataType.BYTE,
+                docsWithFieldSet,
+                byteVectorMap
+        );
+        Assert.assertNotNull(byteVectorValues);
+
+        final KNNVectorValues<byte[]> binaryVectorValues = KNNVectorValuesFactory.getVectorValues(
+                VectorDataType.BINARY,
+                docsWithFieldSet,
+                byteVectorMap
+        );
+        Assert.assertNotNull(binaryVectorValues);
+    }
+
+    @SneakyThrows
+    public void testGetVectorValuesFromFieldInfo_whenVectorDimIsNotZero_thenSuccess() {
+        final List<byte[]> byteArrayList = List.of(new byte[] { 1, 2, 3 });
+        final List<float[]> floatArrayList = List.of(new float[] { 1.3f, 2.2f, 3.2f });
+        final List<byte[]> binaryArrayList = List.of(new byte[] { 3, 2, 3 });
+        final FieldInfo fieldInfo = Mockito.mock(FieldInfo.class);
+        final SegmentReader reader = Mockito.mock(SegmentReader.class);
+        Mockito.when(fieldInfo.hasVectorValues()).thenReturn(true);
+        Mockito.when(fieldInfo.getName()).thenReturn("test_field");
+
+        // Checking for ByteVectorValues
+        Mockito.when(fieldInfo.getVectorEncoding()).thenReturn(VectorEncoding.BYTE);
+        Mockito.when(fieldInfo.getAttribute(KNNConstants.VECTOR_DATA_TYPE_FIELD)).thenReturn(VectorDataType.BYTE.getValue());
+        Mockito.when(reader.getByteVectorValues("test_field")).thenReturn(new TestVectorValues.PreDefinedByteVectorValues(byteArrayList));
+        final KNNVectorValues<byte[]> byteVectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, reader);
+        byteVectorValues.nextDoc();
+        Assert.assertArrayEquals(byteArrayList.getFirst(), byteVectorValues.getVector());
+        Assert.assertNotNull(byteVectorValues);
+
+        // Checking for FloatVectorValues
+        Mockito.when(fieldInfo.getVectorEncoding()).thenReturn(VectorEncoding.FLOAT32);
+        Mockito.when(fieldInfo.getAttribute(KNNConstants.VECTOR_DATA_TYPE_FIELD)).thenReturn(VectorDataType.FLOAT.getValue());
+        Mockito.when(reader.getFloatVectorValues("test_field"))
+                .thenReturn(new TestVectorValues.PreDefinedFloatVectorValues(floatArrayList));
+        final KNNVectorValues<float[]> floatVectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, reader);
+        floatVectorValues.nextDoc();
+        Assert.assertArrayEquals(floatArrayList.getFirst(), floatVectorValues.getVector(), 0.0f);
+        Assert.assertNotNull(floatVectorValues);
+
+        // Checking for BinaryVectorValues
+        Mockito.when(fieldInfo.getVectorEncoding()).thenReturn(VectorEncoding.BYTE);
+        Mockito.when(fieldInfo.getAttribute(KNNConstants.VECTOR_DATA_TYPE_FIELD)).thenReturn(VectorDataType.BINARY.getValue());
+        Mockito.when(reader.getByteVectorValues("test_field"))
+                .thenReturn(new TestVectorValues.PreDefinedBinaryVectorValues(binaryArrayList));
+        final KNNVectorValues<byte[]> binaryVectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, reader);
+        binaryVectorValues.nextDoc();
+        Assert.assertArrayEquals(binaryArrayList.getFirst(), binaryVectorValues.getVector());
+        Assert.assertNotNull(binaryVectorValues);
+
+    }
+
+    @SneakyThrows
+    public void testGetVectorValuesFromFieldInfo_whenVectorDimIsZero_thenSuccess() {
+        final List<byte[]> byteArrayList = List.of(new byte[] { 1, 2, 3 });
+        final List<float[]> floatArrayList = List.of(new float[] { 1.3f, 2.2f, 3.2f });
+        final List<byte[]> binaryArrayList = List.of(new byte[] { 3, 2, 3 });
+        final FieldInfo fieldInfo = Mockito.mock(FieldInfo.class);
+        final SegmentReader reader = Mockito.mock(SegmentReader.class);
+        Mockito.when(fieldInfo.hasVectorValues()).thenReturn(false);
+        Mockito.when(fieldInfo.getName()).thenReturn("test_field");
+
+        // Checking for ByteVectorValues
+        Mockito.when(fieldInfo.getAttribute(KNNConstants.VECTOR_DATA_TYPE_FIELD)).thenReturn(VectorDataType.BYTE.getValue());
+        Mockito.when(reader.getBinaryDocValues("test_field"))
+                .thenReturn(new TestVectorValues.PredefinedByteVectorBinaryDocValues(byteArrayList));
+
+        final KNNVectorValues<byte[]> byteVectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, reader);
+        byteVectorValues.nextDoc();
+        Assert.assertArrayEquals(byteArrayList.getFirst(), byteVectorValues.getVector());
+        Assert.assertNotNull(byteVectorValues);
+
+        // Checking for Floats with BinaryDocValues
+        Mockito.when(fieldInfo.getAttribute(KNNConstants.VECTOR_DATA_TYPE_FIELD)).thenReturn(VectorDataType.FLOAT.getValue());
+        Mockito.when(reader.getBinaryDocValues("test_field"))
+                .thenReturn(new TestVectorValues.PredefinedFloatVectorBinaryDocValues(floatArrayList));
+
+        final KNNVectorValues<float[]> floatVectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, reader);
+        floatVectorValues.nextDoc();
+        Assert.assertArrayEquals(floatArrayList.getFirst(), floatVectorValues.getVector(), 0.0f);
+        Assert.assertNotNull(floatVectorValues);
+
+        // Checking for BinaryVectorValues
+        Mockito.when(fieldInfo.getAttribute(KNNConstants.VECTOR_DATA_TYPE_FIELD)).thenReturn(VectorDataType.BINARY.getValue());
+        Mockito.when(reader.getBinaryDocValues("test_field"))
+                .thenReturn(new TestVectorValues.PredefinedByteVectorBinaryDocValues(binaryArrayList));
+
+        final KNNVectorValues<byte[]> binaryVectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, reader);
+        binaryVectorValues.nextDoc();
+        Assert.assertArrayEquals(binaryArrayList.getFirst(), binaryVectorValues.getVector());
+        Assert.assertNotNull(binaryVectorValues);
+
+        Mockito.verify(fieldInfo, Mockito.times(0)).getVectorEncoding();
+    }
+
+}

--- a/src/test/java/org/opensearch/knn/index/vectorvalues/KNNVectorValuesTests.java
+++ b/src/test/java/org/opensearch/knn/index/vectorvalues/KNNVectorValuesTests.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.vectorvalues;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.index.DocsWithFieldSet;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.VectorDataType;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class KNNVectorValuesTests extends KNNTestCase {
+
+    @SneakyThrows
+    public void testFloatVectorValues_whenValidInput_thenSuccess() {
+        final List<float[]> floatArray = List.of(new float[] { 1, 2 }, new float[] { 2, 3 });
+        final int dimension = floatArray.get(0).length;
+        final TestVectorValues.PreDefinedFloatVectorValues randomVectorValues = new TestVectorValues.PreDefinedFloatVectorValues(
+                floatArray
+        );
+        final KNNVectorValues<float[]> knnVectorValues = KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, randomVectorValues);
+        new CompareVectorValues<float[]>().validateVectorValues(knnVectorValues, floatArray, 8, dimension, true);
+
+        final DocsWithFieldSet docsWithFieldSet = getDocIdSetIterator(floatArray.size());
+
+        final Map<Integer, float[]> vectorsMap = Map.of(0, floatArray.get(0), 1, floatArray.get(1));
+        final KNNVectorValues<float[]> knnVectorValuesForFieldWriter = KNNVectorValuesFactory.getVectorValues(
+                VectorDataType.FLOAT,
+                docsWithFieldSet,
+                vectorsMap
+        );
+        new CompareVectorValues<float[]>().validateVectorValues(knnVectorValuesForFieldWriter, floatArray, 8, dimension, false);
+        final TestVectorValues.PredefinedFloatVectorBinaryDocValues preDefinedFloatVectorValues =
+                new TestVectorValues.PredefinedFloatVectorBinaryDocValues(floatArray);
+        final KNNVectorValues<float[]> knnFloatVectorValuesBinaryDocValues = KNNVectorValuesFactory.getVectorValues(
+                VectorDataType.FLOAT,
+                preDefinedFloatVectorValues
+        );
+        new CompareVectorValues<float[]>().validateVectorValues(knnFloatVectorValuesBinaryDocValues, floatArray, 8, dimension, false);
+    }
+
+    @SneakyThrows
+    public void testByteVectorValues_whenValidInput_thenSuccess() {
+        final List<byte[]> byteArray = List.of(new byte[] { 4, 5 }, new byte[] { 6, 7 });
+        final int dimension = byteArray.get(0).length;
+        final TestVectorValues.PreDefinedByteVectorValues randomVectorValues = new TestVectorValues.PreDefinedByteVectorValues(byteArray);
+        final KNNVectorValues<byte[]> knnVectorValues = KNNVectorValuesFactory.getVectorValues(VectorDataType.BYTE, randomVectorValues);
+        new CompareVectorValues<byte[]>().validateVectorValues(knnVectorValues, byteArray, 2, dimension, true);
+
+        final DocsWithFieldSet docsWithFieldSet = getDocIdSetIterator(byteArray.size());
+        final Map<Integer, byte[]> vectorsMap = Map.of(0, byteArray.get(0), 1, byteArray.get(1));
+        final KNNVectorValues<byte[]> knnVectorValuesForFieldWriter = KNNVectorValuesFactory.getVectorValues(
+                VectorDataType.BYTE,
+                docsWithFieldSet,
+                vectorsMap
+        );
+        new CompareVectorValues<byte[]>().validateVectorValues(knnVectorValuesForFieldWriter, byteArray, 2, dimension, false);
+
+        final TestVectorValues.PredefinedByteVectorBinaryDocValues preDefinedByteVectorValues =
+                new TestVectorValues.PredefinedByteVectorBinaryDocValues(byteArray);
+        final KNNVectorValues<byte[]> knnBinaryVectorValuesBinaryDocValues = KNNVectorValuesFactory.getVectorValues(
+                VectorDataType.BYTE,
+                preDefinedByteVectorValues
+        );
+        new CompareVectorValues<byte[]>().validateVectorValues(knnBinaryVectorValuesBinaryDocValues, byteArray, 2, dimension, false);
+    }
+
+    @SneakyThrows
+    public void testBinaryVectorValues_whenValidInput_thenSuccess() {
+        final List<byte[]> byteArray = List.of(new byte[] { 1, 5, 8 }, new byte[] { 6, 7, 9 });
+        int dimension = byteArray.get(0).length * 8;
+        final TestVectorValues.PreDefinedBinaryVectorValues randomVectorValues = new TestVectorValues.PreDefinedBinaryVectorValues(
+                byteArray
+        );
+        final KNNVectorValues<byte[]> knnVectorValues = KNNVectorValuesFactory.getVectorValues(VectorDataType.BINARY, randomVectorValues);
+        new CompareVectorValues<byte[]>().validateVectorValues(knnVectorValues, byteArray, 3, dimension, true);
+
+        final DocsWithFieldSet docsWithFieldSet = getDocIdSetIterator(byteArray.size());
+        final Map<Integer, byte[]> vectorsMap = Map.of(0, byteArray.get(0), 1, byteArray.get(1));
+        final KNNBinaryVectorValues knnVectorValuesForFieldWriter = (KNNBinaryVectorValues) KNNVectorValuesFactory.getVectorValues(
+                VectorDataType.BINARY,
+                docsWithFieldSet,
+                vectorsMap
+        );
+        new CompareVectorValues<byte[]>().validateVectorValues(knnVectorValuesForFieldWriter, byteArray, 3, dimension, false);
+
+        final TestVectorValues.PredefinedByteVectorBinaryDocValues preDefinedByteVectorValues =
+                new TestVectorValues.PredefinedByteVectorBinaryDocValues(byteArray);
+        final KNNVectorValues<byte[]> knnBinaryVectorValuesBinaryDocValues = KNNVectorValuesFactory.getVectorValues(
+                VectorDataType.BINARY,
+                preDefinedByteVectorValues
+        );
+        new CompareVectorValues<byte[]>().validateVectorValues(knnBinaryVectorValuesBinaryDocValues, byteArray, 3, dimension, false);
+    }
+
+    private DocsWithFieldSet getDocIdSetIterator(int numberOfDocIds) {
+        final DocsWithFieldSet docsWithFieldSet = new DocsWithFieldSet();
+        for (int i = 0; i < numberOfDocIds; i++) {
+            docsWithFieldSet.add(i);
+        }
+        return docsWithFieldSet;
+    }
+
+    private class CompareVectorValues<T> {
+        void validateVectorValues(
+                KNNVectorValues<T> vectorValues,
+                List<T> vectors,
+                int bytesPerVector,
+                int dimension,
+                boolean validateAddress
+        ) throws IOException {
+            assertEquals(vectorValues.totalLiveDocs(), vectors.size());
+            int docId, i = 0;
+            T oldActual = null;
+            int oldDocId = -1;
+            final KNNVectorValuesIterator iterator = vectorValues.vectorValuesIterator;
+            for (docId = iterator.nextDoc(); docId != DocIdSetIterator.NO_MORE_DOCS && i < vectors.size(); docId = iterator.nextDoc()) {
+                T actual = vectorValues.getVector();
+                T clone = vectorValues.conditionalCloneVector();
+                T expected = vectors.get(i);
+                assertNotEquals(oldDocId, docId);
+                assertEquals(dimension, vectorValues.dimension());
+                // this will check if reference is correct for the vectors. This is mainly required because for
+                // VectorValues of Lucene when reading vectors put the vector at same reference
+                if (oldActual != null && validateAddress) {
+                    assertSame(actual, oldActual);
+                    assertNotSame(clone, oldActual);
+                }
+
+                oldActual = actual;
+                // this will do the deep equals
+                assertArrayEquals(new Object[] { actual }, new Object[] { expected });
+                assertArrayEquals(new Object[] { clone }, new Object[] { expected });
+                i++;
+            }
+            assertEquals(bytesPerVector, vectorValues.bytesPerVector);
+        }
+    }
+
+}

--- a/src/test/java/org/opensearch/knn/index/vectorvalues/KNNVectorValuesTests.java
+++ b/src/test/java/org/opensearch/knn/index/vectorvalues/KNNVectorValuesTests.java
@@ -22,7 +22,7 @@ public class KNNVectorValuesTests extends KNNTestCase {
         final List<float[]> floatArray = List.of(new float[] { 1, 2 }, new float[] { 2, 3 });
         final int dimension = floatArray.get(0).length;
         final TestVectorValues.PreDefinedFloatVectorValues randomVectorValues = new TestVectorValues.PreDefinedFloatVectorValues(
-                floatArray
+            floatArray
         );
         final KNNVectorValues<float[]> knnVectorValues = KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, randomVectorValues);
         new CompareVectorValues<float[]>().validateVectorValues(knnVectorValues, floatArray, 8, dimension, true);
@@ -31,16 +31,16 @@ public class KNNVectorValuesTests extends KNNTestCase {
 
         final Map<Integer, float[]> vectorsMap = Map.of(0, floatArray.get(0), 1, floatArray.get(1));
         final KNNVectorValues<float[]> knnVectorValuesForFieldWriter = KNNVectorValuesFactory.getVectorValues(
-                VectorDataType.FLOAT,
-                docsWithFieldSet,
-                vectorsMap
+            VectorDataType.FLOAT,
+            docsWithFieldSet,
+            vectorsMap
         );
         new CompareVectorValues<float[]>().validateVectorValues(knnVectorValuesForFieldWriter, floatArray, 8, dimension, false);
         final TestVectorValues.PredefinedFloatVectorBinaryDocValues preDefinedFloatVectorValues =
-                new TestVectorValues.PredefinedFloatVectorBinaryDocValues(floatArray);
+            new TestVectorValues.PredefinedFloatVectorBinaryDocValues(floatArray);
         final KNNVectorValues<float[]> knnFloatVectorValuesBinaryDocValues = KNNVectorValuesFactory.getVectorValues(
-                VectorDataType.FLOAT,
-                preDefinedFloatVectorValues
+            VectorDataType.FLOAT,
+            preDefinedFloatVectorValues
         );
         new CompareVectorValues<float[]>().validateVectorValues(knnFloatVectorValuesBinaryDocValues, floatArray, 8, dimension, false);
     }
@@ -56,17 +56,17 @@ public class KNNVectorValuesTests extends KNNTestCase {
         final DocsWithFieldSet docsWithFieldSet = getDocIdSetIterator(byteArray.size());
         final Map<Integer, byte[]> vectorsMap = Map.of(0, byteArray.get(0), 1, byteArray.get(1));
         final KNNVectorValues<byte[]> knnVectorValuesForFieldWriter = KNNVectorValuesFactory.getVectorValues(
-                VectorDataType.BYTE,
-                docsWithFieldSet,
-                vectorsMap
+            VectorDataType.BYTE,
+            docsWithFieldSet,
+            vectorsMap
         );
         new CompareVectorValues<byte[]>().validateVectorValues(knnVectorValuesForFieldWriter, byteArray, 2, dimension, false);
 
         final TestVectorValues.PredefinedByteVectorBinaryDocValues preDefinedByteVectorValues =
-                new TestVectorValues.PredefinedByteVectorBinaryDocValues(byteArray);
+            new TestVectorValues.PredefinedByteVectorBinaryDocValues(byteArray);
         final KNNVectorValues<byte[]> knnBinaryVectorValuesBinaryDocValues = KNNVectorValuesFactory.getVectorValues(
-                VectorDataType.BYTE,
-                preDefinedByteVectorValues
+            VectorDataType.BYTE,
+            preDefinedByteVectorValues
         );
         new CompareVectorValues<byte[]>().validateVectorValues(knnBinaryVectorValuesBinaryDocValues, byteArray, 2, dimension, false);
     }
@@ -76,7 +76,7 @@ public class KNNVectorValuesTests extends KNNTestCase {
         final List<byte[]> byteArray = List.of(new byte[] { 1, 5, 8 }, new byte[] { 6, 7, 9 });
         int dimension = byteArray.get(0).length * 8;
         final TestVectorValues.PreDefinedBinaryVectorValues randomVectorValues = new TestVectorValues.PreDefinedBinaryVectorValues(
-                byteArray
+            byteArray
         );
         final KNNVectorValues<byte[]> knnVectorValues = KNNVectorValuesFactory.getVectorValues(VectorDataType.BINARY, randomVectorValues);
         new CompareVectorValues<byte[]>().validateVectorValues(knnVectorValues, byteArray, 3, dimension, true);
@@ -84,17 +84,17 @@ public class KNNVectorValuesTests extends KNNTestCase {
         final DocsWithFieldSet docsWithFieldSet = getDocIdSetIterator(byteArray.size());
         final Map<Integer, byte[]> vectorsMap = Map.of(0, byteArray.get(0), 1, byteArray.get(1));
         final KNNBinaryVectorValues knnVectorValuesForFieldWriter = (KNNBinaryVectorValues) KNNVectorValuesFactory.getVectorValues(
-                VectorDataType.BINARY,
-                docsWithFieldSet,
-                vectorsMap
+            VectorDataType.BINARY,
+            docsWithFieldSet,
+            vectorsMap
         );
         new CompareVectorValues<byte[]>().validateVectorValues(knnVectorValuesForFieldWriter, byteArray, 3, dimension, false);
 
         final TestVectorValues.PredefinedByteVectorBinaryDocValues preDefinedByteVectorValues =
-                new TestVectorValues.PredefinedByteVectorBinaryDocValues(byteArray);
+            new TestVectorValues.PredefinedByteVectorBinaryDocValues(byteArray);
         final KNNVectorValues<byte[]> knnBinaryVectorValuesBinaryDocValues = KNNVectorValuesFactory.getVectorValues(
-                VectorDataType.BINARY,
-                preDefinedByteVectorValues
+            VectorDataType.BINARY,
+            preDefinedByteVectorValues
         );
         new CompareVectorValues<byte[]>().validateVectorValues(knnBinaryVectorValuesBinaryDocValues, byteArray, 3, dimension, false);
     }
@@ -109,11 +109,11 @@ public class KNNVectorValuesTests extends KNNTestCase {
 
     private class CompareVectorValues<T> {
         void validateVectorValues(
-                KNNVectorValues<T> vectorValues,
-                List<T> vectors,
-                int bytesPerVector,
-                int dimension,
-                boolean validateAddress
+            KNNVectorValues<T> vectorValues,
+            List<T> vectors,
+            int bytesPerVector,
+            int dimension,
+            boolean validateAddress
         ) throws IOException {
             assertEquals(vectorValues.totalLiveDocs(), vectors.size());
             int docId, i = 0;

--- a/src/test/java/org/opensearch/knn/index/vectorvalues/TestVectorValues.java
+++ b/src/test/java/org/opensearch/knn/index/vectorvalues/TestVectorValues.java
@@ -1,0 +1,473 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.knn.index.vectorvalues;
+
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.*;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.VectorScorer;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.codec.util.KNNVectorSerializer;
+import org.opensearch.knn.index.codec.util.KNNVectorSerializerFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.carrotsearch.randomizedtesting.RandomizedTest.randomByte;
+import static com.carrotsearch.randomizedtesting.RandomizedTest.randomFloat;
+
+public class TestVectorValues {
+
+    public static class RandomVectorBinaryDocValues extends VectorDocValues {
+
+        public RandomVectorBinaryDocValues(int count, int dimension) {
+            super(count, dimension);
+        }
+
+        @Override
+        public BytesRef binaryValue() throws IOException {
+            return new BytesRef(knnVectorSerializer.floatToByteArray(getRandomVector(dimension)));
+        }
+    }
+
+    public static class ConstantVectorBinaryDocValues extends VectorDocValues {
+
+        private final BytesRef value;
+
+        public ConstantVectorBinaryDocValues(int count, int dimension, float value) {
+            super(count, dimension);
+            float[] array = new float[dimension];
+            Arrays.fill(array, value);
+            this.value = new BytesRef(knnVectorSerializer.floatToByteArray(array));
+        }
+
+        @Override
+        public BytesRef binaryValue() throws IOException {
+            return value;
+        }
+    }
+
+    public static class PredefinedFloatVectorBinaryDocValues extends VectorDocValues {
+        private final List<float[]> vectors;
+
+        public PredefinedFloatVectorBinaryDocValues(final List<float[]> vectors) {
+            super(vectors.size(), vectors.get(0).length);
+            this.vectors = vectors;
+        }
+
+        @Override
+        public BytesRef binaryValue() throws IOException {
+            return new BytesRef(knnVectorSerializer.floatToByteArray(vectors.get(docID())));
+        }
+    }
+
+    public static class PredefinedByteVectorBinaryDocValues extends VectorDocValues {
+        private final List<byte[]> vectors;
+
+        public PredefinedByteVectorBinaryDocValues(final List<byte[]> vectors) {
+            super(vectors.size(), vectors.get(0).length);
+            this.vectors = vectors;
+        }
+
+        @Override
+        public BytesRef binaryValue() throws IOException {
+            return new BytesRef(vectors.get(docID()));
+        }
+    }
+
+    public static class RandomVectorDocValuesProducer extends DocValuesProducer {
+
+        final RandomVectorBinaryDocValues randomBinaryDocValues;
+
+        public RandomVectorDocValuesProducer(int count, int dimension) {
+            this.randomBinaryDocValues = new RandomVectorBinaryDocValues(count, dimension);
+        }
+
+        @Override
+        public NumericDocValues getNumeric(FieldInfo field) {
+            return null;
+        }
+
+        @Override
+        public BinaryDocValues getBinary(FieldInfo field) throws IOException {
+            return randomBinaryDocValues;
+        }
+
+        @Override
+        public SortedDocValues getSorted(FieldInfo field) {
+            return null;
+        }
+
+        @Override
+        public SortedNumericDocValues getSortedNumeric(FieldInfo field) {
+            return null;
+        }
+
+        @Override
+        public SortedSetDocValues getSortedSet(FieldInfo field) {
+            return null;
+        }
+
+        /**
+         * Returns a {@link DocValuesSkipper} for this field. The returned instance need not be
+         * thread-safe: it will only be used by a single thread. The return value is undefined if {@link
+         * FieldInfo#docValuesSkipIndexType()} returns {@link DocValuesSkipIndexType#NONE}.
+         *
+         * @param field
+         */
+        @Override
+        public DocValuesSkipper getSkipper(FieldInfo field) throws IOException {
+            return null;
+        }
+
+        @Override
+        public void checkIntegrity() {
+
+        }
+
+        @Override
+        public void close() throws IOException {
+
+        }
+    }
+
+    static abstract class VectorDocValues extends BinaryDocValues {
+
+        final int count;
+        final int dimension;
+        int current;
+        KNNVectorSerializer knnVectorSerializer;
+
+        public VectorDocValues(int count, int dimension) {
+            this.count = count;
+            this.dimension = dimension;
+            this.current = -1;
+            this.knnVectorSerializer = KNNVectorSerializerFactory.getDefaultSerializer();
+        }
+
+        @Override
+        public boolean advanceExact(int target) throws IOException {
+            return false;
+        }
+
+        @Override
+        public int docID() {
+            if (this.current > this.count) {
+                return BinaryDocValues.NO_MORE_DOCS;
+            }
+            return this.current;
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+            return advance(current + 1);
+        }
+
+        @Override
+        public int advance(int target) throws IOException {
+            current = target;
+            if (current >= count) {
+                current = NO_MORE_DOCS;
+            }
+            return current;
+        }
+
+        @Override
+        public long cost() {
+            return count;
+        }
+    }
+
+    public static class PreDefinedFloatVectorValues extends FloatVectorValues {
+        final int count;
+        final int dimension;
+        final List<float[]> vectors;
+        final VectorSimilarityFunction similarityFunction;
+        int current;
+        float[] vector;
+
+        public PreDefinedFloatVectorValues(final List<float[]> vectors) {
+            this(vectors, null);
+        }
+
+        public PreDefinedFloatVectorValues(final List<float[]> vectors, VectorSimilarityFunction similarityFunction) {
+            super();
+            this.count = vectors.size();
+            this.dimension = vectors.isEmpty() ? 0 : vectors.get(0).length;
+            this.vectors = vectors;
+            this.similarityFunction = similarityFunction;
+            this.current = -1;
+            vector = new float[dimension];
+        }
+
+        @Override
+        public int dimension() {
+            return dimension;
+        }
+
+        @Override
+        public int size() {
+            return count;
+        }
+
+        public float[] vectorValue() throws IOException {
+            // since in FloatVectorValues the reference to returned vector doesn't change. This code ensure that we
+            // are replicating the behavior so that if someone uses this RandomFloatVectorValues they get an
+            // experience similar to what we get in prod.
+            System.arraycopy(vectors.get(docID()), 0, vector, 0, dimension);
+            return vector;
+        }
+
+        @Override
+        public float[] vectorValue(int ordId) throws IOException {
+            // since in FloatVectorValues the reference to returned vector doesn't change. This code ensure that we
+            // are replicating the behavior so that if someone uses this RandomFloatVectorValues they get an
+            // experience similar to what we get in prod.
+            System.arraycopy(vectors.get(ordId), 0, vector, 0, dimension);
+            return vector;
+        }
+
+        @Override
+        public DocIndexIterator iterator() {
+            return createDenseIterator();
+        }
+
+        /**
+         * @return
+         * @throws IOException
+         */
+        @Override
+        public FloatVectorValues copy() throws IOException {
+            return new PreDefinedFloatVectorValues(vectors, similarityFunction);
+        }
+
+        @Override
+        public VectorScorer scorer(float[] query) throws IOException {
+            if (similarityFunction == null) {
+                throw new UnsupportedOperationException("scorer not supported with PreDefinedFloatVectorValues");
+            }
+            PreDefinedFloatVectorValues copy = new PreDefinedFloatVectorValues(vectors, similarityFunction);
+            DocIndexIterator iterator = copy.iterator();
+            return new VectorScorer() {
+                @Override
+                public float score() throws IOException {
+                    return similarityFunction.compare(query, copy.vectorValue(iterator.index()));
+                }
+
+                @Override
+                public DocIdSetIterator iterator() {
+                    return iterator;
+                }
+            };
+        }
+
+        public int docID() {
+            if (this.current > this.count) {
+                return DocIndexIterator.NO_MORE_DOCS;
+            }
+            return this.current;
+        }
+
+        public int nextDoc() throws IOException {
+            return advance(current + 1);
+        }
+
+        public int advance(int target) throws IOException {
+            current = target;
+            if (current >= count) {
+                current = DocIndexIterator.NO_MORE_DOCS;
+            }
+            return current;
+        }
+    }
+
+    public static class PreDefinedByteVectorValues extends ByteVectorValues {
+        private final int count;
+        private final int dimension;
+        private final List<byte[]> vectors;
+        private final VectorSimilarityFunction similarityFunction;
+        private int current;
+        private final byte[] vector;
+
+        public PreDefinedByteVectorValues(final List<byte[]> vectors) {
+            this(vectors, null);
+        }
+
+        public PreDefinedByteVectorValues(final List<byte[]> vectors, VectorSimilarityFunction similarityFunction) {
+            super();
+            this.count = vectors.size();
+            this.dimension = vectors.get(0).length;
+            this.vectors = vectors;
+            this.similarityFunction = similarityFunction;
+            this.current = -1;
+            vector = new byte[dimension];
+        }
+
+        @Override
+        public int dimension() {
+            return dimension;
+        }
+
+        @Override
+        public int size() {
+            return count;
+        }
+
+        public byte[] vectorValue() throws IOException {
+            // since in FloatVectorValues the reference to returned vector doesn't change. This code ensure that we
+            // are replicating the behavior so that if someone uses this RandomFloatVectorValues they get an
+            // experience similar to what we get in prod.
+            System.arraycopy(vectors.get(docID()), 0, vector, 0, dimension);
+            return vector;
+        }
+
+        @Override
+        public byte[] vectorValue(int ordId) throws IOException {
+            // since in FloatVectorValues the reference to returned vector doesn't change. This code ensure that we
+            // are replicating the behavior so that if someone uses this RandomFloatVectorValues they get an
+            // experience similar to what we get in prod.
+            System.arraycopy(vectors.get(ordId), 0, vector, 0, dimension);
+            return vector;
+        }
+
+        /**
+         * @return
+         * @throws IOException
+         */
+        @Override
+        public PreDefinedByteVectorValues copy() throws IOException {
+            return new PreDefinedByteVectorValues(vectors, similarityFunction);
+        }
+
+        @Override
+        public DocIndexIterator iterator() {
+            return createDenseIterator();
+        }
+
+        @Override
+        public VectorScorer scorer(byte[] query) throws IOException {
+            PreDefinedByteVectorValues copy = new PreDefinedByteVectorValues(vectors, similarityFunction);
+            DocIndexIterator iterator = copy.iterator();
+            return new VectorScorer() {
+                @Override
+                public float score() throws IOException {
+                    if (similarityFunction == null) {
+                        return SpaceType.HAMMING.getKnnVectorSimilarityFunction().compare(query, copy.vectorValue(iterator.index()));
+                    }
+                    return similarityFunction.compare(query, copy.vectorValue(iterator.index()));
+                }
+
+                @Override
+                public DocIdSetIterator iterator() {
+                    return iterator;
+                }
+            };
+        }
+
+        public int docID() {
+            if (this.current > this.count) {
+                return DocIndexIterator.NO_MORE_DOCS;
+            }
+            return this.current;
+        }
+
+        public int nextDoc() throws IOException {
+            return advance(current + 1);
+        }
+
+        public int advance(int target) throws IOException {
+            current = target;
+            if (current >= count) {
+                current = DocIndexIterator.NO_MORE_DOCS;
+            }
+            return current;
+        }
+    }
+
+    public static class PreDefinedBinaryVectorValues extends PreDefinedByteVectorValues {
+
+        public PreDefinedBinaryVectorValues(List<byte[]> vectors) {
+            super(vectors);
+        }
+
+        @Override
+        public int dimension() {
+            return super.dimension() * Byte.SIZE;
+        }
+    }
+
+    public static class NotBinaryDocValues extends NumericDocValues {
+
+        @Override
+        public long longValue() throws IOException {
+            return 0;
+        }
+
+        @Override
+        public boolean advanceExact(int target) throws IOException {
+            return false;
+        }
+
+        @Override
+        public int docID() {
+            return 0;
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+            return 0;
+        }
+
+        @Override
+        public int advance(int target) throws IOException {
+            return 0;
+        }
+
+        @Override
+        public long cost() {
+            return 0;
+        }
+    }
+
+    public static float[][] getRandomVectors(int count, int dimension) {
+        float[][] data = new float[count][dimension];
+        for (int i = 0; i < count; i++) {
+            data[i] = getRandomVector(dimension);
+        }
+        return data;
+    }
+
+    public static float[] getRandomVector(int dimension) {
+        float[] data = new float[dimension];
+        for (int i = 0; i < dimension; i++) {
+            data[i] = randomFloat();
+        }
+        return data;
+    }
+
+    public static byte[] getRandomByteVector(int dimension) {
+        byte[] data = new byte[dimension];
+        for (int i = 0; i < dimension; i++) {
+            data[i] = randomByte();
+        }
+        return data;
+    }
+
+    public static KNNVectorValues createKNNBinaryVectorValues(final BinaryDocValues binaryDocValues) {
+        return new KNNBinaryVectorValues(new KNNVectorValuesIterator.DocIdsIteratorValues(binaryDocValues));
+    }
+
+    public static KNNVectorValues createKNNBinaryVectorValues(final List<byte[]> vectors) {
+        return new KNNBinaryVectorValues(new KNNVectorValuesIterator.DocIdsIteratorValues(new PreDefinedBinaryVectorValues(vectors)));
+    }
+
+    public static KNNVectorValues createKNNFloatVectorValues(final List<float[]> vectors) {
+        return new KNNFloatVectorValues(
+            new KNNVectorValuesIterator.DocIdsIteratorValues(new PredefinedFloatVectorBinaryDocValues(vectors))
+        );
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/vectorvalues/VectorValueExtractorStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/vectorvalues/VectorValueExtractorStrategyTests.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.vectorvalues;
+
+import lombok.SneakyThrows;
+import org.junit.Assert;
+import org.mockito.Mockito;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.VectorDataType;
+
+/**
+ * To avoid unit test duplication, tests for exception is added here. For non exception cases tests are present in
+ * {@link KNNVectorValuesTests}
+ */
+public class VectorValueExtractorStrategyTests extends KNNTestCase {
+
+    @SneakyThrows
+    public void testExtractWithDISI_whenInvalidIterator_thenException() {
+        final VectorValueExtractorStrategy disiStrategy = new VectorValueExtractorStrategy.DISIVectorExtractor();
+        final KNNVectorValuesIterator vectorValuesIterator = Mockito.mock(KNNVectorValuesIterator.DocIdsIteratorValues.class);
+        Mockito.when(vectorValuesIterator.getDocIdSetIterator()).thenReturn(new TestVectorValues.NotBinaryDocValues());
+        Assert.assertThrows(IllegalArgumentException.class, () -> disiStrategy.extract(VectorDataType.FLOAT, vectorValuesIterator));
+        Assert.assertThrows(IllegalArgumentException.class, () -> disiStrategy.extract(VectorDataType.BINARY, vectorValuesIterator));
+        Assert.assertThrows(IllegalArgumentException.class, () -> disiStrategy.extract(VectorDataType.BYTE, vectorValuesIterator));
+    }
+}

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
### Description
Part one of tests implementation for #419

KNNVectorValuesTests.java – newest version was compatible

TestVectorValues.java
Compatible version doesn’t include changes from this PR: https://github.com/opensearch-project/k-NN/pull/2587

KNNVectorValuesFactoryTests.java
Migrated state: https://github.com/opensearch-project/k-NN/commit/a4697f4e4e940d7faedb4fd582cf411115fc792c

Mocking final classes requires inline-mock-maker. In solution from KNN, mockito was self-attaching to enable the inline-mock-maker, resulting in deprecation warning. I followed the instructions how to add mockito as an agend to the build, which solves the issue and don’t require additional byte-buddy dependencies. (https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3)

Original KNN solution: https://github.com/opensearch-project/k-NN/pull/759/changes#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7
Warning from original solution:
```
Mockito is currently self-attaching to enable the inline-mock-maker. This will no longer work in future releases of the JDK. Please add Mockito as an agent to your build as described in Mockito's documentation: https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3
WARNING: A Java agent has been loaded dynamically (/Users/wojciechkrakowiak/.gradle/caches/modules-2/files-2.1/net.bytebuddy/byte-buddy-agent/1.18.8/ed5c6c9b3a146b4aa376df3b6770d6cabed20482/byte-buddy-agent-1.18.8.jar)
WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
WARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information
WARNING: Dynamic loading of agents will be disallowed by default in a future release
```

### Related Issues
Part of #419 
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
