### PR TITLE
tests: migrated lucene and lucenelib package tests

### DIFF
--- a/src/test/java/org/opensearch/knn/index/query/lucene/LuceneEngineKnnVectorQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/lucene/LuceneEngineKnnVectorQueryTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query.lucene;
+
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Weight;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.opensearch.test.OpenSearchTestCase;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+public class LuceneEngineKnnVectorQueryTests extends OpenSearchTestCase {
+
+    @Mock
+    IndexSearcher indexSearcher;
+
+    @Mock
+    Query luceneQuery;
+
+    @Mock
+    Weight weight;
+
+    @Mock
+    QueryVisitor queryVisitor;
+
+    @Spy
+    @InjectMocks
+    LuceneEngineKnnVectorQuery objectUnderTest;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        openMocks(this);
+        when(luceneQuery.rewrite(any(IndexSearcher.class))).thenReturn(luceneQuery);
+        when(luceneQuery.createWeight(any(IndexSearcher.class), any(ScoreMode.class), anyFloat())).thenReturn(weight);
+    }
+
+    public void testRewrite() {
+        objectUnderTest.rewrite(indexSearcher);
+        objectUnderTest.rewrite(indexSearcher);
+        objectUnderTest.rewrite(indexSearcher);
+        verifyNoInteractions(luceneQuery);
+        verify(objectUnderTest, times(3)).rewrite(indexSearcher);
+    }
+
+    public void testCreateWeight() throws Exception {
+        objectUnderTest.rewrite(indexSearcher);
+        objectUnderTest.rewrite(indexSearcher);
+        objectUnderTest.rewrite(indexSearcher);
+        verifyNoInteractions(luceneQuery);
+        Weight actualWeight = objectUnderTest.createWeight(indexSearcher, ScoreMode.TOP_DOCS, 1.0f);
+        verify(luceneQuery, times(1)).rewrite(indexSearcher);
+        verify(objectUnderTest, times(3)).rewrite(indexSearcher);
+        assertEquals(weight, actualWeight);
+    }
+
+    public void testVisit() {
+        objectUnderTest.visit(queryVisitor);
+        verify(queryVisitor).visitLeaf(objectUnderTest);
+    }
+
+    public void testEquals() {
+        LuceneEngineKnnVectorQuery mainQuery = new LuceneEngineKnnVectorQuery(luceneQuery);
+        LuceneEngineKnnVectorQuery otherQuery = new LuceneEngineKnnVectorQuery(luceneQuery);
+        assertEquals(mainQuery, otherQuery);
+        assertEquals(mainQuery, mainQuery);
+        assertNotEquals(mainQuery, null);
+        assertNotEquals(mainQuery, new Object());
+        LuceneEngineKnnVectorQuery otherQuery2 = new LuceneEngineKnnVectorQuery(null);
+        assertNotEquals(mainQuery, otherQuery2);
+    }
+
+    public void testHashCode() {
+        LuceneEngineKnnVectorQuery mainQuery = new LuceneEngineKnnVectorQuery(luceneQuery);
+        assertEquals(mainQuery.hashCode(), luceneQuery.hashCode());
+    }
+
+    public void testToString() {
+        LuceneEngineKnnVectorQuery mainQuery = new LuceneEngineKnnVectorQuery(luceneQuery);
+        assertEquals(mainQuery.toString(), luceneQuery.toString());
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/query/lucenelib/ExpandNestedEDocsQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/lucenelib/ExpandNestedEDocsQueryTests.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query.lucenelib;
+
+import junit.framework.TestCase;
+import lombok.SneakyThrows;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.FloatPoint;
+import org.apache.lucene.index.*;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.TaskExecutor;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.search.join.BitSetProducer;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.Bits;
+import org.junit.Before;
+import org.mockito.ArgumentCaptor;
+import org.opensearch.knn.index.query.ResultUtil;
+import org.opensearch.knn.index.query.common.QueryUtils;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ExpandNestedEDocsQueryTests extends TestCase {
+    private Executor executor;
+    private TaskExecutor taskExecutor;
+
+    @Before
+    public void setUp() throws Exception {
+        executor = Executors.newSingleThreadExecutor();
+        taskExecutor = new TaskExecutor(executor);
+    }
+
+    @SneakyThrows
+    public void testCreateWeight_whenCalled_thenSucceed() {
+        Directory directory = new ByteBuffersDirectory();
+        IndexWriterConfig config = new IndexWriterConfig();
+        try (IndexWriter writer = new IndexWriter(directory, config)) {
+            // Add documents to simulate multiple segments
+            Document doc1 = new Document();
+            doc1.add(new FloatPoint("vector", 1.0f, 2.0f, 3.0f));
+            writer.addDocument(doc1);
+            Document doc2 = new Document();
+            doc2.add(new FloatPoint("vector", 4.0f, 5.0f, 6.0f));
+            writer.addDocument(doc2);
+            // Force the creation of a second segment
+            writer.flush();
+            Document doc3 = new Document();
+            doc3.add(new FloatPoint("vector", 7.0f, 8.0f, 9.0f));
+            writer.addDocument(doc3);
+            Document doc4 = new Document();
+            doc4.add(new FloatPoint("vector", 10.0f, 11.0f, 12.0f));
+            writer.addDocument(doc4);
+            writer.commit();
+        }
+
+        IndexReader reader = DirectoryReader.open(directory);
+
+        List<LeafReaderContext> leaves = reader.leaves();
+        assertEquals(2, leaves.size()); // Ensure we have two segments
+        LeafReaderContext leaf1 = leaves.get(0);
+        LeafReaderContext leaf2 = leaves.get(1);
+
+        Weight filterWeight = mock(Weight.class);
+
+        IndexSearcher indexSearcher = mock(IndexSearcher.class);
+        when(indexSearcher.getIndexReader()).thenReturn(reader);
+        when(indexSearcher.getTaskExecutor()).thenReturn(taskExecutor);
+        when(indexSearcher.createWeight(any(), eq(ScoreMode.COMPLETE_NO_SCORES), eq(1.0F))).thenReturn(filterWeight);
+
+        Weight queryWeight = mock(Weight.class);
+        ScoreMode scoreMode = mock(ScoreMode.class);
+        float boost = 1.f;
+        Query docAndScoreQuery = mock(Query.class);
+        when(docAndScoreQuery.createWeight(indexSearcher, scoreMode, boost)).thenReturn(queryWeight);
+
+        TopDocs topDocs1 = ResultUtil.resultMapToTopDocs(Map.of(1, 20f), 0);
+        TopDocs topDocs2 = ResultUtil.resultMapToTopDocs(Map.of(0, 21f), 4);
+
+        Query filterQuery = mock(Query.class);
+        BitSetProducer parentFilter = mock(BitSetProducer.class);
+
+        InternalNestedKnnVectorQuery internalQuery = mock(InternalNestedKnnVectorQuery.class);
+        when(internalQuery.knnRewrite(indexSearcher)).thenReturn(docAndScoreQuery);
+        when(internalQuery.getK()).thenReturn(2);
+        when(internalQuery.knnExactSearch(any(), any())).thenReturn(topDocs1, topDocs2);
+        when(internalQuery.getFilter()).thenReturn(filterQuery);
+        when(internalQuery.getField()).thenReturn("field");
+        when(internalQuery.getParentFilter()).thenReturn(parentFilter);
+
+        Map<Integer, Float> initialLeaf1Results = new HashMap<>(Map.of(0, 19f, 1, 20f, 2, 17f, 3, 15f));
+        Map<Integer, Float> initialLeaf2Results = new HashMap<>(Map.of(0, 21f, 1, 18f, 2, 16f, 3, 14f));
+        List<Map<Integer, Float>> perLeafResults = Arrays.asList(initialLeaf1Results, initialLeaf2Results);
+
+        Bits queryFilterBits = mock(Bits.class);
+        DocIdSetIterator allSiblings = mock(DocIdSetIterator.class);
+        when(allSiblings.nextDoc()).thenReturn(1, 2, DocIdSetIterator.NO_MORE_DOCS);
+
+        Weight expectedWeight = mock(Weight.class);
+        TopDocs topK = TopDocs.merge(2, new TopDocs[] { topDocs1, topDocs2 });
+        Query finalQuery = mock(Query.class);
+        when(finalQuery.createWeight(indexSearcher, scoreMode, boost)).thenReturn(expectedWeight);
+
+        QueryUtils queryUtils = mock(QueryUtils.class);
+        when(queryUtils.doSearch(indexSearcher, reader.leaves(), queryWeight)).thenReturn(perLeafResults);
+        when(queryUtils.createBits(any(), any())).thenReturn(queryFilterBits);
+        when(queryUtils.getAllSiblings(any(), any(), any(), any())).thenReturn(allSiblings);
+        when(queryUtils.createDocAndScoreQuery(eq(reader), any())).thenReturn(finalQuery);
+
+        // Run
+        ExpandNestedDocsQuery query = new ExpandNestedDocsQuery(internalQuery, queryUtils);
+        Weight finalWeigh = query.createWeight(indexSearcher, scoreMode, 1.f);
+
+        // Verify
+        assertEquals(expectedWeight, finalWeigh);
+        verify(queryUtils).createBits(leaf1, filterWeight);
+        verify(queryUtils).createBits(leaf2, filterWeight);
+        verify(queryUtils).getAllSiblings(leaf1, perLeafResults.get(0).keySet(), parentFilter, queryFilterBits);
+        verify(queryUtils).getAllSiblings(leaf2, perLeafResults.get(1).keySet(), parentFilter, queryFilterBits);
+        ArgumentCaptor<TopDocs> topDocsCaptor = ArgumentCaptor.forClass(TopDocs.class);
+        verify(queryUtils).createDocAndScoreQuery(eq(reader), topDocsCaptor.capture());
+        TopDocs capturedTopDocs = topDocsCaptor.getValue();
+        assertEquals(topK.totalHits, capturedTopDocs.totalHits);
+        for (int i = 0; i < topK.scoreDocs.length; i++) {
+            assertEquals(topK.scoreDocs[i].doc, capturedTopDocs.scoreDocs[i].doc);
+            assertEquals(topK.scoreDocs[i].score, capturedTopDocs.scoreDocs[i].score, 0.01f);
+            assertEquals(topK.scoreDocs[i].shardIndex, capturedTopDocs.scoreDocs[i].shardIndex);
+        }
+
+        // Verify acceptedDocIds is intersection of allSiblings and filteredDocIds
+        ArgumentCaptor<DocIdSetIterator> iteratorCaptor = ArgumentCaptor.forClass(DocIdSetIterator.class);
+        verify(internalQuery, times(perLeafResults.size())).knnExactSearch(any(), iteratorCaptor.capture());
+        assertEquals(1, iteratorCaptor.getValue().nextDoc());
+        assertEquals(2, iteratorCaptor.getValue().nextDoc());
+        assertEquals(DocIdSetIterator.NO_MORE_DOCS, iteratorCaptor.getValue().nextDoc());
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/query/lucenelib/NestedKnnVectorQueryFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/lucenelib/NestedKnnVectorQueryFactoryTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query.lucenelib;
+
+import junit.framework.TestCase;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.join.BitSetProducer;
+import org.apache.lucene.search.join.DiversifyingChildrenByteKnnVectorQuery;
+import org.apache.lucene.search.join.DiversifyingChildrenFloatKnnVectorQuery;
+
+import static org.mockito.Mockito.mock;
+
+public class NestedKnnVectorQueryFactoryTests extends TestCase {
+    public void testCreate_whenCalled_thenCreateQuery() {
+        String fieldName = "field";
+        byte[] byteVectors = new byte[3];
+        float[] floatVectors = new float[3];
+        int k = 3;
+        Query queryFilter = mock(Query.class);
+        BitSetProducer parentFilter = mock(BitSetProducer.class);
+        boolean expandNestedDocs = true;
+
+        ExpandNestedDocsQuery expectedByteQuery = new ExpandNestedDocsQuery.ExpandNestedDocsQueryBuilder().internalNestedKnnVectorQuery(
+            new InternalNestedKnnByteVectoryQuery(fieldName, byteVectors, queryFilter, k, parentFilter)
+        ).queryUtils(null).build();
+        assertEquals(
+            expectedByteQuery,
+            NestedKnnVectorQueryFactory.createNestedKnnVectorQuery(fieldName, byteVectors, k, queryFilter, parentFilter, expandNestedDocs)
+        );
+
+        ExpandNestedDocsQuery expectedFloatQuery = new ExpandNestedDocsQuery.ExpandNestedDocsQueryBuilder().internalNestedKnnVectorQuery(
+            new InternalNestedKnnFloatVectoryQuery(fieldName, floatVectors, queryFilter, k, parentFilter)
+        ).queryUtils(null).build();
+        assertEquals(
+            expectedFloatQuery,
+            NestedKnnVectorQueryFactory.createNestedKnnVectorQuery(fieldName, floatVectors, k, queryFilter, parentFilter, expandNestedDocs)
+        );
+    }
+
+    public void testCreate_whenNoExpandNestedDocs_thenDiversifyingQuery() {
+        String fieldName = "field";
+        byte[] byteVectors = new byte[3];
+        float[] floatVectors = new float[3];
+        int k = 3;
+        Query queryFilter = mock(Query.class);
+        BitSetProducer parentFilter = mock(BitSetProducer.class);
+        boolean expandNestedDocs = false;
+
+        assertEquals(
+            DiversifyingChildrenByteKnnVectorQuery.class,
+            NestedKnnVectorQueryFactory.createNestedKnnVectorQuery(fieldName, byteVectors, k, queryFilter, parentFilter, expandNestedDocs)
+                .getClass()
+        );
+
+        assertEquals(
+            DiversifyingChildrenFloatKnnVectorQuery.class,
+            NestedKnnVectorQueryFactory.createNestedKnnVectorQuery(fieldName, floatVectors, k, queryFilter, parentFilter, expandNestedDocs)
+                .getClass()
+        );
+    }
+}


### PR DESCRIPTION
### Description
[Describe what this change achieves]

**lucene**
- `LuceneEngineKnnVectorQueryTests` - migrated latest version

**lucenelib**
When I was debugging `k-NN` `lucenelib` package, i found that it is advanced version from a recent refactor done here: https://github.com/opensearch-project/k-NN/pull/3037

Hence, migrated the tests that are compatible with our implementation.
- `ExpandNestedEDocsQueryTests` - migrated forked version
- `NestedKnnVectorQueryFactoryTests` - migrated forked version



### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->
Closes #445 

Parent: #390 


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
