### PR TITLE
test: migrated query subpackage Parser tests

### DIFF
--- a/src/test/java/org/opensearch/knn/index/KNNClusterTestUtils.java
+++ b/src/test/java/org/opensearch/knn/index/KNNClusterTestUtils.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index;
+
+import org.opensearch.Version;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.cluster.service.ClusterService;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Collection of util methods required for testing and related to OpenSearch cluster setup and functionality
+ */
+public class KNNClusterTestUtils {
+
+    /**
+     * Create new mock for ClusterService
+     * @param version min version for cluster nodes
+     * @return
+     */
+    public static ClusterService mockClusterService(final Version version) {
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterState clusterState = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(clusterState);
+        DiscoveryNodes discoveryNodes = mock(DiscoveryNodes.class);
+        when(clusterState.getNodes()).thenReturn(discoveryNodes);
+        when(discoveryNodes.getMinNodeVersion()).thenReturn(version);
+        return clusterService;
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/query/parser/KNNQueryBuilderParserTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/parser/KNNQueryBuilderParserTests.java
@@ -1,0 +1,595 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query.parser;
+
+import org.opensearch.Version;
+import org.opensearch.cluster.ClusterModule;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.ParsingException;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.query.rescore.RescoreContext;
+import org.opensearch.knn.index.util.KNNClusterUtil;
+import org.opensearch.knn.index.query.KNNQueryBuilder;
+import org.opensearch.plugins.SearchPlugin;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
+import static org.opensearch.index.query.AbstractQueryBuilder.BOOST_FIELD;
+import static org.opensearch.knn.index.KNNClusterTestUtils.mockClusterService;
+import static org.opensearch.knn.index.query.KNNQueryBuilder.NAME;
+import static org.opensearch.knn.index.query.KNNQueryBuilder.EF_SEARCH_FIELD;
+import static org.opensearch.knn.index.query.parser.RescoreParser.RESCORE_OVERSAMPLE_PARAMETER;
+import static org.opensearch.knn.index.query.parser.RescoreParser.RESCORE_PARAMETER;
+
+import static org.mockito.Mockito.mock;
+
+public class KNNQueryBuilderParserTests extends KNNTestCase {
+
+    private static final String FIELD_NAME = "myvector";
+    private static final int K = 1;
+    private static final int EF_SEARCH = 10;
+    private static final Map<String, ?> HNSW_METHOD_PARAMS = Map.of("ef_search", EF_SEARCH);
+    private static final Float MAX_DISTANCE = 1.0f;
+    private static final Float MIN_SCORE = 0.5f;
+    private static final Float BOOST = 10.5f;
+    private static final TermQueryBuilder TERM_QUERY = QueryBuilders.termQuery("field", "value");
+
+    public void testFromXContent() throws Exception {
+        float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
+        KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder().fieldName(FIELD_NAME).vector(queryVector).k(K).build();
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.startObject(knnQueryBuilder.fieldName());
+        builder.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), knnQueryBuilder.vector());
+        builder.field(KNNQueryBuilder.K_FIELD.getPreferredName(), knnQueryBuilder.getK());
+        builder.endObject();
+        builder.endObject();
+        XContentParser contentParser = createParser(builder);
+        contentParser.nextToken();
+        KNNQueryBuilder actualBuilder = KNNQueryBuilderParser.fromXContent(contentParser);
+        assertEquals(knnQueryBuilder, actualBuilder);
+    }
+
+    public void testFromXContent_KnnWithMethodParameters() throws Exception {
+        float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
+        KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .k(K)
+            .methodParameters(HNSW_METHOD_PARAMS)
+            .build();
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.startObject(knnQueryBuilder.fieldName());
+        builder.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), knnQueryBuilder.vector());
+        builder.field(KNNQueryBuilder.K_FIELD.getPreferredName(), knnQueryBuilder.getK());
+        builder.startObject(org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER);
+        builder.field(EF_SEARCH_FIELD.getPreferredName(), EF_SEARCH);
+        builder.endObject();
+        builder.endObject();
+        builder.endObject();
+        XContentParser contentParser = createParser(builder);
+        contentParser.nextToken();
+        KNNQueryBuilder actualBuilder = KNNQueryBuilderParser.fromXContent(contentParser);
+        assertEquals(knnQueryBuilder, actualBuilder);
+    }
+
+    public void testFromXContent_whenDoRadiusSearch_whenDistanceThreshold_whenMethodParameter_thenSucceed() throws Exception {
+        float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
+        KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .maxDistance(MAX_DISTANCE)
+            .methodParameters(HNSW_METHOD_PARAMS)
+            .build();
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.startObject(knnQueryBuilder.fieldName());
+        builder.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), knnQueryBuilder.vector());
+        builder.field(KNNQueryBuilder.MAX_DISTANCE_FIELD.getPreferredName(), knnQueryBuilder.getMaxDistance());
+        builder.startObject(org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER);
+        builder.field(EF_SEARCH_FIELD.getPreferredName(), EF_SEARCH);
+        builder.endObject();
+        builder.endObject();
+        builder.endObject();
+        XContentParser contentParser = createParser(builder);
+        contentParser.nextToken();
+        KNNQueryBuilder actualBuilder = KNNQueryBuilderParser.fromXContent(contentParser);
+        assertEquals(knnQueryBuilder, actualBuilder);
+    }
+
+    public void testFromXContent_whenDoRadiusSearch_whenScoreThreshold_whenMethodParameter_thenSucceed() throws Exception {
+        float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
+        KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .minScore(MAX_DISTANCE)
+            .methodParameters(HNSW_METHOD_PARAMS)
+            .build();
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.startObject(knnQueryBuilder.fieldName());
+        builder.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), knnQueryBuilder.vector());
+        builder.field(KNNQueryBuilder.MIN_SCORE_FIELD.getPreferredName(), knnQueryBuilder.getMinScore());
+        builder.startObject(org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER);
+        builder.field(EF_SEARCH_FIELD.getPreferredName(), EF_SEARCH);
+        builder.endObject();
+        builder.endObject();
+        builder.endObject();
+        XContentParser contentParser = createParser(builder);
+        contentParser.nextToken();
+        KNNQueryBuilder actualBuilder = KNNQueryBuilderParser.fromXContent(contentParser);
+        assertEquals(knnQueryBuilder, actualBuilder);
+    }
+
+    public void testFromXContent_withFilter() throws Exception {
+        final ClusterService clusterService = mockClusterService(Version.CURRENT);
+
+        final KNNClusterUtil knnClusterUtil = KNNClusterUtil.instance();
+        knnClusterUtil.initialize(clusterService, mock(IndexNameExpressionResolver.class));
+
+        float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
+        KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .k(K)
+            .filter(TERM_QUERY)
+            .build();
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.startObject(knnQueryBuilder.fieldName());
+        builder.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), knnQueryBuilder.vector());
+        builder.field(KNNQueryBuilder.K_FIELD.getPreferredName(), knnQueryBuilder.getK());
+        builder.field(KNNQueryBuilder.FILTER_FIELD.getPreferredName(), knnQueryBuilder.getFilter());
+        builder.endObject();
+        builder.endObject();
+        XContentParser contentParser = createParser(builder);
+        contentParser.nextToken();
+        KNNQueryBuilder actualBuilder = KNNQueryBuilderParser.fromXContent(contentParser);
+        assertEquals(knnQueryBuilder, actualBuilder);
+    }
+
+    public void testFromXContent_KnnWithEfSearch_withFilter() throws Exception {
+        float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
+        KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .k(K)
+            .filter(TERM_QUERY)
+            .methodParameters(HNSW_METHOD_PARAMS)
+            .build();
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.startObject(knnQueryBuilder.fieldName());
+        builder.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), knnQueryBuilder.vector());
+        builder.field(KNNQueryBuilder.K_FIELD.getPreferredName(), knnQueryBuilder.getK());
+        builder.startObject(org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER);
+        builder.field(EF_SEARCH_FIELD.getPreferredName(), EF_SEARCH);
+        builder.endObject();
+        builder.field(KNNQueryBuilder.FILTER_FIELD.getPreferredName(), knnQueryBuilder.getFilter());
+        builder.endObject();
+        builder.endObject();
+        XContentParser contentParser = createParser(builder);
+        contentParser.nextToken();
+        KNNQueryBuilder actualBuilder = KNNQueryBuilderParser.fromXContent(contentParser);
+        assertEquals(knnQueryBuilder, actualBuilder);
+    }
+
+    public void testFromXContent_whenDoRadiusSearch_whenDistanceThreshold_whenFilter_thenSucceed() throws Exception {
+        final ClusterService clusterService = mockClusterService(Version.CURRENT);
+
+        final KNNClusterUtil knnClusterUtil = KNNClusterUtil.instance();
+        knnClusterUtil.initialize(clusterService, mock(IndexNameExpressionResolver.class));
+
+        float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
+        KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .maxDistance(MAX_DISTANCE)
+            .filter(TERM_QUERY)
+            .build();
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.startObject(knnQueryBuilder.fieldName());
+        builder.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), knnQueryBuilder.vector());
+        builder.field(KNNQueryBuilder.MAX_DISTANCE_FIELD.getPreferredName(), knnQueryBuilder.getMaxDistance());
+        builder.field(KNNQueryBuilder.FILTER_FIELD.getPreferredName(), knnQueryBuilder.getFilter());
+        builder.endObject();
+        builder.endObject();
+        XContentParser contentParser = createParser(builder);
+        contentParser.nextToken();
+        KNNQueryBuilder actualBuilder = KNNQueryBuilderParser.fromXContent(contentParser);
+        assertEquals(knnQueryBuilder, actualBuilder);
+    }
+
+    public void testFromXContent_whenDoRadiusSearch_whenScoreThreshold_whenFilter_thenSucceed() throws Exception {
+        final ClusterService clusterService = mockClusterService(Version.CURRENT);
+
+        final KNNClusterUtil knnClusterUtil = KNNClusterUtil.instance();
+        knnClusterUtil.initialize(clusterService, mock(IndexNameExpressionResolver.class));
+
+        float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
+        KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .minScore(MIN_SCORE)
+            .filter(TERM_QUERY)
+            .build();
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.startObject(knnQueryBuilder.fieldName());
+        builder.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), knnQueryBuilder.vector());
+        builder.field(KNNQueryBuilder.MIN_SCORE_FIELD.getPreferredName(), knnQueryBuilder.getMinScore());
+        builder.field(KNNQueryBuilder.FILTER_FIELD.getPreferredName(), knnQueryBuilder.getFilter());
+        builder.endObject();
+        builder.endObject();
+        XContentParser contentParser = createParser(builder);
+        contentParser.nextToken();
+        KNNQueryBuilder actualBuilder = KNNQueryBuilderParser.fromXContent(contentParser);
+        assertEquals(knnQueryBuilder, actualBuilder);
+    }
+
+    public void testFromXContent_InvalidQueryVectorType() throws Exception {
+        final ClusterService clusterService = mockClusterService(Version.CURRENT);
+
+        final KNNClusterUtil knnClusterUtil = KNNClusterUtil.instance();
+        knnClusterUtil.initialize(clusterService, mock(IndexNameExpressionResolver.class));
+
+        List<Object> invalidTypeQueryVector = new ArrayList<>();
+        invalidTypeQueryVector.add(1.5);
+        invalidTypeQueryVector.add(2.5);
+        invalidTypeQueryVector.add("a");
+        invalidTypeQueryVector.add(null);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.startObject(FIELD_NAME);
+        builder.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), invalidTypeQueryVector);
+        builder.field(KNNQueryBuilder.K_FIELD.getPreferredName(), K);
+        builder.endObject();
+        builder.endObject();
+        XContentParser contentParser = createParser(builder);
+        contentParser.nextToken();
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> KNNQueryBuilderParser.fromXContent(contentParser)
+        );
+        assertTrue(exception.getMessage(), exception.getMessage().contains("[knn] failed to parse field [vector]"));
+    }
+
+    public void testFromXContent_whenDoRadiusSearch_whenInputInvalidQueryVectorType_thenException() throws Exception {
+        final ClusterService clusterService = mockClusterService(Version.CURRENT);
+
+        final KNNClusterUtil knnClusterUtil = KNNClusterUtil.instance();
+        knnClusterUtil.initialize(clusterService, mock(IndexNameExpressionResolver.class));
+
+        List<Object> invalidTypeQueryVector = new ArrayList<>();
+        invalidTypeQueryVector.add(1.5);
+        invalidTypeQueryVector.add(2.5);
+        invalidTypeQueryVector.add("a");
+        invalidTypeQueryVector.add(null);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.startObject(FIELD_NAME);
+        builder.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), invalidTypeQueryVector);
+        builder.field(KNNQueryBuilder.MAX_DISTANCE_FIELD.getPreferredName(), MAX_DISTANCE);
+        builder.endObject();
+        builder.endObject();
+        XContentParser contentParser = createParser(builder);
+        contentParser.nextToken();
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> KNNQueryBuilderParser.fromXContent(contentParser)
+        );
+        assertTrue(exception.getMessage(), exception.getMessage().contains("[knn] failed to parse field [vector]"));
+    }
+
+    public void testFromXContent_missingQueryVector() throws Exception {
+        final ClusterService clusterService = mockClusterService(Version.CURRENT);
+
+        final KNNClusterUtil knnClusterUtil = KNNClusterUtil.instance();
+        knnClusterUtil.initialize(clusterService, mock(IndexNameExpressionResolver.class));
+
+        // Test without vector field
+        XContentBuilder builderWithoutVectorField = XContentFactory.jsonBuilder();
+        builderWithoutVectorField.startObject();
+        builderWithoutVectorField.startObject(FIELD_NAME);
+        builderWithoutVectorField.field(KNNQueryBuilder.K_FIELD.getPreferredName(), K);
+        builderWithoutVectorField.endObject();
+        builderWithoutVectorField.endObject();
+        XContentParser contentParserWithoutVectorField = createParser(builderWithoutVectorField);
+        contentParserWithoutVectorField.nextToken();
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> KNNQueryBuilderParser.fromXContent(contentParserWithoutVectorField)
+        );
+        assertTrue(exception.getMessage(), exception.getMessage().contains("[knn] requires query vector"));
+
+        // Test empty vector field
+        List<Object> emptyQueryVector = new ArrayList<>();
+        XContentBuilder builderWithEmptyVector = XContentFactory.jsonBuilder();
+        builderWithEmptyVector.startObject();
+        builderWithEmptyVector.startObject(FIELD_NAME);
+        builderWithEmptyVector.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), emptyQueryVector);
+        builderWithEmptyVector.field(KNNQueryBuilder.K_FIELD.getPreferredName(), K);
+        builderWithEmptyVector.endObject();
+        builderWithEmptyVector.endObject();
+        XContentParser contentParserWithEmptyVector = createParser(builderWithEmptyVector);
+        contentParserWithEmptyVector.nextToken();
+        exception = expectThrows(IllegalArgumentException.class, () -> KNNQueryBuilderParser.fromXContent(contentParserWithEmptyVector));
+        assertTrue(exception.getMessage(), exception.getMessage().contains("[knn] failed to parse field [vector]"));
+    }
+
+    public void testFromXContent_rescoreEnabled() throws Exception {
+        float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
+        RescoreContext explicitRescoreContext = RescoreContext.builder().oversampleFactor(1.5f).build();
+        // Test with default rescore
+        KNNQueryBuilder knnQueryBuilderDefaultRescore = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .k(K)
+            .rescoreContext(RescoreContext.getDefault())
+            .build();
+        XContentBuilder builderDefaultRescore = XContentFactory.jsonBuilder();
+        builderDefaultRescore.startObject();
+        builderDefaultRescore.startObject(knnQueryBuilderDefaultRescore.fieldName());
+        builderDefaultRescore.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), knnQueryBuilderDefaultRescore.vector());
+        builderDefaultRescore.field(KNNQueryBuilder.K_FIELD.getPreferredName(), knnQueryBuilderDefaultRescore.getK());
+        builderDefaultRescore.field(KNNQueryBuilder.RESCORE_FIELD.getPreferredName(), true);
+        builderDefaultRescore.endObject();
+        builderDefaultRescore.endObject();
+        XContentParser contentParserDefaultRescore = createParser(builderDefaultRescore);
+        contentParserDefaultRescore.nextToken();
+        KNNQueryBuilder actualBuilderDefaultRescore = KNNQueryBuilderParser.fromXContent(contentParserDefaultRescore);
+        assertEquals(knnQueryBuilderDefaultRescore, actualBuilderDefaultRescore);
+
+        // Test with explicit rescore
+        KNNQueryBuilder knnQueryBuilderExplicitRescore = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .k(K)
+            .rescoreContext(explicitRescoreContext)
+            .build();
+        XContentBuilder builderExplicitRescore = XContentFactory.jsonBuilder();
+        builderExplicitRescore.startObject();
+        builderExplicitRescore.startObject(knnQueryBuilderExplicitRescore.fieldName());
+        builderExplicitRescore.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), knnQueryBuilderExplicitRescore.vector());
+        builderExplicitRescore.field(KNNQueryBuilder.K_FIELD.getPreferredName(), knnQueryBuilderExplicitRescore.getK());
+        builderExplicitRescore.startObject(KNNQueryBuilder.RESCORE_FIELD.getPreferredName());
+        builderExplicitRescore.field(
+            KNNQueryBuilder.RESCORE_OVERSAMPLE_FIELD.getPreferredName(),
+            explicitRescoreContext.getOversampleFactor()
+        );
+        builderExplicitRescore.endObject();
+        builderExplicitRescore.endObject();
+        builderExplicitRescore.endObject();
+        XContentParser contentParserExplicitRescore = createParser(builderExplicitRescore);
+        contentParserExplicitRescore.nextToken();
+        KNNQueryBuilder actualBuilderExplicitRescore = KNNQueryBuilderParser.fromXContent(contentParserExplicitRescore);
+        assertEquals(knnQueryBuilderExplicitRescore, actualBuilderExplicitRescore);
+    }
+
+    public void testFromXContent_rescoreDisabled() throws Exception {
+        float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
+        // Test with rescore disabled
+        KNNQueryBuilder knnQueryBuilderRescoreDisabled = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .k(K)
+            .rescoreContext(RescoreContext.EXPLICITLY_DISABLED_RESCORE_CONTEXT)
+            .build();
+        XContentBuilder builderRescoreDisabled = XContentFactory.jsonBuilder();
+        builderRescoreDisabled.startObject();
+        builderRescoreDisabled.startObject(knnQueryBuilderRescoreDisabled.fieldName());
+        builderRescoreDisabled.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), knnQueryBuilderRescoreDisabled.vector());
+        builderRescoreDisabled.field(KNNQueryBuilder.K_FIELD.getPreferredName(), knnQueryBuilderRescoreDisabled.getK());
+        builderRescoreDisabled.field(KNNQueryBuilder.RESCORE_FIELD.getPreferredName(), false);
+        builderRescoreDisabled.endObject();
+        builderRescoreDisabled.endObject();
+        XContentParser contentParserRescoreDisabled = createParser(builderRescoreDisabled);
+        contentParserRescoreDisabled.nextToken();
+        KNNQueryBuilder actualBuilderRescoreDisabled = KNNQueryBuilderParser.fromXContent(contentParserRescoreDisabled);
+        assertEquals(knnQueryBuilderRescoreDisabled, actualBuilderRescoreDisabled);
+    }
+
+    public void testFromXContent_whenFlat_thenException() throws Exception {
+        float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.field(FIELD_NAME, queryVector);
+        builder.endObject();
+        XContentParser contentParser = createParser(builder);
+        contentParser.nextToken();
+        Exception exception = expectThrows(IllegalArgumentException.class, () -> KNNQueryBuilderParser.fromXContent(contentParser));
+        assertTrue(exception.getMessage(), exception.getMessage().contains("[knn] requires exactly one of k, distance or score to be set"));
+    }
+
+    public void testFromXContent_whenMultiFields_thenException() throws Exception {
+        float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.startObject(FIELD_NAME + "1");
+        builder.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), queryVector);
+        builder.field(KNNQueryBuilder.K_FIELD.getPreferredName(), K);
+        builder.endObject();
+        builder.startObject(FIELD_NAME + "2");
+        builder.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), queryVector);
+        builder.field(KNNQueryBuilder.K_FIELD.getPreferredName(), K);
+        builder.endObject();
+        builder.endObject();
+        XContentParser contentParser = createParser(builder);
+        contentParser.nextToken();
+        Exception exception = expectThrows(ParsingException.class, () -> KNNQueryBuilderParser.fromXContent(contentParser));
+        assertTrue(exception.getMessage(), exception.getMessage().contains("[knn] query doesn't support multiple fields"));
+    }
+
+    public void testToXContent_whenParamsVectorBoostK_thenSucceed() throws IOException {
+        float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.startObject(NAME);
+        builder.startObject(FIELD_NAME);
+        builder.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), queryVector);
+        builder.field(KNNQueryBuilder.K_FIELD.getPreferredName(), K);
+        builder.field(BOOST_FIELD.getPreferredName(), BOOST);
+        builder.endObject();
+        builder.endObject();
+        builder.endObject();
+
+        KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder().fieldName(FIELD_NAME).vector(queryVector).k(K).boost(BOOST).build();
+        XContentBuilder testBuilder = XContentFactory.jsonBuilder();
+        testBuilder.startObject();
+        KNNQueryBuilderParser.toXContent(testBuilder, EMPTY_PARAMS, knnQueryBuilder);
+        testBuilder.endObject();
+        assertEquals(builder.toString(), testBuilder.toString());
+    }
+
+    public void testToXContent_whenFilter_thenSucceed() throws IOException {
+        float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.startObject(NAME);
+        builder.startObject(FIELD_NAME);
+        builder.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), queryVector);
+        builder.field(KNNQueryBuilder.K_FIELD.getPreferredName(), K);
+        builder.field(KNNQueryBuilder.FILTER_FIELD.getPreferredName(), TERM_QUERY);
+        builder.field(BOOST_FIELD.getPreferredName(), BOOST);
+        builder.endObject();
+        builder.endObject();
+        builder.endObject();
+
+        KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .k(K)
+            .boost(BOOST)
+            .filter(TERM_QUERY)
+            .build();
+        XContentBuilder testBuilder = XContentFactory.jsonBuilder();
+        testBuilder.startObject();
+        KNNQueryBuilderParser.toXContent(testBuilder, EMPTY_PARAMS, knnQueryBuilder);
+        testBuilder.endObject();
+        assertEquals(builder.toString(), testBuilder.toString());
+    }
+
+    public void testToXContent_whenMaxDistance_thenSucceed() throws IOException {
+        float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.startObject(NAME);
+        builder.startObject(FIELD_NAME);
+        builder.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), queryVector);
+        builder.field(KNNQueryBuilder.K_FIELD.getPreferredName(), 0);
+        builder.field(KNNQueryBuilder.MAX_DISTANCE_FIELD.getPreferredName(), MAX_DISTANCE);
+        builder.field(BOOST_FIELD.getPreferredName(), BOOST);
+        builder.endObject();
+        builder.endObject();
+        builder.endObject();
+
+        KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .boost(BOOST)
+            .maxDistance(MAX_DISTANCE)
+            .build();
+        XContentBuilder testBuilder = XContentFactory.jsonBuilder();
+        testBuilder.startObject();
+        KNNQueryBuilderParser.toXContent(testBuilder, EMPTY_PARAMS, knnQueryBuilder);
+        testBuilder.endObject();
+        assertEquals(builder.toString(), testBuilder.toString());
+    }
+
+    public void testToXContent_whenMethodParams_thenSucceed() throws IOException {
+        float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.startObject(NAME);
+        builder.startObject(FIELD_NAME);
+        builder.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), queryVector);
+        builder.field(KNNQueryBuilder.K_FIELD.getPreferredName(), K);
+        builder.startObject(org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER);
+        builder.field(EF_SEARCH_FIELD.getPreferredName(), EF_SEARCH);
+        builder.endObject();
+        builder.field(BOOST_FIELD.getPreferredName(), BOOST);
+        builder.endObject();
+        builder.endObject();
+        builder.endObject();
+
+        KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .boost(BOOST)
+            .k(K)
+            .methodParameters(HNSW_METHOD_PARAMS)
+            .build();
+        XContentBuilder testBuilder = XContentFactory.jsonBuilder();
+        testBuilder.startObject();
+        KNNQueryBuilderParser.toXContent(testBuilder, EMPTY_PARAMS, knnQueryBuilder);
+        testBuilder.endObject();
+        logger.info(builder.toString());
+        logger.info(testBuilder.toString());
+        assertEquals(builder.toString(), testBuilder.toString());
+    }
+
+    public void testToXContent_whenRescore_thenSucceed() throws IOException {
+        float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
+        float oversample = 1.0f;
+        XContentBuilder builderFromObject = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(NAME)
+            .startObject(FIELD_NAME)
+            .field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), queryVector)
+            .field(KNNQueryBuilder.K_FIELD.getPreferredName(), K)
+            .startObject(RESCORE_PARAMETER)
+            .field(RESCORE_OVERSAMPLE_PARAMETER, oversample)
+            .endObject()
+            .field(BOOST_FIELD.getPreferredName(), BOOST)
+            .endObject()
+            .endObject()
+            .endObject();
+
+        KNNQueryBuilder knnQueryBuilderFromObject = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .boost(BOOST)
+            .k(K)
+            .rescoreContext(RescoreContext.builder().oversampleFactor(oversample).build())
+            .build();
+
+        XContentBuilder testBuilder = XContentFactory.jsonBuilder();
+        testBuilder.startObject();
+        KNNQueryBuilderParser.toXContent(testBuilder, EMPTY_PARAMS, knnQueryBuilderFromObject);
+        testBuilder.endObject();
+        assertEquals(builderFromObject.toString(), testBuilder.toString());
+    }
+
+    @Override
+    protected NamedXContentRegistry xContentRegistry() {
+        List<NamedXContentRegistry.Entry> list = ClusterModule.getNamedXWriteables();
+        SearchPlugin.QuerySpec<?> spec = new SearchPlugin.QuerySpec<>(
+            TermQueryBuilder.NAME,
+            TermQueryBuilder::new,
+            TermQueryBuilder::fromXContent
+        );
+        list.add(new NamedXContentRegistry.Entry(QueryBuilder.class, spec.getName(), (p, c) -> spec.getParser().fromXContent(p)));
+        NamedXContentRegistry registry = new NamedXContentRegistry(list);
+        return registry;
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/query/parser/MethodParametersParserTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/parser/MethodParametersParserTests.java
@@ -1,0 +1,97 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.index.query.parser;
+
+import lombok.SneakyThrows;
+import org.opensearch.common.ValidationException;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.ParsingException;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.knn.KNNTestCase;
+
+import java.util.Map;
+
+import static org.opensearch.knn.index.query.parser.MethodParametersParser.doXContent;
+import static org.opensearch.knn.index.query.parser.MethodParametersParser.validateMethodParameters;
+
+public class MethodParametersParserTests extends KNNTestCase {
+
+    public void testValidateMethodParameters() {
+        ValidationException validationException = validateMethodParameters(Map.of("dummy", 0));
+        assertEquals("Validation Failed: 1: dummy is not a valid method parameter;", validationException.getMessage());
+
+        ValidationException validationException2 = validateMethodParameters(Map.of("ef_search", 0));
+        assertTrue(validationException2.getMessage().contains("Validation Failed: 1: ef_search should be greater than 0"));
+
+        ValidationException validationException3 = validateMethodParameters(Map.of("ef_search", 10));
+        assertNull(validationException3);
+
+        ValidationException validationException4 = validateMethodParameters(Map.of("nprobes", 0));
+        assertTrue(validationException4.getMessage().contains("Validation Failed: 1: nprobes should be greater than 0"));
+    }
+
+    @SneakyThrows
+    public void testDoXContent() {
+        Map<String, ?> params = Map.of("ef_search", 10);
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("method_parameters")
+            .field("ef_search", 10)
+            .endObject()
+            .endObject();
+
+        XContentBuilder builder2 = XContentFactory.jsonBuilder().startObject();
+        doXContent(builder2, params);
+        builder2.endObject();
+        assertEquals(builder.toString(), builder2.toString());
+
+        XContentBuilder b3 = XContentFactory.jsonBuilder();
+        XContentBuilder b4 = XContentFactory.jsonBuilder();
+
+        doXContent(b4, null);
+        assertEquals(b3.toString(), b4.toString());
+    }
+
+    @SneakyThrows
+    public void testFromXContent() {
+        // efsearch string
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().field("ef_search", "string").endObject();
+        XContentParser parser1 = createParser(builder);
+        expectThrows(ParsingException.class, () -> MethodParametersParser.fromXContent(parser1));
+
+        // unknown method parameter
+        builder = XContentFactory.jsonBuilder().startObject().field("unknown", "10").endObject();
+        XContentParser parser2 = createParser(builder);
+        expectThrows(ParsingException.class, () -> MethodParametersParser.fromXContent(parser2));
+
+        // Valid
+        builder = XContentFactory.jsonBuilder().startObject().field("ef_search", 10).endObject();
+        XContentParser parser3 = createParser(builder);
+        assertEquals(Map.of("ef_search", 10), MethodParametersParser.fromXContent(parser3));
+
+        // empty map
+        builder = XContentFactory.jsonBuilder().startObject().endObject();
+        XContentParser parser4 = createParser(builder);
+        expectThrows(ParsingException.class, () -> MethodParametersParser.fromXContent(parser4));
+
+        // nprobes string
+        builder = XContentFactory.jsonBuilder().startObject().field("nprobes", "string").endObject();
+        XContentParser parser5 = createParser(builder);
+        expectThrows(ParsingException.class, () -> MethodParametersParser.fromXContent(parser5));
+
+        // nprobes Valid
+        builder = XContentFactory.jsonBuilder().startObject().field("nprobes", 10).endObject();
+        XContentParser parser6 = createParser(builder);
+        assertEquals(Map.of("nprobes", 10), MethodParametersParser.fromXContent(parser6));
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/query/parser/RescoreParserTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/parser/RescoreParserTests.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query.parser;
+
+import lombok.SneakyThrows;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.query.rescore.RescoreContext;
+
+import java.io.IOException;
+
+import static org.opensearch.knn.index.query.parser.RescoreParser.RESCORE_OVERSAMPLE_PARAMETER;
+import static org.opensearch.knn.index.query.parser.RescoreParser.RESCORE_PARAMETER;
+
+public class RescoreParserTests extends KNNTestCase {
+
+    @SneakyThrows
+    public void testStreams() {
+        RescoreContext rescoreContext = RescoreContext.builder().oversampleFactor(RescoreContext.DEFAULT_OVERSAMPLE_FACTOR).build();
+        validateStreams(rescoreContext);
+        validateStreams(null);
+    }
+
+    private void validateStreams(RescoreContext rescoreContext) throws IOException {
+        try (BytesStreamOutput output = new BytesStreamOutput()) {
+            RescoreParser.streamOutput(output, rescoreContext);
+
+            try (StreamInput in = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry())) {
+                RescoreContext parsedRescoreContext = RescoreParser.streamInput(in);
+                assertEquals(rescoreContext, parsedRescoreContext);
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testDoXContent() {
+        float oversample = RescoreContext.MAX_OVERSAMPLE_FACTOR - 1;
+        XContentBuilder expectedBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(RESCORE_PARAMETER)
+            .field(RESCORE_OVERSAMPLE_PARAMETER, oversample)
+            .endObject()
+            .endObject();
+
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        RescoreParser.doXContent(builder, RescoreContext.builder().oversampleFactor(oversample).build());
+        builder.endObject();
+        assertEquals(expectedBuilder.toString(), builder.toString());
+    }
+
+    @SneakyThrows
+    public void testFromXContent_whenValid_thenSucceed() {
+        float oversample1 = RescoreContext.MAX_OVERSAMPLE_FACTOR - 1;
+        XContentBuilder builder1 = XContentFactory.jsonBuilder().startObject().field(RESCORE_OVERSAMPLE_PARAMETER, oversample1).endObject();
+        validateOversample(oversample1, builder1);
+        XContentBuilder builder2 = XContentFactory.jsonBuilder().startObject().endObject();
+        validateOversample(RescoreContext.DEFAULT_OVERSAMPLE_FACTOR, builder2);
+    }
+
+    @SneakyThrows
+    public void testFromXContent_whenInvalid_thenFail() {
+        XContentBuilder invalidParamBuilder = XContentFactory.jsonBuilder().startObject().field("invalid", 0).endObject();
+        expectValidationException(invalidParamBuilder);
+
+        XContentBuilder invalidParamValueBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(RESCORE_OVERSAMPLE_PARAMETER, "c")
+            .endObject();
+        expectValidationException(invalidParamValueBuilder);
+
+        XContentBuilder extraParamBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(RESCORE_OVERSAMPLE_PARAMETER, RescoreContext.MAX_OVERSAMPLE_FACTOR - 1)
+            .field("invalid", 0)
+            .endObject();
+        expectValidationException(extraParamBuilder);
+    }
+
+    private void validateOversample(float expectedOversample, XContentBuilder builder) throws IOException {
+        XContentParser parser = createParser(builder);
+        RescoreContext rescoreContext = RescoreParser.fromXContent(parser);
+        assertEquals(expectedOversample, rescoreContext.getOversampleFactor(), 0.0001);
+    }
+
+    private void expectValidationException(XContentBuilder builder) throws IOException {
+        XContentParser parser = createParser(builder);
+        expectThrows(IllegalArgumentException.class, () -> RescoreParser.fromXContent(parser));
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/query/parser/RescoreValidationTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/parser/RescoreValidationTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query.parser;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import lombok.AllArgsConstructor;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.query.rescore.RescoreContext;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
+import static com.carrotsearch.randomizedtesting.RandomizedTest.$$;
+
+@AllArgsConstructor
+public class RescoreValidationTests extends KNNTestCase {
+
+    private boolean isValid;
+    private RescoreContext rescoreContext;
+
+    @ParametersFactory(argumentFormatting = "isValid:%1$s; rescoreContext:%2$s")
+    public static Collection<Object[]> validParams() {
+        return Arrays.asList(
+            $$(
+                $(true, RescoreContext.builder().build()),
+                $(true, RescoreContext.getDefault()),
+                $(true, RescoreContext.builder().oversampleFactor(RescoreContext.MAX_OVERSAMPLE_FACTOR - 1).build()),
+                $(false, RescoreContext.builder().oversampleFactor(RescoreContext.MAX_OVERSAMPLE_FACTOR + 1).build()),
+                $(false, RescoreContext.builder().oversampleFactor(RescoreContext.MIN_OVERSAMPLE_FACTOR - 1).build())
+            )
+        );
+    }
+
+    public void testValidate() {
+        if (isValid) {
+            assertNull(RescoreParser.validate(rescoreContext));
+        } else {
+            assertNotNull(RescoreParser.validate(rescoreContext));
+        }
+    }
+}


### PR DESCRIPTION
### Description
[Describe what this change achieves]

- `KNNClusterTestUtils` Added latest test utils class from `k-NN`
- `KNNQueryBuilderParserTests` - picked up latest version for migration from `k-NN`
- `MethodParametersParserTests` - picked up latest version for migration from `k-NN`
- `RescoreParserTests` - picked up latest version for migration from `k-NN`
- `RescoreValidationTests` - picked up latest version for migration from `k-NN`


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->
https://github.com/opensearch-project/opensearch-jvector/issues/441
Parent issue: https://github.com/opensearch-project/opensearch-jvector/issues/390

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
