### PR TITLE
Migrate knn/quantization tests from k-NN repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -201,6 +201,7 @@ allprojects {
 
 configurations {
     zipArchive
+    mockitoAgent
 }
 
 publishing {
@@ -308,6 +309,7 @@ task release(type: Copy, group: 'build') {
 //****************************************************************************/
 // Dependencies
 //****************************************************************************/
+
 dependencies {
     api "org.opensearch:opensearch:${opensearch_version}"
     compileOnly "org.opensearch.plugin:opensearch-scripting-painless-spi:${versions.opensearch}"
@@ -315,6 +317,7 @@ dependencies {
     compileOnly group: 'com.google.guava', name: 'guava', version: "${versions.guava}"
     api "org.apache.commons:commons-lang3:${versions.commonslang}"
     testFixturesImplementation "org.opensearch.test:framework:${opensearch_version}"
+    mockitoAgent("org.mockito:mockito-core:${versions.mockito}") { transitive = false }
     // Add the high-level client dependency
     testImplementation "org.opensearch.client:opensearch-rest-high-level-client:${opensearch_version}"
     // Add netty dependency so we can use it within internal test clusters (not just external ones)
@@ -361,7 +364,8 @@ test {
             '-Djdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK=0',
             '--enable-native-access=ALL-UNNAMED',
             '-Dio.netty.tryReflectionSetAccessible=true',
-            '--enable-preview'
+            '--enable-preview',
+            "-javaagent:${configurations.mockitoAgent.asPath}"
     ]
 
 
@@ -451,10 +455,10 @@ testClusters.integTest { cluster ->
                         File getAsFile() {
                             return it
                         }
+                    }
                 }
-            }
-          }))
-      }
+            }))
+        }
     }
 
     plugin(project.tasks.bundlePlugin.archiveFile)

--- a/src/test/java/org/opensearch/knn/quantization/enums/ScalarQuantizationTypeTests.java
+++ b/src/test/java/org/opensearch/knn/quantization/enums/ScalarQuantizationTypeTests.java
@@ -13,9 +13,9 @@ import java.util.Set;
 public class ScalarQuantizationTypeTests extends KNNTestCase {
     public void testSQTypesValues() {
         ScalarQuantizationType[] expectedValues = {
-                ScalarQuantizationType.ONE_BIT,
-                ScalarQuantizationType.TWO_BIT,
-                ScalarQuantizationType.FOUR_BIT };
+            ScalarQuantizationType.ONE_BIT,
+            ScalarQuantizationType.TWO_BIT,
+            ScalarQuantizationType.FOUR_BIT };
         assertArrayEquals(expectedValues, ScalarQuantizationType.values());
     }
 

--- a/src/test/java/org/opensearch/knn/quantization/enums/ScalarQuantizationTypeTests.java
+++ b/src/test/java/org/opensearch/knn/quantization/enums/ScalarQuantizationTypeTests.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.quantization.enums;
+
+import org.opensearch.knn.KNNTestCase;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class ScalarQuantizationTypeTests extends KNNTestCase {
+    public void testSQTypesValues() {
+        ScalarQuantizationType[] expectedValues = {
+                ScalarQuantizationType.ONE_BIT,
+                ScalarQuantizationType.TWO_BIT,
+                ScalarQuantizationType.FOUR_BIT };
+        assertArrayEquals(expectedValues, ScalarQuantizationType.values());
+    }
+
+    public void testSQTypesValueOf() {
+        assertEquals(ScalarQuantizationType.ONE_BIT, ScalarQuantizationType.valueOf("ONE_BIT"));
+        assertEquals(ScalarQuantizationType.TWO_BIT, ScalarQuantizationType.valueOf("TWO_BIT"));
+        assertEquals(ScalarQuantizationType.FOUR_BIT, ScalarQuantizationType.valueOf("FOUR_BIT"));
+    }
+
+    public void testUniqueSQTypeValues() {
+        Set<Integer> uniqueIds = new HashSet<>();
+        for (ScalarQuantizationType type : ScalarQuantizationType.values()) {
+            boolean added = uniqueIds.add(type.getId());
+            assertTrue("Duplicate value found: " + type.getId(), added);
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/quantization/factory/QuantizerFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/quantization/factory/QuantizerFactoryTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.quantization.factory;
+
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
+import org.opensearch.knn.quantization.models.quantizationParams.ScalarQuantizationParams;
+import org.opensearch.knn.quantization.quantizer.MultiBitScalarQuantizer;
+import org.opensearch.knn.quantization.quantizer.OneBitScalarQuantizer;
+import org.opensearch.knn.quantization.quantizer.Quantizer;
+
+public class QuantizerFactoryTests extends KNNTestCase {
+
+    public void test_Lazy_Registration() {
+        try {
+            ScalarQuantizationParams params = new ScalarQuantizationParams(ScalarQuantizationType.ONE_BIT);
+            ScalarQuantizationParams paramsTwoBit = new ScalarQuantizationParams(ScalarQuantizationType.TWO_BIT);
+            ScalarQuantizationParams paramsFourBit = new ScalarQuantizationParams(ScalarQuantizationType.FOUR_BIT);
+            Quantizer<Float[], Byte[]> oneBitQuantizer = QuantizerFactory.getQuantizer(params);
+            Quantizer<Float[], Byte[]> quantizerTwoBit = QuantizerFactory.getQuantizer(paramsTwoBit);
+            Quantizer<Float[], Byte[]> quantizerFourBit = QuantizerFactory.getQuantizer(paramsFourBit);
+            assertEquals(OneBitScalarQuantizer.class, oneBitQuantizer.getClass());
+            assertEquals(MultiBitScalarQuantizer.class, quantizerTwoBit.getClass());
+            assertEquals(MultiBitScalarQuantizer.class, quantizerFourBit.getClass());
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("already registered"));
+        }
+    }
+
+    public void testGetQuantizer_withNullParams() {
+        try {
+            QuantizerFactory.getQuantizer(null);
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Quantization parameters must not be null.", e.getMessage());
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/quantization/factory/QuantizerRegistryTests.java
+++ b/src/test/java/org/opensearch/knn/quantization/factory/QuantizerRegistryTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.quantization.factory;
+
+import org.junit.BeforeClass;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
+import org.opensearch.knn.quantization.models.quantizationParams.ScalarQuantizationParams;
+import org.opensearch.knn.quantization.quantizer.MultiBitScalarQuantizer;
+import org.opensearch.knn.quantization.quantizer.OneBitScalarQuantizer;
+import org.opensearch.knn.quantization.quantizer.Quantizer;
+
+public class QuantizerRegistryTests extends KNNTestCase {
+
+    @BeforeClass
+    public static void setup() {
+        try {
+            QuantizerRegistry.register(
+                    ScalarQuantizationParams.generateTypeIdentifier(ScalarQuantizationType.ONE_BIT),
+                    new OneBitScalarQuantizer()
+            );
+            QuantizerRegistry.register(
+                    ScalarQuantizationParams.generateTypeIdentifier(ScalarQuantizationType.TWO_BIT),
+                    new MultiBitScalarQuantizer(2)
+            );
+            QuantizerRegistry.register(
+                    ScalarQuantizationParams.generateTypeIdentifier(ScalarQuantizationType.FOUR_BIT),
+                    new MultiBitScalarQuantizer(4)
+            );
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("already registered"));
+        }
+    }
+
+    public void testRegisterAndGetQuantizer() {
+        // Test for OneBitScalarQuantizer
+        ScalarQuantizationParams oneBitParams = new ScalarQuantizationParams(ScalarQuantizationType.ONE_BIT);
+        Quantizer<Float[], Byte[]> oneBitQuantizer = QuantizerRegistry.getQuantizer(oneBitParams);
+        assertEquals(OneBitScalarQuantizer.class, oneBitQuantizer.getClass());
+
+        // Test for MultiBitScalarQuantizer (2-bit)
+        ScalarQuantizationParams twoBitParams = new ScalarQuantizationParams(ScalarQuantizationType.TWO_BIT);
+        Quantizer<Float[], Byte[]> twoBitQuantizer = QuantizerRegistry.getQuantizer(twoBitParams);
+        assertEquals(MultiBitScalarQuantizer.class, twoBitQuantizer.getClass());
+
+        // Test for MultiBitScalarQuantizer (4-bit)
+        ScalarQuantizationParams fourBitParams = new ScalarQuantizationParams(ScalarQuantizationType.FOUR_BIT);
+        Quantizer<Float[], Byte[]> fourBitQuantizer = QuantizerRegistry.getQuantizer(fourBitParams);
+        assertEquals(MultiBitScalarQuantizer.class, fourBitQuantizer.getClass());
+    }
+
+    public void testQuantizerRegistryIsSingleton() {
+        // Ensure the same instance is returned for the same type identifier
+        ScalarQuantizationParams oneBitParams = new ScalarQuantizationParams(ScalarQuantizationType.ONE_BIT);
+        Quantizer<Float[], Byte[]> firstOneBitQuantizer = QuantizerRegistry.getQuantizer(oneBitParams);
+        Quantizer<Float[], Byte[]> secondOneBitQuantizer = QuantizerRegistry.getQuantizer(oneBitParams);
+        assertSame(firstOneBitQuantizer, secondOneBitQuantizer);
+
+        // Ensure the same instance is returned for the same type identifier (2-bit)
+        ScalarQuantizationParams twoBitParams = new ScalarQuantizationParams(ScalarQuantizationType.TWO_BIT);
+        Quantizer<Float[], Byte[]> firstTwoBitQuantizer = QuantizerRegistry.getQuantizer(twoBitParams);
+        Quantizer<Float[], Byte[]> secondTwoBitQuantizer = QuantizerRegistry.getQuantizer(twoBitParams);
+        assertSame(firstTwoBitQuantizer, secondTwoBitQuantizer);
+
+        // Ensure the same instance is returned for the same type identifier (4-bit)
+        ScalarQuantizationParams fourBitParams = new ScalarQuantizationParams(ScalarQuantizationType.FOUR_BIT);
+        Quantizer<Float[], Byte[]> firstFourBitQuantizer = QuantizerRegistry.getQuantizer(fourBitParams);
+        Quantizer<Float[], Byte[]> secondFourBitQuantizer = QuantizerRegistry.getQuantizer(fourBitParams);
+        assertSame(firstFourBitQuantizer, secondFourBitQuantizer);
+    }
+
+    public void testRegisterQuantizerThrowsExceptionWhenAlreadyRegistered() {
+        // Attempt to register the same quantizer again should throw an exception
+        assertThrows(IllegalArgumentException.class, () -> QuantizerRegistry.register(
+                ScalarQuantizationParams.generateTypeIdentifier(ScalarQuantizationType.ONE_BIT),
+                new OneBitScalarQuantizer()
+        ));
+    }
+}

--- a/src/test/java/org/opensearch/knn/quantization/factory/QuantizerRegistryTests.java
+++ b/src/test/java/org/opensearch/knn/quantization/factory/QuantizerRegistryTests.java
@@ -19,16 +19,16 @@ public class QuantizerRegistryTests extends KNNTestCase {
     public static void setup() {
         try {
             QuantizerRegistry.register(
-                    ScalarQuantizationParams.generateTypeIdentifier(ScalarQuantizationType.ONE_BIT),
-                    new OneBitScalarQuantizer()
+                ScalarQuantizationParams.generateTypeIdentifier(ScalarQuantizationType.ONE_BIT),
+                new OneBitScalarQuantizer()
             );
             QuantizerRegistry.register(
-                    ScalarQuantizationParams.generateTypeIdentifier(ScalarQuantizationType.TWO_BIT),
-                    new MultiBitScalarQuantizer(2)
+                ScalarQuantizationParams.generateTypeIdentifier(ScalarQuantizationType.TWO_BIT),
+                new MultiBitScalarQuantizer(2)
             );
             QuantizerRegistry.register(
-                    ScalarQuantizationParams.generateTypeIdentifier(ScalarQuantizationType.FOUR_BIT),
-                    new MultiBitScalarQuantizer(4)
+                ScalarQuantizationParams.generateTypeIdentifier(ScalarQuantizationType.FOUR_BIT),
+                new MultiBitScalarQuantizer(4)
             );
         } catch (Exception e) {
             assertTrue(e.getMessage().contains("already registered"));
@@ -74,9 +74,12 @@ public class QuantizerRegistryTests extends KNNTestCase {
 
     public void testRegisterQuantizerThrowsExceptionWhenAlreadyRegistered() {
         // Attempt to register the same quantizer again should throw an exception
-        assertThrows(IllegalArgumentException.class, () -> QuantizerRegistry.register(
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> QuantizerRegistry.register(
                 ScalarQuantizationParams.generateTypeIdentifier(ScalarQuantizationType.ONE_BIT),
                 new OneBitScalarQuantizer()
-        ));
+            )
+        );
     }
 }

--- a/src/test/java/org/opensearch/knn/quantization/models/quantizationState/QuantizationStateCacheManagerTests.java
+++ b/src/test/java/org/opensearch/knn/quantization/models/quantizationState/QuantizationStateCacheManagerTests.java
@@ -38,7 +38,7 @@ public class QuantizationStateCacheManagerTests extends KNNTestCase {
             Mockito.doNothing().when(quantizationStateCache).addQuantizationState(cacheKey, quantizationState);
             try (MockedStatic<KNN990QuantizationStateReader> mockedStaticReader = Mockito.mockStatic(KNN990QuantizationStateReader.class)) {
                 mockedStaticReader.when(() -> KNN990QuantizationStateReader.read(quantizationStateReadConfig))
-                        .thenReturn(quantizationState);
+                    .thenReturn(quantizationState);
                 QuantizationStateCacheManager.getInstance().getQuantizationState(quantizationStateReadConfig);
                 Mockito.verify(quantizationStateCache, times(1)).addQuantizationState(cacheKey, quantizationState);
             }

--- a/src/test/java/org/opensearch/knn/quantization/models/quantizationState/QuantizationStateCacheManagerTests.java
+++ b/src/test/java/org/opensearch/knn/quantization/models/quantizationState/QuantizationStateCacheManagerTests.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.quantization.models.quantizationState;
+
+import lombok.SneakyThrows;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.codec.KNN990Codec.KNN990QuantizationStateReader;
+
+import static org.mockito.Mockito.times;
+
+public class QuantizationStateCacheManagerTests extends KNNTestCase {
+
+    @SneakyThrows
+    public void testRebuildCache() {
+        try (MockedStatic<QuantizationStateCache> mockedStaticCache = Mockito.mockStatic(QuantizationStateCache.class)) {
+            QuantizationStateCache quantizationStateCache = Mockito.mock(QuantizationStateCache.class);
+            mockedStaticCache.when(QuantizationStateCache::getInstance).thenReturn(quantizationStateCache);
+            Mockito.doNothing().when(quantizationStateCache).rebuildCache();
+            QuantizationStateCacheManager.getInstance().rebuildCache();
+            Mockito.verify(quantizationStateCache, times(1)).rebuildCache();
+        }
+    }
+
+    @SneakyThrows
+    public void testGetQuantizationState() {
+        try (MockedStatic<QuantizationStateCache> mockedStaticCache = Mockito.mockStatic(QuantizationStateCache.class)) {
+            QuantizationStateReadConfig quantizationStateReadConfig = Mockito.mock(QuantizationStateReadConfig.class);
+            String cacheKey = "test-key";
+            Mockito.when(quantizationStateReadConfig.getCacheKey()).thenReturn(cacheKey);
+            QuantizationState quantizationState = Mockito.mock(QuantizationState.class);
+            QuantizationStateCache quantizationStateCache = Mockito.mock(QuantizationStateCache.class);
+            mockedStaticCache.when(QuantizationStateCache::getInstance).thenReturn(quantizationStateCache);
+            Mockito.doNothing().when(quantizationStateCache).addQuantizationState(cacheKey, quantizationState);
+            try (MockedStatic<KNN990QuantizationStateReader> mockedStaticReader = Mockito.mockStatic(KNN990QuantizationStateReader.class)) {
+                mockedStaticReader.when(() -> KNN990QuantizationStateReader.read(quantizationStateReadConfig))
+                        .thenReturn(quantizationState);
+                QuantizationStateCacheManager.getInstance().getQuantizationState(quantizationStateReadConfig);
+                Mockito.verify(quantizationStateCache, times(1)).addQuantizationState(cacheKey, quantizationState);
+            }
+            Mockito.when(quantizationStateCache.getQuantizationState(cacheKey)).thenReturn(quantizationState);
+            QuantizationStateCacheManager.getInstance().getQuantizationState(quantizationStateReadConfig);
+            Mockito.verify(quantizationStateCache, times(1)).addQuantizationState(cacheKey, quantizationState);
+        }
+    }
+
+    @SneakyThrows
+    public void testEvict() {
+        try (MockedStatic<QuantizationStateCache> mockedStaticCache = Mockito.mockStatic(QuantizationStateCache.class)) {
+            String field = "test-field";
+            QuantizationStateCache quantizationStateCache = Mockito.mock(QuantizationStateCache.class);
+            mockedStaticCache.when(QuantizationStateCache::getInstance).thenReturn(quantizationStateCache);
+            Mockito.doNothing().when(quantizationStateCache).evict(field);
+            QuantizationStateCacheManager.getInstance().evict(field);
+            Mockito.verify(quantizationStateCache, times(1)).evict(field);
+        }
+    }
+
+    @SneakyThrows
+    public void testAddQuantizationState() {
+        try (MockedStatic<QuantizationStateCache> mockedStaticCache = Mockito.mockStatic(QuantizationStateCache.class)) {
+            String field = "test-field";
+            QuantizationState quantizationState = Mockito.mock(QuantizationState.class);
+            QuantizationStateCache quantizationStateCache = Mockito.mock(QuantizationStateCache.class);
+            mockedStaticCache.when(QuantizationStateCache::getInstance).thenReturn(quantizationStateCache);
+            Mockito.doNothing().when(quantizationStateCache).addQuantizationState(field, quantizationState);
+            QuantizationStateCacheManager.getInstance().addQuantizationState(field, quantizationState);
+            Mockito.verify(quantizationStateCache, times(1)).addQuantizationState(field, quantizationState);
+        }
+    }
+
+    @SneakyThrows
+    public void testSetMaxCacheSizeInKB() {
+        try (MockedStatic<QuantizationStateCache> mockedStaticCache = Mockito.mockStatic(QuantizationStateCache.class)) {
+            long maxCacheSizeInKB = 1024;
+            QuantizationStateCache quantizationStateCache = Mockito.mock(QuantizationStateCache.class);
+            mockedStaticCache.when(QuantizationStateCache::getInstance).thenReturn(quantizationStateCache);
+            Mockito.doNothing().when(quantizationStateCache).setMaxCacheSizeInKB(maxCacheSizeInKB);
+            QuantizationStateCacheManager.getInstance().setMaxCacheSizeInKB(1024);
+            Mockito.verify(quantizationStateCache, times(1)).setMaxCacheSizeInKB(1024);
+        }
+    }
+
+    @SneakyThrows
+    public void testClear() {
+        try (MockedStatic<QuantizationStateCache> mockedStaticCache = Mockito.mockStatic(QuantizationStateCache.class)) {
+            QuantizationStateCache quantizationStateCache = Mockito.mock(QuantizationStateCache.class);
+            mockedStaticCache.when(QuantizationStateCache::getInstance).thenReturn(quantizationStateCache);
+            Mockito.doNothing().when(quantizationStateCache).clear();
+            QuantizationStateCacheManager.getInstance().clear();
+            Mockito.verify(quantizationStateCache, times(1)).clear();
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/quantization/models/quantizationState/QuantizationStateCacheTests.java
+++ b/src/test/java/org/opensearch/knn/quantization/models/quantizationState/QuantizationStateCacheTests.java
@@ -1,0 +1,492 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.quantization.models.quantizationState;
+
+import com.google.common.collect.ImmutableSet;
+import lombok.SneakyThrows;
+import org.junit.After;
+import org.junit.Before;
+import org.opensearch.transport.client.Client;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.KNNSettings;
+import org.opensearch.knn.quantization.models.quantizationParams.ScalarQuantizationParams;
+import org.opensearch.threadpool.Scheduler;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.knn.index.KNNSettings.QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING;
+import static org.opensearch.knn.index.KNNSettings.QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING;
+import static org.opensearch.knn.quantization.enums.ScalarQuantizationType.ONE_BIT;
+
+public class QuantizationStateCacheTests extends KNNTestCase {
+
+    private ThreadPool threadPool;
+
+    @Before
+    public void setThreadPool() {
+        threadPool = new ThreadPool(Settings.builder().put("node.name", "QuantizationStateCacheTests").build());
+        QuantizationStateCache.setThreadPool(threadPool);
+    }
+
+    @After
+    public void terminateThreadPool() {
+        terminate(threadPool);
+    }
+
+    @SneakyThrows
+    public void testSingleThreadedAddAndRetrieve() {
+        String fieldName = "singleThreadField";
+        QuantizationState state = new OneBitScalarQuantizationState(
+                new ScalarQuantizationParams(ONE_BIT),
+                new float[] { 1.2f, 2.3f, 3.4f }
+        );
+
+        String cacheSize = "10%";
+        TimeValue expiry = TimeValue.timeValueMinutes(30);
+
+        Settings settings = Settings.builder()
+                .put(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize)
+                .put(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING.getKey(), expiry)
+                .build();
+        ClusterSettings clusterSettings = new ClusterSettings(
+                settings,
+                ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+        );
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        when(clusterService.getSettings()).thenReturn(settings);
+
+        QuantizationStateCache cache = QuantizationStateCache.getInstance();
+        clusterService.getClusterSettings().applySettings(settings);
+
+        // Add state
+        cache.addQuantizationState(fieldName, state);
+
+        QuantizationState retrievedState = cache.getQuantizationState(fieldName);
+        assertNotNull("State should be retrieved successfully", retrievedState);
+        assertSame("Retrieved state should be the same instance as the one added", state, retrievedState);
+    }
+
+    @SneakyThrows
+    public void testMultiThreadedAddAndRetrieve() {
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        String fieldName = "multiThreadField";
+        QuantizationState state = new OneBitScalarQuantizationState(
+                new ScalarQuantizationParams(ONE_BIT),
+                new float[] { 1.2f, 2.3f, 3.4f }
+        );
+        String cacheSize = "10%";
+        TimeValue expiry = TimeValue.timeValueMinutes(30);
+
+        Settings settings = Settings.builder()
+                .put(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize)
+                .put(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING.getKey(), expiry)
+                .build();
+        ClusterSettings clusterSettings = new ClusterSettings(
+                settings,
+                ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+        );
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        when(clusterService.getSettings()).thenReturn(settings);
+
+        QuantizationStateCache cache = QuantizationStateCache.getInstance();
+        clusterService.getClusterSettings().applySettings(settings);
+
+        // Add state from multiple threads
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    cache.addQuantizationState(fieldName, state);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        // Wait for all threads to finish
+        latch.await();
+        executorService.shutdown();
+
+        QuantizationState retrievedState = cache.getQuantizationState(fieldName);
+        assertNotNull("State should be retrieved successfully", retrievedState);
+        assertSame("Retrieved state should be the same instance as the one added", state, retrievedState);
+    }
+
+    @SneakyThrows
+    public void testMultiThreadedEvict() {
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        String fieldName = "multiThreadEvictField";
+        QuantizationState state = new OneBitScalarQuantizationState(
+                new ScalarQuantizationParams(ONE_BIT),
+                new float[] { 1.2f, 2.3f, 3.4f }
+        );
+        String cacheSize = "10%";
+        TimeValue expiry = TimeValue.timeValueMinutes(30);
+
+        Settings settings = Settings.builder()
+                .put(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize)
+                .put(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING.getKey(), expiry)
+                .build();
+        ClusterSettings clusterSettings = new ClusterSettings(
+                settings,
+                ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+        );
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        when(clusterService.getSettings()).thenReturn(settings);
+
+        QuantizationStateCache cache = QuantizationStateCache.getInstance();
+
+        clusterService.getClusterSettings().applySettings(settings);
+
+        cache.addQuantizationState(fieldName, state);
+
+        // Evict state from multiple threads
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    cache.evict(fieldName);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        // Wait for all threads to finish
+        latch.await();
+        executorService.shutdown();
+
+        QuantizationState retrievedState = cache.getQuantizationState(fieldName);
+        assertNull("State should be null", retrievedState);
+    }
+
+    @SneakyThrows
+    public void testConcurrentAddAndEvict() {
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        String fieldName = "concurrentAddEvictField";
+        QuantizationState state = new OneBitScalarQuantizationState(
+                new ScalarQuantizationParams(ONE_BIT),
+                new float[] { 1.2f, 2.3f, 3.4f }
+        );
+        String cacheSize = "10%";
+        TimeValue expiry = TimeValue.timeValueMinutes(30);
+
+        Settings settings = Settings.builder()
+                .put(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize)
+                .put(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING.getKey(), expiry)
+                .build();
+        ClusterSettings clusterSettings = new ClusterSettings(
+                settings,
+                ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+        );
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        when(clusterService.getSettings()).thenReturn(settings);
+
+        QuantizationStateCache cache = QuantizationStateCache.getInstance();
+        clusterService.getClusterSettings().applySettings(settings);
+
+        // Concurrently add and evict state from multiple threads
+        for (int i = 0; i < threadCount; i++) {
+            if (i % 2 == 0) {
+                executorService.submit(() -> {
+                    try {
+                        cache.addQuantizationState(fieldName, state);
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            } else {
+                executorService.submit(() -> {
+                    try {
+                        cache.evict(fieldName);
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+        }
+
+        // Wait for all threads to finish
+        latch.await();
+        executorService.shutdown();
+
+        // Since operations are concurrent, we can't be sure of the final state, but we can assert that the cache handles it gracefully
+        QuantizationState retrievedState = cache.getQuantizationState(fieldName);
+        assertTrue("Final state should be either null or the added state", retrievedState == null || retrievedState == state);
+    }
+
+    @SneakyThrows
+    public void testMultipleThreadedCacheClear() {
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        String fieldName = "multiThreadField";
+        QuantizationState state = new OneBitScalarQuantizationState(
+                new ScalarQuantizationParams(ONE_BIT),
+                new float[] { 1.2f, 2.3f, 3.4f }
+        );
+        String cacheSize = "10%";
+        TimeValue expiry = TimeValue.timeValueMinutes(30);
+
+        Settings settings = Settings.builder()
+                .put(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize)
+                .put(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING.getKey(), expiry)
+                .build();
+        ClusterSettings clusterSettings = new ClusterSettings(
+                settings,
+                ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+        );
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        when(clusterService.getSettings()).thenReturn(settings);
+
+        QuantizationStateCache cache = QuantizationStateCache.getInstance();
+        clusterService.getClusterSettings().applySettings(settings);
+        cache.addQuantizationState(fieldName, state);
+
+        // Clear cache from multiple threads
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    cache.clear();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        // Wait for all threads to finish
+        latch.await();
+        executorService.shutdown();
+
+        QuantizationState retrievedState = cache.getQuantizationState(fieldName);
+        assertNull("State should be null", retrievedState);
+    }
+
+    @SneakyThrows
+    public void testRebuild() {
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        String fieldName = "rebuildField";
+        QuantizationState state = new OneBitScalarQuantizationState(
+                new ScalarQuantizationParams(ONE_BIT),
+                new float[] { 1.2f, 2.3f, 3.4f }
+        );
+        String cacheSize = "10%";
+        TimeValue expiry = TimeValue.timeValueMinutes(30);
+
+        Settings settings = Settings.builder()
+                .put(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize)
+                .put(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING.getKey(), expiry)
+                .build();
+        ClusterSettings clusterSettings = new ClusterSettings(
+                settings,
+                ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+        );
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        when(clusterService.getSettings()).thenReturn(settings);
+
+        QuantizationStateCache cache = QuantizationStateCache.getInstance();
+        cache.addQuantizationState(fieldName, state);
+
+        // Rebuild cache from multiple threads
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    cache.rebuildCache();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        // Wait for all threads to finish
+        latch.await();
+        executorService.shutdown();
+
+        QuantizationState retrievedState = cache.getQuantizationState(fieldName);
+        assertNull("State should be null", retrievedState);
+    }
+
+    @SneakyThrows
+    public void testRebuildOnCacheSizeSettingsChange() {
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        String fieldName = "rebuildField";
+        QuantizationState state = new OneBitScalarQuantizationState(
+                new ScalarQuantizationParams(ONE_BIT),
+                new float[] { 1.2f, 2.3f, 3.4f }
+        );
+
+        Settings settings = Settings.builder().build();
+        ClusterSettings clusterSettings = new ClusterSettings(
+                settings,
+                ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+        );
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        when(clusterService.getSettings()).thenReturn(settings);
+
+        Client client = mock(Client.class);
+
+        KNNSettings.state().initialize(client, clusterService);
+
+        QuantizationStateCache cache = QuantizationStateCache.getInstance();
+        cache.rebuildCache();
+        long maxCacheSizeInKB = cache.getMaxCacheSizeInKB();
+        cache.addQuantizationState(fieldName, state);
+
+        String newCacheSize = "10%";
+
+        Settings newSettings = Settings.builder().put(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING.getKey(), newCacheSize).build();
+
+        // Rebuild cache from multiple threads
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    clusterService.getClusterSettings().applySettings(newSettings);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        // Wait for all threads to finish
+        latch.await();
+        executorService.shutdown();
+
+        QuantizationState retrievedState = cache.getQuantizationState(fieldName);
+        assertNull("State should be null", retrievedState);
+        assertNotEquals(maxCacheSizeInKB, cache.getMaxCacheSizeInKB());
+    }
+
+    @SneakyThrows
+    public void testRebuildOnTimeExpirySettingsChange() {
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        String fieldName = "rebuildField";
+        QuantizationState state = new OneBitScalarQuantizationState(
+                new ScalarQuantizationParams(ONE_BIT),
+                new float[] { 1.2f, 2.3f, 3.4f }
+        );
+
+        Settings settings = Settings.builder().build();
+        ClusterSettings clusterSettings = new ClusterSettings(
+                settings,
+                ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+        );
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        when(clusterService.getSettings()).thenReturn(settings);
+
+        Client client = mock(Client.class);
+
+        KNNSettings.state().initialize(client, clusterService);
+
+        QuantizationStateCache cache = QuantizationStateCache.getInstance();
+        cache.addQuantizationState(fieldName, state);
+
+        TimeValue newExpiry = TimeValue.timeValueMinutes(30);
+
+        Settings newSettings = Settings.builder().put(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING.getKey(), newExpiry).build();
+
+        // Rebuild cache from multiple threads
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    clusterService.getClusterSettings().applySettings(newSettings);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        // Wait for all threads to finish
+        latch.await();
+        executorService.shutdown();
+
+        QuantizationState retrievedState = cache.getQuantizationState(fieldName);
+        assertNull("State should be null", retrievedState);
+    }
+
+    public void testCacheEvictionDueToSize() throws IOException {
+        String fieldName = "evictionField";
+        // States have size of slightly over 500 bytes so that adding two will reach the max size of 1 kb for the cache
+        int arrayLength = 112;
+        float[] arr = new float[arrayLength];
+        float[] arr2 = new float[arrayLength];
+        for (int i = 0; i < arrayLength; i++) {
+            arr[i] = i;
+            arr[i] = i + 1;
+        }
+        QuantizationState state = new OneBitScalarQuantizationState(new ScalarQuantizationParams(ONE_BIT), arr);
+        QuantizationState state2 = new OneBitScalarQuantizationState(new ScalarQuantizationParams(ONE_BIT), arr2);
+        long cacheSize = 1;
+        Settings settings = Settings.builder().build();
+        ClusterSettings clusterSettings = new ClusterSettings(
+                settings,
+                ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+        );
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        when(clusterService.getSettings()).thenReturn(settings);
+
+        QuantizationStateCache cache = new QuantizationStateCache();
+        cache.setMaxCacheSizeInKB(cacheSize);
+        cache.rebuildCache();
+        cache.addQuantizationState(fieldName, state);
+        cache.addQuantizationState(fieldName, state2);
+        cache.clear();
+        cache.close();
+        assertNotNull(cache.getEvictedDueToSizeAt());
+    }
+
+    public void testMaintenanceScheduled() throws Exception {
+        QuantizationStateCache quantizationStateCache = new QuantizationStateCache();
+        Scheduler.Cancellable maintenanceTask = quantizationStateCache.getMaintenanceTask();
+
+        assertNotNull(maintenanceTask);
+
+        quantizationStateCache.close();
+        assertTrue(maintenanceTask.isCancelled());
+    }
+
+    public void testMaintenanceWithRebuild() throws Exception {
+        QuantizationStateCache quantizationStateCache = new QuantizationStateCache();
+        Scheduler.Cancellable task1 = quantizationStateCache.getMaintenanceTask();
+        assertNotNull(task1);
+
+        quantizationStateCache.rebuildCache();
+
+        Scheduler.Cancellable task2 = quantizationStateCache.getMaintenanceTask();
+        assertTrue(task1.isCancelled());
+        assertNotNull(task2);
+        quantizationStateCache.close();
+    }
+}

--- a/src/test/java/org/opensearch/knn/quantization/models/quantizationState/QuantizationStateCacheTests.java
+++ b/src/test/java/org/opensearch/knn/quantization/models/quantizationState/QuantizationStateCacheTests.java
@@ -50,20 +50,20 @@ public class QuantizationStateCacheTests extends KNNTestCase {
     public void testSingleThreadedAddAndRetrieve() {
         String fieldName = "singleThreadField";
         QuantizationState state = new OneBitScalarQuantizationState(
-                new ScalarQuantizationParams(ONE_BIT),
-                new float[] { 1.2f, 2.3f, 3.4f }
+            new ScalarQuantizationParams(ONE_BIT),
+            new float[] { 1.2f, 2.3f, 3.4f }
         );
 
         String cacheSize = "10%";
         TimeValue expiry = TimeValue.timeValueMinutes(30);
 
         Settings settings = Settings.builder()
-                .put(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize)
-                .put(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING.getKey(), expiry)
-                .build();
+            .put(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize)
+            .put(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING.getKey(), expiry)
+            .build();
         ClusterSettings clusterSettings = new ClusterSettings(
-                settings,
-                ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+            settings,
+            ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
         );
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
@@ -87,19 +87,19 @@ public class QuantizationStateCacheTests extends KNNTestCase {
         CountDownLatch latch = new CountDownLatch(threadCount);
         String fieldName = "multiThreadField";
         QuantizationState state = new OneBitScalarQuantizationState(
-                new ScalarQuantizationParams(ONE_BIT),
-                new float[] { 1.2f, 2.3f, 3.4f }
+            new ScalarQuantizationParams(ONE_BIT),
+            new float[] { 1.2f, 2.3f, 3.4f }
         );
         String cacheSize = "10%";
         TimeValue expiry = TimeValue.timeValueMinutes(30);
 
         Settings settings = Settings.builder()
-                .put(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize)
-                .put(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING.getKey(), expiry)
-                .build();
+            .put(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize)
+            .put(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING.getKey(), expiry)
+            .build();
         ClusterSettings clusterSettings = new ClusterSettings(
-                settings,
-                ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+            settings,
+            ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
         );
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
@@ -135,19 +135,19 @@ public class QuantizationStateCacheTests extends KNNTestCase {
         CountDownLatch latch = new CountDownLatch(threadCount);
         String fieldName = "multiThreadEvictField";
         QuantizationState state = new OneBitScalarQuantizationState(
-                new ScalarQuantizationParams(ONE_BIT),
-                new float[] { 1.2f, 2.3f, 3.4f }
+            new ScalarQuantizationParams(ONE_BIT),
+            new float[] { 1.2f, 2.3f, 3.4f }
         );
         String cacheSize = "10%";
         TimeValue expiry = TimeValue.timeValueMinutes(30);
 
         Settings settings = Settings.builder()
-                .put(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize)
-                .put(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING.getKey(), expiry)
-                .build();
+            .put(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize)
+            .put(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING.getKey(), expiry)
+            .build();
         ClusterSettings clusterSettings = new ClusterSettings(
-                settings,
-                ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+            settings,
+            ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
         );
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
@@ -185,19 +185,19 @@ public class QuantizationStateCacheTests extends KNNTestCase {
         CountDownLatch latch = new CountDownLatch(threadCount);
         String fieldName = "concurrentAddEvictField";
         QuantizationState state = new OneBitScalarQuantizationState(
-                new ScalarQuantizationParams(ONE_BIT),
-                new float[] { 1.2f, 2.3f, 3.4f }
+            new ScalarQuantizationParams(ONE_BIT),
+            new float[] { 1.2f, 2.3f, 3.4f }
         );
         String cacheSize = "10%";
         TimeValue expiry = TimeValue.timeValueMinutes(30);
 
         Settings settings = Settings.builder()
-                .put(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize)
-                .put(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING.getKey(), expiry)
-                .build();
+            .put(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize)
+            .put(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING.getKey(), expiry)
+            .build();
         ClusterSettings clusterSettings = new ClusterSettings(
-                settings,
-                ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+            settings,
+            ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
         );
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
@@ -244,19 +244,19 @@ public class QuantizationStateCacheTests extends KNNTestCase {
         CountDownLatch latch = new CountDownLatch(threadCount);
         String fieldName = "multiThreadField";
         QuantizationState state = new OneBitScalarQuantizationState(
-                new ScalarQuantizationParams(ONE_BIT),
-                new float[] { 1.2f, 2.3f, 3.4f }
+            new ScalarQuantizationParams(ONE_BIT),
+            new float[] { 1.2f, 2.3f, 3.4f }
         );
         String cacheSize = "10%";
         TimeValue expiry = TimeValue.timeValueMinutes(30);
 
         Settings settings = Settings.builder()
-                .put(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize)
-                .put(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING.getKey(), expiry)
-                .build();
+            .put(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize)
+            .put(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING.getKey(), expiry)
+            .build();
         ClusterSettings clusterSettings = new ClusterSettings(
-                settings,
-                ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+            settings,
+            ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
         );
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
@@ -292,19 +292,19 @@ public class QuantizationStateCacheTests extends KNNTestCase {
         CountDownLatch latch = new CountDownLatch(threadCount);
         String fieldName = "rebuildField";
         QuantizationState state = new OneBitScalarQuantizationState(
-                new ScalarQuantizationParams(ONE_BIT),
-                new float[] { 1.2f, 2.3f, 3.4f }
+            new ScalarQuantizationParams(ONE_BIT),
+            new float[] { 1.2f, 2.3f, 3.4f }
         );
         String cacheSize = "10%";
         TimeValue expiry = TimeValue.timeValueMinutes(30);
 
         Settings settings = Settings.builder()
-                .put(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize)
-                .put(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING.getKey(), expiry)
-                .build();
+            .put(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize)
+            .put(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING.getKey(), expiry)
+            .build();
         ClusterSettings clusterSettings = new ClusterSettings(
-                settings,
-                ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+            settings,
+            ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
         );
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
@@ -339,14 +339,14 @@ public class QuantizationStateCacheTests extends KNNTestCase {
         CountDownLatch latch = new CountDownLatch(threadCount);
         String fieldName = "rebuildField";
         QuantizationState state = new OneBitScalarQuantizationState(
-                new ScalarQuantizationParams(ONE_BIT),
-                new float[] { 1.2f, 2.3f, 3.4f }
+            new ScalarQuantizationParams(ONE_BIT),
+            new float[] { 1.2f, 2.3f, 3.4f }
         );
 
         Settings settings = Settings.builder().build();
         ClusterSettings clusterSettings = new ClusterSettings(
-                settings,
-                ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+            settings,
+            ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
         );
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
@@ -392,14 +392,14 @@ public class QuantizationStateCacheTests extends KNNTestCase {
         CountDownLatch latch = new CountDownLatch(threadCount);
         String fieldName = "rebuildField";
         QuantizationState state = new OneBitScalarQuantizationState(
-                new ScalarQuantizationParams(ONE_BIT),
-                new float[] { 1.2f, 2.3f, 3.4f }
+            new ScalarQuantizationParams(ONE_BIT),
+            new float[] { 1.2f, 2.3f, 3.4f }
         );
 
         Settings settings = Settings.builder().build();
         ClusterSettings clusterSettings = new ClusterSettings(
-                settings,
-                ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+            settings,
+            ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
         );
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
@@ -450,8 +450,8 @@ public class QuantizationStateCacheTests extends KNNTestCase {
         long cacheSize = 1;
         Settings settings = Settings.builder().build();
         ClusterSettings clusterSettings = new ClusterSettings(
-                settings,
-                ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+            settings,
+            ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
         );
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);

--- a/src/test/java/org/opensearch/knn/quantization/output/BinaryQuantizationOutputTests.java
+++ b/src/test/java/org/opensearch/knn/quantization/output/BinaryQuantizationOutputTests.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.quantization.output;
+
+import org.junit.Before;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.quantization.models.quantizationOutput.BinaryQuantizationOutput;
+
+public class BinaryQuantizationOutputTests extends KNNTestCase {
+
+    private static final int BITS_PER_COORDINATE = 1;
+    private BinaryQuantizationOutput quantizationOutput;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        quantizationOutput = new BinaryQuantizationOutput(BITS_PER_COORDINATE);
+    }
+
+    public void testPrepareQuantizedVector_ShouldInitializeCorrectly_WhenVectorLengthIsValid() {
+        // Arrange
+        int vectorLength = 10;
+
+        // Act
+        quantizationOutput.prepareQuantizedVector(vectorLength);
+
+        // Assert
+        assertNotNull(quantizationOutput.getQuantizedVector());
+    }
+
+    public void testPrepareQuantizedVector_ShouldThrowException_WhenVectorLengthIsZeroOrNegative() {
+        // Act and Assert
+        expectThrows(IllegalArgumentException.class, () -> quantizationOutput.prepareQuantizedVector(0));
+        expectThrows(IllegalArgumentException.class, () -> quantizationOutput.prepareQuantizedVector(-1));
+    }
+
+    public void testIsPrepared_ShouldReturnTrue_WhenCalledWithSameVectorLength() {
+        // Arrange
+        int vectorLength = 8;
+        quantizationOutput.prepareQuantizedVector(vectorLength);
+        // Act and Assert
+        assertTrue(quantizationOutput.isPrepared(vectorLength));
+    }
+
+    public void testIsPrepared_ShouldReturnFalse_WhenCalledWithDifferentVectorLength() {
+        // Arrange
+        int vectorLength = 8;
+        quantizationOutput.prepareQuantizedVector(vectorLength);
+        // Act and Assert
+        assertFalse(quantizationOutput.isPrepared(vectorLength + 1));
+    }
+
+    public void testGetQuantizedVector_ShouldReturnSameReference() {
+        // Arrange
+        int vectorLength = 5;
+        quantizationOutput.prepareQuantizedVector(vectorLength);
+        // Act
+        byte[] vector = quantizationOutput.getQuantizedVector();
+        // Assert
+        assertEquals(vector, quantizationOutput.getQuantizedVector());
+    }
+
+    public void testGetQuantizedVectorCopy_ShouldReturnCopyOfVector() {
+        // Arrange
+        int vectorLength = 5;
+        quantizationOutput.prepareQuantizedVector(vectorLength);
+
+        // Act
+        byte[] vectorCopy = quantizationOutput.getQuantizedVectorCopy();
+
+        // Assert
+        assertNotSame(vectorCopy, quantizationOutput.getQuantizedVector());
+        assertArrayEquals(vectorCopy, quantizationOutput.getQuantizedVector());
+    }
+
+    public void testGetQuantizedVectorCopy_ShouldReturnNewCopyOnEachCall() {
+        // Arrange
+        int vectorLength = 5;
+        quantizationOutput.prepareQuantizedVector(vectorLength);
+
+        // Act
+        byte[] vectorCopy1 = quantizationOutput.getQuantizedVectorCopy();
+        byte[] vectorCopy2 = quantizationOutput.getQuantizedVectorCopy();
+
+        // Assert
+        assertNotSame(vectorCopy1, vectorCopy2);
+    }
+
+    public void testPrepareQuantizedVector_ShouldResetQuantizedVector_WhenCalledWithDifferentLength() {
+        // Arrange
+        int initialLength = 5;
+        int newLength = 10;
+        quantizationOutput.prepareQuantizedVector(initialLength);
+        byte[] initialVector = quantizationOutput.getQuantizedVector();
+
+        // Act
+        quantizationOutput.prepareQuantizedVector(newLength);
+        byte[] newVector = quantizationOutput.getQuantizedVector();
+
+        // Assert
+        assertNotSame(initialVector, newVector); // The array reference should change
+        assertEquals((BITS_PER_COORDINATE * newLength + 7) / 8, newVector.length); // Correct size for new vector
+    }
+
+    public void testPrepareQuantizedVector_ShouldRetainSameArray_WhenCalledWithSameLength() {
+        // Arrange
+        int vectorLength = 5;
+        quantizationOutput.prepareQuantizedVector(vectorLength);
+        byte[] initialVector = quantizationOutput.getQuantizedVector();
+
+        // Act
+        quantizationOutput.prepareQuantizedVector(vectorLength);
+        byte[] newVector = quantizationOutput.getQuantizedVector();
+
+        // Assert
+        assertSame(newVector, initialVector); // The array reference should remain the same
+    }
+}

--- a/src/test/java/org/opensearch/knn/quantization/quantizationState/QuantizationStateSerializerTests.java
+++ b/src/test/java/org/opensearch/knn/quantization/quantizationState/QuantizationStateSerializerTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.quantization.quantizationState;
+
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
+import org.opensearch.knn.quantization.models.quantizationParams.ScalarQuantizationParams;
+import org.opensearch.knn.quantization.models.quantizationState.MultiBitScalarQuantizationState;
+import org.opensearch.knn.quantization.models.quantizationState.OneBitScalarQuantizationState;
+
+import java.io.IOException;
+
+public class QuantizationStateSerializerTests extends KNNTestCase {
+
+    public void testSerializeAndDeserializeOneBitScalarQuantizationState() throws IOException {
+        ScalarQuantizationParams params = new ScalarQuantizationParams(ScalarQuantizationType.ONE_BIT);
+        float[] mean = new float[] { 0.1f, 0.2f, 0.3f };
+        OneBitScalarQuantizationState state = new OneBitScalarQuantizationState(params, mean);
+
+        // Serialize
+        byte[] serialized = state.toByteArray();
+
+        OneBitScalarQuantizationState deserialized = OneBitScalarQuantizationState.fromByteArray(serialized);
+
+        assertArrayEquals(mean, deserialized.getMeanThresholds(), 0.0f);
+        assertEquals(params, deserialized.getQuantizationParams());
+    }
+
+    public void testSerializeAndDeserializeMultiBitScalarQuantizationState() throws IOException {
+        ScalarQuantizationParams params = new ScalarQuantizationParams(ScalarQuantizationType.TWO_BIT);
+        float[][] thresholds = new float[][] { { 0.1f, 0.2f, 0.3f }, { 0.4f, 0.5f, 0.6f } };
+        MultiBitScalarQuantizationState state = new MultiBitScalarQuantizationState(params, thresholds);
+
+        // Serialize
+        byte[] serialized = state.toByteArray();
+        MultiBitScalarQuantizationState deserialized = MultiBitScalarQuantizationState.fromByteArray(serialized);
+
+        for (int i = 0; i < thresholds.length; i++) {
+            assertArrayEquals(thresholds[i], deserialized.getThresholds()[i], 0.0f);
+        }
+        assertEquals(params, deserialized.getQuantizationParams());
+    }
+}

--- a/src/test/java/org/opensearch/knn/quantization/quantizationState/QuantizationStateTests.java
+++ b/src/test/java/org/opensearch/knn/quantization/quantizationState/QuantizationStateTests.java
@@ -87,14 +87,14 @@ public class QuantizationStateTests extends KNNTestCase {
 
         // 3. RAM Usage from RamUsageEstimator
         long expectedRamBytesUsed = RamUsageEstimator.shallowSizeOfInstance(OneBitScalarQuantizationState.class) + RamUsageEstimator
-                .shallowSizeOf(params) + RamUsageEstimator.sizeOf(mean);
+            .shallowSizeOf(params) + RamUsageEstimator.sizeOf(mean);
 
         long actualRamBytesUsed = state.ramBytesUsed();
 
         // Allow a difference between manual estimation, serialization size, and actual RAM usage
         assertTrue(
-                "The difference between manual and actual RAM usage exceeds 8 bytes",
-                Math.abs(manualEstimatedRamBytesUsed - actualRamBytesUsed) <= 8
+            "The difference between manual and actual RAM usage exceeds 8 bytes",
+            Math.abs(manualEstimatedRamBytesUsed - actualRamBytesUsed) <= 8
         );
 
         assertEquals(expectedRamBytesUsed, actualRamBytesUsed);
@@ -117,10 +117,10 @@ public class QuantizationStateTests extends KNNTestCase {
 
         // Case 3: 4 thresholds, each with 7 dimensions (28 bits, should align to 32)
         float[][] thresholds3 = {
-                { 0.5f, 1.5f, 2.5f, 3.5f, 4.5f, 5.5f, 6.5f },
-                { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f },
-                { 1.5f, 2.5f, 3.5f, 4.5f, 5.5f, 6.5f, 7.5f },
-                { 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f } };
+            { 0.5f, 1.5f, 2.5f, 3.5f, 4.5f, 5.5f, 6.5f },
+            { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f },
+            { 1.5f, 2.5f, 3.5f, 4.5f, 5.5f, 6.5f, 7.5f },
+            { 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f } };
         MultiBitScalarQuantizationState state3 = new MultiBitScalarQuantizationState(params, thresholds3);
         int expectedDimensions3 = 32; // The next multiple of 8 considering all bits
         assertEquals(expectedDimensions3, state3.getDimensions());
@@ -195,7 +195,7 @@ public class QuantizationStateTests extends KNNTestCase {
         }
 
         long ramEstimatorRamBytesUsed = RamUsageEstimator.shallowSizeOfInstance(MultiBitScalarQuantizationState.class) + RamUsageEstimator
-                .shallowSizeOf(params) + RamUsageEstimator.shallowSizeOf(thresholds);
+            .shallowSizeOf(params) + RamUsageEstimator.shallowSizeOf(thresholds);
 
         for (float[] row : thresholds) {
             ramEstimatorRamBytesUsed += RamUsageEstimator.sizeOf(row);

--- a/src/test/java/org/opensearch/knn/quantization/quantizationState/QuantizationStateTests.java
+++ b/src/test/java/org/opensearch/knn/quantization/quantizationState/QuantizationStateTests.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.quantization.quantizationState;
+
+import org.apache.lucene.util.RamUsageEstimator;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
+import org.opensearch.knn.quantization.models.quantizationParams.ScalarQuantizationParams;
+import org.opensearch.knn.quantization.models.quantizationState.MultiBitScalarQuantizationState;
+import org.opensearch.knn.quantization.models.quantizationState.OneBitScalarQuantizationState;
+
+import java.io.IOException;
+
+public class QuantizationStateTests extends KNNTestCase {
+
+    public void testOneBitScalarQuantizationStateSerialization() throws IOException {
+        ScalarQuantizationParams params = new ScalarQuantizationParams(ScalarQuantizationType.ONE_BIT);
+        float[] mean = { 1.0f, 2.0f, 3.0f };
+
+        OneBitScalarQuantizationState state = new OneBitScalarQuantizationState(params, mean);
+
+        // Serialize
+        byte[] serializedState = state.toByteArray();
+
+        // Deserialize
+        StreamInput in = StreamInput.wrap(serializedState);
+        OneBitScalarQuantizationState deserializedState = new OneBitScalarQuantizationState(in);
+
+        float delta = 0.0001f;
+        assertArrayEquals(mean, deserializedState.getMeanThresholds(), delta);
+        assertEquals(params.getSqType(), deserializedState.getQuantizationParams().getSqType());
+    }
+
+    public void testMultiBitScalarQuantizationStateSerialization() throws IOException {
+        ScalarQuantizationParams params = new ScalarQuantizationParams(ScalarQuantizationType.TWO_BIT);
+        float[][] thresholds = { { 0.5f, 1.5f, 2.5f }, { 1.0f, 2.0f, 3.0f } };
+
+        MultiBitScalarQuantizationState state = new MultiBitScalarQuantizationState(params, thresholds);
+        byte[] serializedState = state.toByteArray();
+
+        // Deserialize
+        StreamInput in = StreamInput.wrap(serializedState);
+        MultiBitScalarQuantizationState deserializedState = new MultiBitScalarQuantizationState(in);
+
+        float delta = 0.0001f;
+        for (int i = 0; i < thresholds.length; i++) {
+            assertArrayEquals(thresholds[i], deserializedState.getThresholds()[i], delta);
+        }
+        assertEquals(params.getSqType(), deserializedState.getQuantizationParams().getSqType());
+    }
+
+    public void testSerializationWithDifferentVersions() throws IOException {
+        ScalarQuantizationParams params = new ScalarQuantizationParams(ScalarQuantizationType.ONE_BIT);
+        float[] mean = { 1.0f, 2.0f, 3.0f };
+
+        OneBitScalarQuantizationState state = new OneBitScalarQuantizationState(params, mean);
+        byte[] serializedState = state.toByteArray();
+        StreamInput in = StreamInput.wrap(serializedState);
+        OneBitScalarQuantizationState deserializedState = new OneBitScalarQuantizationState(in);
+
+        float delta = 0.0001f;
+        assertArrayEquals(mean, deserializedState.getMeanThresholds(), delta);
+        assertEquals(params.getSqType(), deserializedState.getQuantizationParams().getSqType());
+    }
+
+    public void testOneBitScalarQuantizationStateRamBytesUsed() {
+        ScalarQuantizationParams params = new ScalarQuantizationParams(ScalarQuantizationType.ONE_BIT);
+        float[] mean = { 1.0f, 2.0f, 3.0f };
+
+        OneBitScalarQuantizationState state = new OneBitScalarQuantizationState(params, mean);
+
+        // 1. Manual Calculation of RAM Usage
+        long manualEstimatedRamBytesUsed = 0L;
+
+        // OneBitScalarQuantizationState object overhead for Object Header
+        manualEstimatedRamBytesUsed += alignSize(16L);
+
+        // ScalarQuantizationParams object overhead Object Header
+        manualEstimatedRamBytesUsed += alignSize(16L);
+
+        // Mean array overhead (array header + size of elements)
+        manualEstimatedRamBytesUsed += alignSize(16L + 4L * mean.length);
+
+        // 3. RAM Usage from RamUsageEstimator
+        long expectedRamBytesUsed = RamUsageEstimator.shallowSizeOfInstance(OneBitScalarQuantizationState.class) + RamUsageEstimator
+                .shallowSizeOf(params) + RamUsageEstimator.sizeOf(mean);
+
+        long actualRamBytesUsed = state.ramBytesUsed();
+
+        // Allow a difference between manual estimation, serialization size, and actual RAM usage
+        assertTrue(
+                "The difference between manual and actual RAM usage exceeds 8 bytes",
+                Math.abs(manualEstimatedRamBytesUsed - actualRamBytesUsed) <= 8
+        );
+
+        assertEquals(expectedRamBytesUsed, actualRamBytesUsed);
+    }
+
+    public void testMultiBitScalarQuantizationStateGetDimensions_withDimensionNotMultipleOf8_thenSuccess() {
+        ScalarQuantizationParams params = new ScalarQuantizationParams(ScalarQuantizationType.TWO_BIT);
+
+        // Case 1: 3 thresholds, each with 2 dimensions
+        float[][] thresholds1 = { { 0.5f, 1.5f }, { 1.0f, 2.0f }, { 1.5f, 2.5f } };
+        MultiBitScalarQuantizationState state1 = new MultiBitScalarQuantizationState(params, thresholds1);
+        int expectedDimensions1 = 24; // The next multiple of 8 considering all bits
+        assertEquals(expectedDimensions1, state1.getDimensions());
+
+        // Case 2: 1 threshold, with 5 dimensions (5 bits, should align to 8)
+        float[][] thresholds2 = { { 0.5f, 1.5f, 2.5f, 3.5f, 4.5f } };
+        MultiBitScalarQuantizationState state2 = new MultiBitScalarQuantizationState(params, thresholds2);
+        int expectedDimensions2 = 8; // The next multiple of 8 considering all bits
+        assertEquals(expectedDimensions2, state2.getDimensions());
+
+        // Case 3: 4 thresholds, each with 7 dimensions (28 bits, should align to 32)
+        float[][] thresholds3 = {
+                { 0.5f, 1.5f, 2.5f, 3.5f, 4.5f, 5.5f, 6.5f },
+                { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f },
+                { 1.5f, 2.5f, 3.5f, 4.5f, 5.5f, 6.5f, 7.5f },
+                { 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f } };
+        MultiBitScalarQuantizationState state3 = new MultiBitScalarQuantizationState(params, thresholds3);
+        int expectedDimensions3 = 32; // The next multiple of 8 considering all bits
+        assertEquals(expectedDimensions3, state3.getDimensions());
+
+        // Case 4: 2 thresholds, each with 8 dimensions (16 bits, already aligned)
+        float[][] thresholds4 = { { 0.5f, 1.5f, 2.5f, 3.5f, 4.5f, 5.5f, 6.5f, 7.5f }, { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f } };
+        MultiBitScalarQuantizationState state4 = new MultiBitScalarQuantizationState(params, thresholds4);
+        int expectedDimensions4 = 16; // Already aligned to 8
+        assertEquals(expectedDimensions4, state4.getDimensions());
+
+        // Case 5: 2 thresholds, each with 6 dimensions (12 bits, should align to 16)
+        float[][] thresholds5 = { { 0.5f, 1.5f, 2.5f, 3.5f, 4.5f, 5.5f }, { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f } };
+        MultiBitScalarQuantizationState state5 = new MultiBitScalarQuantizationState(params, thresholds5);
+        int expectedDimensions5 = 16; // The next multiple of 8 considering all bits
+        assertEquals(expectedDimensions5, state5.getDimensions());
+    }
+
+    public void testOneBitScalarQuantizationStateGetDimensions_withDimensionNotMultipleOf8_thenSuccess() {
+        ScalarQuantizationParams params = new ScalarQuantizationParams(ScalarQuantizationType.ONE_BIT);
+
+        // Case 1: 5 dimensions (should align to 8)
+        float[] thresholds1 = { 0.5f, 1.5f, 2.5f, 3.5f, 4.5f };
+        OneBitScalarQuantizationState state1 = new OneBitScalarQuantizationState(params, thresholds1);
+        int expectedDimensions1 = 8; // The next multiple of 8
+        assertEquals(expectedDimensions1, state1.getDimensions());
+
+        // Case 2: 7 dimensions (should align to 8)
+        float[] thresholds2 = { 0.5f, 1.5f, 2.5f, 3.5f, 4.5f, 5.5f, 6.5f };
+        OneBitScalarQuantizationState state2 = new OneBitScalarQuantizationState(params, thresholds2);
+        int expectedDimensions2 = 8; // The next multiple of 8
+        assertEquals(expectedDimensions2, state2.getDimensions());
+
+        // Case 3: 8 dimensions (already aligned to 8)
+        float[] thresholds3 = { 0.5f, 1.5f, 2.5f, 3.5f, 4.5f, 5.5f, 6.5f, 7.5f };
+        OneBitScalarQuantizationState state3 = new OneBitScalarQuantizationState(params, thresholds3);
+        int expectedDimensions3 = 8; // Already aligned to 8
+        assertEquals(expectedDimensions3, state3.getDimensions());
+
+        // Case 4: 10 dimensions (should align to 16)
+        float[] thresholds4 = { 0.5f, 1.5f, 2.5f, 3.5f, 4.5f, 5.5f, 6.5f, 7.5f, 8.5f, 9.5f };
+        OneBitScalarQuantizationState state4 = new OneBitScalarQuantizationState(params, thresholds4);
+        int expectedDimensions4 = 16; // The next multiple of 8
+        assertEquals(expectedDimensions4, state4.getDimensions());
+
+        // Case 5: 16 dimensions (already aligned to 16)
+        float[] thresholds5 = { 0.5f, 1.5f, 2.5f, 3.5f, 4.5f, 5.5f, 6.5f, 7.5f, 8.5f, 9.5f, 10.5f, 11.5f, 12.5f, 13.5f, 14.5f, 15.5f };
+        OneBitScalarQuantizationState state5 = new OneBitScalarQuantizationState(params, thresholds5);
+        int expectedDimensions5 = 16; // Already aligned to 16
+        assertEquals(expectedDimensions5, state5.getDimensions());
+    }
+
+    public void testMultiBitScalarQuantizationStateRamBytesUsedManualCalculation() {
+        ScalarQuantizationParams params = new ScalarQuantizationParams(ScalarQuantizationType.TWO_BIT);
+        float[][] thresholds = { { 0.5f, 1.5f, 2.5f }, { 1.0f, 2.0f, 3.0f } };
+
+        MultiBitScalarQuantizationState state = new MultiBitScalarQuantizationState(params, thresholds);
+
+        // Manually estimate RAM usage with alignment
+        long manualEstimatedRamBytesUsed = 0L;
+
+        // Estimate for MultiBitScalarQuantizationState object
+        manualEstimatedRamBytesUsed += alignSize(16L);  // Example overhead for object
+
+        // Estimate for ScalarQuantizationParams object
+        manualEstimatedRamBytesUsed += alignSize(16L);  // Overhead for params object (including fields)
+
+        // Estimate for thresholds array
+        manualEstimatedRamBytesUsed += alignSize(16L + 4L * thresholds.length);  // Overhead for array + references to sub-arrays
+
+        for (float[] row : thresholds) {
+            manualEstimatedRamBytesUsed += alignSize(16L + 4L * row.length);  // Overhead for each sub-array + size of each float
+        }
+
+        long ramEstimatorRamBytesUsed = RamUsageEstimator.shallowSizeOfInstance(MultiBitScalarQuantizationState.class) + RamUsageEstimator
+                .shallowSizeOf(params) + RamUsageEstimator.shallowSizeOf(thresholds);
+
+        for (float[] row : thresholds) {
+            ramEstimatorRamBytesUsed += RamUsageEstimator.sizeOf(row);
+        }
+
+        long difference = Math.abs(manualEstimatedRamBytesUsed - ramEstimatorRamBytesUsed);
+        assertTrue("The difference between manual and actual RAM usage exceeds 8 bytes", difference <= 8);
+        assertEquals(ramEstimatorRamBytesUsed, state.ramBytesUsed());
+    }
+
+    private long alignSize(long size) {
+        return (size + 7) & ~7;  // Align to 8 bytes boundary
+    }
+
+}

--- a/src/test/java/org/opensearch/knn/quantization/quantizer/MultiBitScalarQuantizerTests.java
+++ b/src/test/java/org/opensearch/knn/quantization/quantizer/MultiBitScalarQuantizerTests.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.quantization.quantizer;
+
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
+import org.opensearch.knn.quantization.models.quantizationOutput.BinaryQuantizationOutput;
+import org.opensearch.knn.quantization.models.quantizationParams.ScalarQuantizationParams;
+import org.opensearch.knn.quantization.models.quantizationState.MultiBitScalarQuantizationState;
+import org.opensearch.knn.quantization.models.quantizationState.QuantizationState;
+import org.opensearch.knn.quantization.models.requests.TrainingRequest;
+
+import java.io.IOException;
+
+public class MultiBitScalarQuantizerTests extends KNNTestCase {
+
+    public void testTrain_twoBit() throws IOException {
+        float[][] vectors = {
+            { 0.5f, 1.5f, 2.5f, 3.5f, 4.5f, 5.5f, 6.5f, 7.5f },
+            { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f },
+            { 1.5f, 2.5f, 3.5f, 4.5f, 5.5f, 6.5f, 7.5f, 8.5f } };
+        MultiBitScalarQuantizer twoBitQuantizer = new MultiBitScalarQuantizer(2);
+        ScalarQuantizationParams params = new ScalarQuantizationParams(ScalarQuantizationType.TWO_BIT);
+        TrainingRequest<float[]> request = new MockTrainingRequest(params, vectors);
+        QuantizationState state = twoBitQuantizer.train(request);
+
+        assertTrue(state instanceof MultiBitScalarQuantizationState);
+        MultiBitScalarQuantizationState mbState = (MultiBitScalarQuantizationState) state;
+        assertNotNull(mbState.getThresholds());
+        assertEquals(2, mbState.getThresholds().length); // 2-bit quantization should have 2 thresholds
+    }
+
+    public void testTrain_fourBit() throws IOException {
+        MultiBitScalarQuantizer fourBitQuantizer = new MultiBitScalarQuantizer(4);
+        float[][] vectors = {
+            { 0.5f, 1.5f, 2.5f, 3.5f, 4.5f, 5.5f, 6.5f, 7.5f },
+            { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f },
+            { 1.5f, 2.5f, 3.5f, 4.5f, 5.5f, 6.5f, 7.5f, 8.5f } };
+        ScalarQuantizationParams params = new ScalarQuantizationParams(ScalarQuantizationType.FOUR_BIT);
+        TrainingRequest<float[]> request = new MockTrainingRequest(params, vectors);
+        QuantizationState state = fourBitQuantizer.train(request);
+
+        assertTrue(state instanceof MultiBitScalarQuantizationState);
+        MultiBitScalarQuantizationState mbState = (MultiBitScalarQuantizationState) state;
+        assertNotNull(mbState.getThresholds());
+        assertEquals(4, mbState.getThresholds().length); // 4-bit quantization should have 4 thresholds
+    }
+
+    public void testQuantize_twoBit() {
+        MultiBitScalarQuantizer twoBitQuantizer = new MultiBitScalarQuantizer(2);
+        float[] vector = { 1.3f, 2.2f, 3.3f, 4.1f, 5.6f, 6.7f, 7.4f, 8.1f };
+        float[][] thresholds = { { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f }, { 1.5f, 2.5f, 3.5f, 4.5f, 5.5f, 6.5f, 7.5f, 8.5f } };
+        ScalarQuantizationParams params = new ScalarQuantizationParams(ScalarQuantizationType.TWO_BIT);
+        MultiBitScalarQuantizationState state = new MultiBitScalarQuantizationState(params, thresholds);
+
+        BinaryQuantizationOutput output = new BinaryQuantizationOutput(2);
+        twoBitQuantizer.quantize(vector, state, output);
+
+        assertNotNull(output.getQuantizedVector());
+    }
+
+    public void testQuantize_fourBit() {
+        MultiBitScalarQuantizer fourBitQuantizer = new MultiBitScalarQuantizer(4);
+        float[] vector = { 1.3f, 2.2f, 3.3f, 4.1f, 5.6f, 6.7f, 7.4f, 8.1f };
+        float[][] thresholds = {
+            { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f },
+            { 1.1f, 2.1f, 3.1f, 4.1f, 5.1f, 6.1f, 7.1f, 8.1f },
+            { 1.2f, 2.2f, 3.2f, 4.2f, 5.2f, 6.2f, 7.2f, 8.2f },
+            { 1.3f, 2.3f, 3.3f, 4.3f, 5.3f, 6.3f, 7.3f, 8.3f } };
+        ScalarQuantizationParams params = new ScalarQuantizationParams(ScalarQuantizationType.FOUR_BIT);
+        MultiBitScalarQuantizationState state = new MultiBitScalarQuantizationState(params, thresholds);
+
+        BinaryQuantizationOutput output = new BinaryQuantizationOutput(4);
+        fourBitQuantizer.quantize(vector, state, output);
+
+        assertNotNull(output.getQuantizedVector());
+    }
+
+    public void testQuantize_withNullVector() {
+        MultiBitScalarQuantizer twoBitQuantizer = new MultiBitScalarQuantizer(2);
+        BinaryQuantizationOutput output = new BinaryQuantizationOutput(2);
+        output.prepareQuantizedVector(8); // Example length
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> twoBitQuantizer.quantize(
+                null,
+                new MultiBitScalarQuantizationState(new ScalarQuantizationParams(ScalarQuantizationType.TWO_BIT), new float[2][8]),
+                output
+            )
+        );
+    }
+
+    public void testQuantize_twoBit_multiple_times() {
+        MultiBitScalarQuantizer twoBitQuantizer = new MultiBitScalarQuantizer(2);
+        float[] vector = { -2.5f, 1.5f, -0.5f, 4.0f, 6.5f, -3.5f, 0.0f, 7.2f };
+        float[][] thresholds = {
+            { -3.0f, 1.0f, -1.0f, 3.5f, 5.0f, -4.0f, 0.5f, 7.0f },
+            { -2.0f, 2.0f, 0.0f, 4.5f, 6.0f, -2.5f, -0.5f, 8.0f } };
+        ScalarQuantizationParams params = new ScalarQuantizationParams(ScalarQuantizationType.TWO_BIT);
+        MultiBitScalarQuantizationState state = new MultiBitScalarQuantizationState(params, thresholds);
+
+        BinaryQuantizationOutput output = new BinaryQuantizationOutput(2);
+
+        // First quantization
+        twoBitQuantizer.quantize(vector, state, output);
+        assertNotNull(output.getQuantizedVector());
+
+        // Save the reference to the byte array
+        byte[] firstByteArray = output.getQuantizedVector();
+
+        // Expected output after the first quantization
+        byte[] expectedPackedBits = new byte[] { (byte) 0b11111101, (byte) 0b00001010 };
+
+        // Check the output value after the first quantization
+        assertArrayEquals(expectedPackedBits, output.getQuantizedVector());
+
+        // Modify vector for a second quantization call
+        vector = new float[] { -2.5f, 1.5f, -0.5f, 4.0f, 6.5f, -3.5f, 0.0f, 7.2f };
+
+        // Second quantization
+        twoBitQuantizer.quantize(vector, state, output);
+
+        // Assert that the same byte array reference is used
+        assertSame(firstByteArray, output.getQuantizedVector());
+
+        // Expected output after the second quantization (based on updated vector)
+        assertArrayEquals(expectedPackedBits, output.getQuantizedVector());
+    }
+
+    public void testQuantize_ReuseByteArray_forMultiBitQuantizer() {
+        MultiBitScalarQuantizer twoBitQuantizer = new MultiBitScalarQuantizer(2);
+        float[] vector = { -2.5f, 1.5f, -0.5f, 4.0f, 6.5f, -3.5f, 0.0f, 7.2f };
+        float[][] thresholds = {
+            { -3.0f, 1.0f, -1.0f, 3.5f, 5.0f, -4.0f, 0.5f, 7.0f },
+            { -2.0f, 2.0f, 0.0f, 4.5f, 6.0f, -2.5f, -0.5f, 8.0f } };
+        ScalarQuantizationParams params = new ScalarQuantizationParams(ScalarQuantizationType.TWO_BIT);
+        MultiBitScalarQuantizationState state = new MultiBitScalarQuantizationState(params, thresholds);
+
+        BinaryQuantizationOutput output = new BinaryQuantizationOutput(2);
+
+        // First quantization
+        twoBitQuantizer.quantize(vector, state, output);
+        byte[] firstByteArray = output.getQuantizedVector();
+
+        // Expected output after the first quantization
+        byte[] expectedPackedBits = new byte[] { (byte) 0b11111101, (byte) 0b00001010 };
+
+        // Check the output value after the first quantization
+        assertArrayEquals(expectedPackedBits, output.getQuantizedVector());
+
+        // Second quantization with the same vector length
+        twoBitQuantizer.quantize(vector, state, output);
+        byte[] secondByteArray = output.getQuantizedVector();
+
+        // Assert that the same byte array reference is used
+        assertSame(firstByteArray, secondByteArray);
+
+        // Check the output value after the second quantization
+        assertArrayEquals(expectedPackedBits, output.getQuantizedVector());
+
+        // Third quantization with the same vector length
+        twoBitQuantizer.quantize(vector, state, output);
+        byte[] thirdByteArray = output.getQuantizedVector();
+
+        // Assert that the same byte array reference is still used
+        assertSame(firstByteArray, thirdByteArray);
+
+        // Check the output value after the third quantization
+        assertArrayEquals(expectedPackedBits, output.getQuantizedVector());
+    }
+
+    public void testQuantize_withMultipleVectors_inLoop() {
+        MultiBitScalarQuantizer twoBitQuantizer = new MultiBitScalarQuantizer(2);
+        float[][] vectors = {
+            { -2.5f, 1.5f, -0.5f, 4.0f, 6.5f, -3.5f, 0.0f, 7.2f },
+            { 2.0f, -1.0f, 3.5f, 0.0f, 5.5f, -2.5f, 1.5f, 6.0f },
+            { -4.0f, 2.0f, -1.5f, 3.5f, -0.5f, 1.0f, 2.5f, -3.0f } };
+        float[][] thresholds = {
+            { -3.0f, 1.0f, -1.0f, 3.5f, 5.0f, -4.0f, 0.5f, 7.0f },
+            { -2.0f, 2.0f, 0.0f, 4.5f, 6.0f, -2.5f, -0.5f, 8.0f } };
+        ScalarQuantizationParams params = new ScalarQuantizationParams(ScalarQuantizationType.TWO_BIT);
+        MultiBitScalarQuantizationState state = new MultiBitScalarQuantizationState(params, thresholds);
+
+        BinaryQuantizationOutput output = new BinaryQuantizationOutput(2);
+
+        byte[] previousByteArray = null;
+        for (float[] vector : vectors) {
+            // Check if output is already prepared before quantization
+            boolean wasPrepared = output.isPrepared(vector.length);
+
+            // Prepare the output for the new vector length
+            output.prepareQuantizedVector(vector.length);
+
+            // Ensure that if it was prepared, it stays the same reference
+            if (wasPrepared) {
+                assertSame(previousByteArray, output.getQuantizedVector());
+            }
+
+            // Perform the quantization
+            twoBitQuantizer.quantize(vector, state, output);
+
+            // Save the reference to the byte array after quantization
+            previousByteArray = output.getQuantizedVector();
+
+            // Check that the output vector is correctly prepared
+            assertTrue(output.isPrepared(vector.length));
+        }
+    }
+
+    // Mock classes for testing
+    private static class MockTrainingRequest extends TrainingRequest<float[]> {
+        private final float[][] vectors;
+
+        public MockTrainingRequest(ScalarQuantizationParams params, float[][] vectors) {
+            super(vectors.length);
+            this.vectors = vectors;
+        }
+
+        @Override
+        public float[] getVectorAtThePosition(int position) {
+            return vectors[position];
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/quantization/quantizer/OneBitScalarQuantizerTests.java
+++ b/src/test/java/org/opensearch/knn/quantization/quantizer/OneBitScalarQuantizerTests.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.quantization.quantizer;
+
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
+import org.opensearch.knn.quantization.models.quantizationOutput.BinaryQuantizationOutput;
+import org.opensearch.knn.quantization.models.quantizationOutput.QuantizationOutput;
+import org.opensearch.knn.quantization.models.quantizationParams.ScalarQuantizationParams;
+import org.opensearch.knn.quantization.models.quantizationState.OneBitScalarQuantizationState;
+import org.opensearch.knn.quantization.models.quantizationState.QuantizationState;
+import org.opensearch.knn.quantization.models.requests.TrainingRequest;
+import org.opensearch.knn.quantization.sampler.Sampler;
+import org.opensearch.knn.quantization.sampler.SamplerType;
+import org.opensearch.knn.quantization.sampler.SamplingFactory;
+
+import java.io.IOException;
+
+public class OneBitScalarQuantizerTests extends KNNTestCase {
+
+    public void testTrain_withTrainingRequired() throws IOException {
+        float[][] vectors = { { 1.0f, 2.0f, 3.0f }, { 4.0f, 5.0f, 6.0f }, { 7.0f, 8.0f, 9.0f } };
+
+        TrainingRequest<float[]> originalRequest = new TrainingRequest<>(vectors.length) {
+            @Override
+            public float[] getVectorAtThePosition(int position) {
+                return vectors[position];
+            }
+        };
+        OneBitScalarQuantizer quantizer = new OneBitScalarQuantizer();
+        QuantizationState state = quantizer.train(originalRequest);
+
+        assertTrue(state instanceof OneBitScalarQuantizationState);
+        float[] meanThresholds = ((OneBitScalarQuantizationState) state).getMeanThresholds();
+        assertArrayEquals(new float[] { 4.0f, 5.0f, 6.0f }, meanThresholds, 0.001f);
+    }
+
+    public void testQuantize_withState() {
+        float[] vector = { 3.0f, 6.0f, 9.0f };
+        float[] thresholds = { 4.0f, 5.0f, 6.0f };
+        OneBitScalarQuantizationState state = new OneBitScalarQuantizationState(
+            new ScalarQuantizationParams(ScalarQuantizationType.ONE_BIT),
+            thresholds
+        );
+
+        OneBitScalarQuantizer quantizer = new OneBitScalarQuantizer();
+        BinaryQuantizationOutput output = new BinaryQuantizationOutput(1);
+
+        quantizer.quantize(vector, state, output);
+
+        assertNotNull(output);
+        byte[] expectedPackedBits = new byte[] { 0b01100000 };  // or 96 in decimal
+        assertArrayEquals(expectedPackedBits, output.getQuantizedVector());
+    }
+
+    public void testQuantize_withNullVector() {
+        OneBitScalarQuantizer quantizer = new OneBitScalarQuantizer();
+        OneBitScalarQuantizationState state = new OneBitScalarQuantizationState(
+            new ScalarQuantizationParams(ScalarQuantizationType.ONE_BIT),
+            new float[] { 0.0f }
+        );
+        BinaryQuantizationOutput output = new BinaryQuantizationOutput(1);
+        expectThrows(IllegalArgumentException.class, () -> quantizer.quantize(null, state, output));
+    }
+
+    public void testQuantize_withInvalidState() throws IOException {
+        OneBitScalarQuantizer quantizer = new OneBitScalarQuantizer();
+        float[] vector = { 1.0f, 2.0f, 3.0f };
+        QuantizationState invalidState = new QuantizationState() {
+            @Override
+            public ScalarQuantizationParams getQuantizationParams() {
+                return new ScalarQuantizationParams(ScalarQuantizationType.ONE_BIT);
+            }
+
+            @Override
+            public int getBytesPerVector() {
+                return 0;
+            }
+
+            @Override
+            public int getDimensions() {
+                return 0;
+            }
+
+            @Override
+            public long ramBytesUsed() {
+                return 0;
+            }
+
+            @Override
+            public byte[] toByteArray() {
+                return new byte[0];
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) {
+                // Empty implementation for test
+            }
+        };
+        BinaryQuantizationOutput output = new BinaryQuantizationOutput(1);
+        expectThrows(IllegalArgumentException.class, () -> quantizer.quantize(vector, invalidState, output));
+    }
+
+    public void testQuantize_withMismatchedDimensions() {
+        OneBitScalarQuantizer quantizer = new OneBitScalarQuantizer();
+        float[] vector = { 1.0f, 2.0f, 3.0f };
+        float[] thresholds = { 4.0f, 5.0f };
+        OneBitScalarQuantizationState state = new OneBitScalarQuantizationState(
+            new ScalarQuantizationParams(ScalarQuantizationType.ONE_BIT),
+            thresholds
+        );
+        QuantizationOutput<byte[]> output = new BinaryQuantizationOutput(1);
+        expectThrows(IllegalArgumentException.class, () -> quantizer.quantize(vector, state, output));
+    }
+
+    public void testCalculateMean() throws IOException {
+        float[][] vectors = { { 1.0f, 2.0f, 3.0f }, { 4.0f, 5.0f, 6.0f }, { 7.0f, 8.0f, 9.0f } };
+
+        TrainingRequest<float[]> samplingRequest = new TrainingRequest<float[]>(vectors.length) {
+            @Override
+            public float[] getVectorAtThePosition(int position) {
+                return vectors[position];
+            }
+        };
+
+        Sampler sampler = SamplingFactory.getSampler(SamplerType.RESERVOIR);
+        int[] sampledIndices = sampler.sample(vectors.length, 3);
+        float[] meanThresholds = QuantizerHelper.calculateMeanThresholds(samplingRequest, sampledIndices);
+        assertArrayEquals(new float[] { 4.0f, 5.0f, 6.0f }, meanThresholds, 0.001f);
+    }
+
+    public void testCalculateMean_withNullVector() {
+        float[][] vectors = { { 1.0f, 2.0f, 3.0f }, null, { 7.0f, 8.0f, 9.0f } };
+
+        TrainingRequest<float[]> samplingRequest = new TrainingRequest<>(vectors.length) {
+            @Override
+            public float[] getVectorAtThePosition(int position) {
+                return vectors[position];
+            }
+        };
+
+        Sampler sampler = SamplingFactory.getSampler(SamplerType.RESERVOIR);
+        int[] sampledIndices = sampler.sample(vectors.length, 3);
+        expectThrows(IllegalArgumentException.class, () -> QuantizerHelper.calculateMeanThresholds(samplingRequest, sampledIndices));
+    }
+
+    public void testQuantize_withState_multiple_times() {
+        float[] vector = { 3.0f, 6.0f, 9.0f };
+        float[] thresholds = { 4.0f, 5.0f, 6.0f };
+        OneBitScalarQuantizationState state = new OneBitScalarQuantizationState(
+            new ScalarQuantizationParams(ScalarQuantizationType.ONE_BIT),
+            thresholds
+        );
+
+        OneBitScalarQuantizer quantizer = new OneBitScalarQuantizer();
+        BinaryQuantizationOutput output = new BinaryQuantizationOutput(1);
+
+        // First quantization
+        quantizer.quantize(vector, state, output);
+        assertNotNull(output);
+        byte[] expectedPackedBits = new byte[] { 0b01100000 };  // or 96 in decimal
+        assertArrayEquals(expectedPackedBits, output.getQuantizedVector());
+
+        // Save the reference to the byte array
+        byte[] firstByteArray = output.getQuantizedVector();
+
+        // Modify vector and thresholds for a second quantization call
+        vector = new float[] { 7.0f, 8.0f, 9.0f };
+        thresholds = new float[] { 6.0f, 7.0f, 8.0f };
+        state = new OneBitScalarQuantizationState(new ScalarQuantizationParams(ScalarQuantizationType.ONE_BIT), thresholds);
+
+        // Second quantization
+        output.prepareQuantizedVector(vector.length);  // Ensure it is prepared for the new vector
+        quantizer.quantize(vector, state, output);
+
+        // Assert that the same byte array reference is used
+        assertSame(firstByteArray, output.getQuantizedVector());
+
+        // Check the new output
+        expectedPackedBits = new byte[] { (byte) 0b11100000 };  // or 224 in decimal
+        assertArrayEquals(expectedPackedBits, output.getQuantizedVector());
+    }
+
+    public void testQuantize_ReuseByteArray() {
+        float[] vector = { 3.0f, 6.0f, 9.0f };
+        float[] thresholds = { 4.0f, 5.0f, 6.0f };
+        OneBitScalarQuantizationState state = new OneBitScalarQuantizationState(
+            new ScalarQuantizationParams(ScalarQuantizationType.ONE_BIT),
+            thresholds
+        );
+
+        OneBitScalarQuantizer quantizer = new OneBitScalarQuantizer();
+        BinaryQuantizationOutput output = new BinaryQuantizationOutput(1);
+        output.prepareQuantizedVector(vector.length);
+
+        // First quantization
+        quantizer.quantize(vector, state, output);
+        byte[] firstByteArray = output.getQuantizedVector();
+
+        // Second quantization with the same vector length
+        output.prepareQuantizedVector(vector.length);  // Reuse the prepared output
+        byte[] secondByteArray = output.getQuantizedVector();
+
+        // Assert that the same byte array reference is used
+        assertSame(firstByteArray, secondByteArray);
+
+        // Third quantization with the same vector length
+        output.prepareQuantizedVector(vector.length);  // Reuse the prepared output again
+        quantizer.quantize(vector, state, output);
+        byte[] thirdByteArray = output.getQuantizedVector();
+
+        // Assert that the same byte array reference is still used
+        assertSame(firstByteArray, thirdByteArray);
+    }
+
+    public void testQuantize_withMultipleVectors_inLoop() {
+        OneBitScalarQuantizer oneBitQuantizer = new OneBitScalarQuantizer();
+        float[][] vectors = { { 1.0f, 2.0f, 3.0f, 4.0f }, { 2.0f, 3.0f, 4.0f, 5.0f }, { 1.5f, 2.5f, 3.5f, 4.5f } };
+        float[] thresholds = { 1.5f, 2.5f, 3.5f, 4.5f };
+
+        ScalarQuantizationParams params = new ScalarQuantizationParams(ScalarQuantizationType.ONE_BIT);
+        OneBitScalarQuantizationState state = new OneBitScalarQuantizationState(params, thresholds);
+
+        BinaryQuantizationOutput output = new BinaryQuantizationOutput(1);
+
+        byte[] previousByteArray = null;
+        for (float[] vector : vectors) {
+            // Check if output is already prepared before quantization
+            boolean wasPrepared = output.isPrepared(vector.length);
+
+            // Prepare the output for the new vector length
+            output.prepareQuantizedVector(vector.length);
+
+            // Ensure that if it was prepared, it stays the same reference
+            if (wasPrepared) {
+                assertSame(previousByteArray, output.getQuantizedVector());
+            }
+
+            // Perform the quantization
+            oneBitQuantizer.quantize(vector, state, output);
+
+            // Save the reference to the byte array after quantization
+            previousByteArray = output.getQuantizedVector();
+
+            // Check that the output vector is correctly prepared
+            assertTrue(output.isPrepared(vector.length));
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/quantization/quantizer/QuantizerHelperTests.java
+++ b/src/test/java/org/opensearch/knn/quantization/quantizer/QuantizerHelperTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.quantization.quantizer;
+
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
+import org.opensearch.knn.quantization.models.quantizationParams.ScalarQuantizationParams;
+import org.opensearch.knn.quantization.models.requests.TrainingRequest;
+import oshi.util.tuples.Pair;
+
+import java.io.IOException;
+
+public class QuantizerHelperTests extends KNNTestCase {
+
+    public void testCalculateMeanAndStdDev() throws IOException {
+        float[][] vectors = { { 1f, 2f }, { 3f, 4f }, { 5f, 6f } };
+        ScalarQuantizationParams params = new ScalarQuantizationParams(ScalarQuantizationType.ONE_BIT);
+        TrainingRequest<float[]> request = new MockTrainingRequest(params, vectors);
+        int[] sampledIndices = { 0, 1, 2 };
+
+        Pair<float[], float[]> result = QuantizerHelper.calculateMeanAndStdDev(request, sampledIndices);
+
+        assertArrayEquals(new float[] { 3f, 4f }, result.getA(), 0.01f);
+        assertArrayEquals(new float[] { (float) Math.sqrt(8f / 3), (float) Math.sqrt(8f / 3) }, result.getB(), 0.01f);
+    }
+
+    private static class MockTrainingRequest extends TrainingRequest<float[]> {
+        private final float[][] vectors;
+
+        public MockTrainingRequest(ScalarQuantizationParams params, float[][] vectors) {
+            super(vectors.length);
+            this.vectors = vectors;
+        }
+
+        @Override
+        public float[] getVectorAtThePosition(int position) {
+            return vectors[position];
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/quantization/sampler/ReservoirSamplerTests.java
+++ b/src/test/java/org/opensearch/knn/quantization/sampler/ReservoirSamplerTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.quantization.sampler;
+
+import org.opensearch.knn.KNNTestCase;
+
+import java.util.Arrays;
+import java.util.stream.IntStream;
+
+public class ReservoirSamplerTests extends KNNTestCase {
+
+    public void testSampleLessThanSampleSize() {
+        ReservoirSampler sampler = ReservoirSampler.getInstance();
+        int totalNumberOfVectors = 5;
+        int sampleSize = 10;
+        int[] sampledIndices = sampler.sample(totalNumberOfVectors, sampleSize);
+        int[] expectedIndices = IntStream.range(0, totalNumberOfVectors).toArray();
+        assertArrayEquals("Sampled indices should include all available indices.", expectedIndices, sampledIndices);
+    }
+
+    public void testSampleEqualToSampleSize() {
+        ReservoirSampler sampler = ReservoirSampler.getInstance();
+        int totalNumberOfVectors = 10;
+        int sampleSize = 10;
+        int[] sampledIndices = sampler.sample(totalNumberOfVectors, sampleSize);
+        int[] expectedIndices = IntStream.range(0, totalNumberOfVectors).toArray();
+        assertArrayEquals("Sampled indices should include all available indices.", expectedIndices, sampledIndices);
+    }
+
+    public void testSampleRandomness() {
+        ReservoirSampler sampler1 = ReservoirSampler.getInstance();
+        ReservoirSampler sampler2 = ReservoirSampler.getInstance();
+        int totalNumberOfVectors = 100;
+        int sampleSize = 10;
+
+        int[] sampledIndices1 = sampler1.sample(totalNumberOfVectors, sampleSize);
+        int[] sampledIndices2 = sampler2.sample(totalNumberOfVectors, sampleSize);
+
+        // It's unlikely but possible for the two samples to be equal, so we just check they are sorted correctly
+        Arrays.sort(sampledIndices1);
+        Arrays.sort(sampledIndices2);
+        assertFalse("Sampled indices should be different", Arrays.equals(sampledIndices1, sampledIndices2));
+    }
+
+    public void testEdgeCaseZeroVectors() {
+        ReservoirSampler sampler = ReservoirSampler.getInstance();
+        int totalNumberOfVectors = 0;
+        int sampleSize = 10;
+        int[] sampledIndices = sampler.sample(totalNumberOfVectors, sampleSize);
+        assertEquals("Sampled indices should be empty when there are zero vectors.", 0, sampledIndices.length);
+    }
+
+    public void testEdgeCaseZeroSampleSize() {
+        ReservoirSampler sampler = ReservoirSampler.getInstance();
+        int totalNumberOfVectors = 10;
+        int sampleSize = 0;
+        int[] sampledIndices = sampler.sample(totalNumberOfVectors, sampleSize);
+        assertEquals("Sampled indices should be empty when sample size is zero.", 0, sampledIndices.length);
+    }
+}

--- a/src/test/java/org/opensearch/knn/quantization/sampler/SamplingFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/quantization/sampler/SamplingFactoryTests.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.quantization.sampler;
+
+import org.opensearch.knn.KNNTestCase;
+
+public class SamplingFactoryTests extends KNNTestCase {
+    public void testGetSampler_withReservoir() {
+        Sampler sampler = SamplingFactory.getSampler(SamplerType.RESERVOIR);
+        assertTrue(sampler instanceof ReservoirSampler);
+    }
+
+    public void testGetSampler_withUnsupportedType() {
+        expectThrows(NullPointerException.class, () -> SamplingFactory.getSampler(null)); // This should throw an exception
+    }
+}

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
### Description
Migrate tests from https://github.com/opensearch-project/k-NN/tree/main/src/test/java/org/opensearch/knn/quantization.  

Based on previous versions (from 30/06/2025) - https://github.com/opensearch-project/k-NN/commit/134a4107b572be9a44e4e10d74fe8e0c9f8c22ce#diff-34bbb4c0b12ee5437160c283d2b670203ab520d94820f823229f5b5f2dae780a

Coverage:
<img width="1283" height="205" alt="image" src="https://github.com/user-attachments/assets/fbd35c49-8aca-41d4-b1cd-29f4cf9defe1" />


### Related Issues
https://github.com/opensearch-project/opensearch-jvector/issues/425

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
