### PR TITLE
test: migrated query common tests

### DIFF
--- a/src/main/java/org/opensearch/knn/index/query/common/QueryUtils.java
+++ b/src/main/java/org/opensearch/knn/index/query/common/QueryUtils.java
@@ -37,6 +37,11 @@ import java.util.concurrent.Callable;
 public class QueryUtils {
     public static QueryUtils INSTANCE = new QueryUtils();
 
+    // Public method to get the singleton instance
+    public static QueryUtils getInstance() {
+        return INSTANCE;
+    }
+
     /**
      * Returns a query that represents the specified TopDocs
      * This is copied from org.apache.lucene.search.AbstractKnnVectorQuery#createRewrittenQuery

--- a/src/main/java/org/opensearch/knn/index/query/common/QueryUtils.java
+++ b/src/main/java/org/opensearch/knn/index/query/common/QueryUtils.java
@@ -37,11 +37,6 @@ import java.util.concurrent.Callable;
 public class QueryUtils {
     public static QueryUtils INSTANCE = new QueryUtils();
 
-    // Public method to get the singleton instance
-    public static QueryUtils getInstance() {
-        return INSTANCE;
-    }
-
     /**
      * Returns a query that represents the specified TopDocs
      * This is copied from org.apache.lucene.search.AbstractKnnVectorQuery#createRewrittenQuery

--- a/src/test/java/org/opensearch/knn/index/query/common/DocAndScoreQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/common/DocAndScoreQueryTests.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query.common;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexReaderContext;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.store.ByteBuffersDirectory;
+
+import org.apache.lucene.tests.analysis.MockAnalyzer;
+import org.mockito.Mock;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+public class DocAndScoreQueryTests extends OpenSearchTestCase {
+
+    @Mock
+    private LeafReaderContext leaf1;
+    @Mock
+    private IndexSearcher indexSearcher;
+    private IndexReaderContext readerContext;
+
+    private DocAndScoreQuery objectUnderTest;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        openMocks(this);
+
+        IndexReader reader = createTestIndexReader();
+        when(indexSearcher.getIndexReader()).thenReturn(reader);
+        readerContext = reader.getContext();
+    }
+
+    // Note: cannot test with multi leaf as there LeafReaderContext is readonly with no getters for some fields to mock
+    public void testScorer() throws Exception {
+        // Given
+        int[] expectedDocs = { 0, 1, 2, 3, 4 };
+        float[] expectedScores = { 0.1f, 1.2f, 2.3f, 5.1f, 3.4f };
+        int[] findSegments = { 0, 2, 5 };
+        objectUnderTest = new DocAndScoreQuery(4, expectedDocs, expectedScores, findSegments, readerContext.id());
+
+        // When
+        Scorer scorer1 = objectUnderTest.createWeight(indexSearcher, ScoreMode.COMPLETE, 1).scorer(leaf1);
+        DocIdSetIterator iterator1 = scorer1.iterator();
+        Scorer scorer2 = objectUnderTest.createWeight(indexSearcher, ScoreMode.COMPLETE, 1).scorer(leaf1);
+        DocIdSetIterator iterator2 = scorer2.iterator();
+
+        int[] actualDocs = new int[2];
+        float[] actualScores = new float[2];
+        int index = 0;
+        while (iterator1.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+            actualDocs[index] = iterator1.docID();
+            actualScores[index] = scorer1.score();
+            ++index;
+        }
+
+        // Then
+        assertEquals(2, iterator1.cost());
+        assertArrayEquals(new int[] { 0, 1 }, actualDocs);
+        assertArrayEquals(new float[] { 0.1f, 1.2f }, actualScores, 0.0001f);
+
+        assertEquals(1.2f, scorer2.getMaxScore(1), 0.0001f);
+        assertEquals(iterator2.advance(1), 1);
+    }
+
+    @SneakyThrows
+    public void testWeight() {
+        // Given
+        int[] expectedDocs = { 0, 1, 2, 3, 4 };
+        float[] expectedScores = { 0.1f, 1.2f, 2.3f, 5.1f, 3.4f };
+        int[] findSegments = { 0, 2, 5 };
+        Explanation expectedExplanation = Explanation.match(1.2f, "within top 4");
+
+        // When
+        objectUnderTest = new DocAndScoreQuery(4, expectedDocs, expectedScores, findSegments, readerContext.id());
+        Weight weight = objectUnderTest.createWeight(indexSearcher, ScoreMode.COMPLETE, 1);
+        Explanation explanation = weight.explain(leaf1, 1);
+
+        // Then
+        assertEquals(objectUnderTest, weight.getQuery());
+        assertTrue(weight.isCacheable(leaf1));
+        assertEquals(2, weight.count(leaf1));
+        assertEquals(expectedExplanation, explanation);
+        assertEquals(Explanation.noMatch("not in top 4"), weight.explain(leaf1, 9));
+    }
+
+    private IndexReader createTestIndexReader() throws IOException {
+        ByteBuffersDirectory directory = new ByteBuffersDirectory();
+        IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig(new MockAnalyzer(random())));
+        writer.addDocument(new Document());
+        writer.close();
+        return DirectoryReader.open(directory);
+    }
+
+}

--- a/src/test/java/org/opensearch/knn/index/query/common/QueryUtilsTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/common/QueryUtilsTests.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query.common;
+
+import junit.framework.TestCase;
+import lombok.SneakyThrows;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.TaskExecutor;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.search.join.BitSetProducer;
+import org.apache.lucene.util.BitSet;
+import org.apache.lucene.util.BitSetIterator;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.FixedBitSet;
+import org.junit.Before;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class QueryUtilsTests extends TestCase {
+    private Executor executor;
+    private TaskExecutor taskExecutor;
+    private QueryUtils queryUtils;
+
+    @Before
+    public void setUp() throws Exception {
+        executor = Executors.newSingleThreadExecutor();
+        taskExecutor = new TaskExecutor(executor);
+        queryUtils = QueryUtils.getInstance();
+    }
+
+    @SneakyThrows
+    public void testDoSearch_whenExecuted_thenSucceed() {
+        IndexSearcher indexSearcher = mock(IndexSearcher.class);
+        when(indexSearcher.getTaskExecutor()).thenReturn(taskExecutor);
+
+        LeafReaderContext leafReaderContext1 = mock(LeafReaderContext.class);
+        LeafReaderContext leafReaderContext2 = mock(LeafReaderContext.class);
+        List<LeafReaderContext> leafReaderContexts = Arrays.asList(leafReaderContext1, leafReaderContext2);
+
+        DocIdSetIterator docIdSetIterator = mock(DocIdSetIterator.class);
+        when(docIdSetIterator.docID()).thenReturn(0, 1, DocIdSetIterator.NO_MORE_DOCS);
+        Scorer scorer = mock(Scorer.class);
+        when(scorer.iterator()).thenReturn(docIdSetIterator);
+        when(scorer.docID()).thenReturn(0, 1, DocIdSetIterator.NO_MORE_DOCS);
+        when(scorer.score()).thenReturn(10.f, 11.f, -1f);
+
+        Weight weight = mock(Weight.class);
+        when(weight.scorer(leafReaderContext1)).thenReturn(null);
+        when(weight.scorer(leafReaderContext2)).thenReturn(scorer);
+
+        // Run
+        List<Map<Integer, Float>> results = queryUtils.doSearch(indexSearcher, leafReaderContexts, weight);
+
+        // Verify
+        assertEquals(2, results.size());
+        assertEquals(0, results.get(0).size());
+        assertEquals(2, results.get(1).size());
+        assertEquals(10.f, results.get(1).get(0));
+        assertEquals(11.f, results.get(1).get(1));
+
+    }
+
+    @SneakyThrows
+    public void testGetAllSiblings_whenEmptyDocIds_thenEmptyIterator() {
+        LeafReaderContext leafReaderContext = mock(LeafReaderContext.class);
+        BitSetProducer bitSetProducer = mock(BitSetProducer.class);
+        Bits bits = mock(Bits.class);
+
+        // Run
+        DocIdSetIterator docIdSetIterator = queryUtils.getAllSiblings(leafReaderContext, Collections.emptySet(), bitSetProducer, bits);
+
+        // Verify
+        assertEquals(DocIdSetIterator.NO_MORE_DOCS, docIdSetIterator.nextDoc());
+    }
+
+    @SneakyThrows
+    public void testGetAllSiblings_whenNonEmptyDocIds_thenReturnAllSiblings() {
+        LeafReaderContext leafReaderContext = mock(LeafReaderContext.class);
+        // 0, 1, 2(parent), 3, 4, 5, 6, 7(parent), 8, 9, 10(parent)
+        BitSet bitSet = new FixedBitSet(new long[1], 11);
+        bitSet.set(2);
+        bitSet.set(7);
+        bitSet.set(10);
+        BitSetProducer bitSetProducer = mock(BitSetProducer.class);
+        when(bitSetProducer.getBitSet(leafReaderContext)).thenReturn(bitSet);
+
+        BitSet filterBits = new FixedBitSet(new long[1], 11);
+        filterBits.set(1);
+        filterBits.set(8);
+        filterBits.set(9);
+
+        // Run
+        Set<Integer> docIds = Set.of(1, 8);
+        DocIdSetIterator docIdSetIterator = queryUtils.getAllSiblings(leafReaderContext, docIds, bitSetProducer, filterBits);
+
+        // Verify
+        Set<Integer> expectedDocIds = Set.of(1, 8, 9);
+        Set<Integer> returnedDocIds = new HashSet<>();
+        docIdSetIterator.nextDoc();
+        while (docIdSetIterator.docID() != DocIdSetIterator.NO_MORE_DOCS) {
+            returnedDocIds.add(docIdSetIterator.docID());
+            docIdSetIterator.nextDoc();
+        }
+        assertEquals(expectedDocIds, returnedDocIds);
+    }
+
+    @SneakyThrows
+    public void testCreateBits_whenWeightIsNull_thenMatchAllBits() {
+        LeafReaderContext leafReaderContext = mock(LeafReaderContext.class);
+
+        // Run
+        Bits bits = queryUtils.createBits(leafReaderContext, null);
+
+        // Verify
+        assertEquals(Bits.MatchAllBits.class, bits.getClass());
+
+    }
+
+    @SneakyThrows
+    public void testCreateBits_whenScoreIsNull_thenMatchNoBits() {
+        LeafReaderContext leafReaderContext = mock(LeafReaderContext.class);
+        Weight weight = mock(Weight.class);
+        when(weight.scorer(leafReaderContext)).thenReturn(null);
+
+        // Run
+        Bits bits = queryUtils.createBits(leafReaderContext, weight);
+
+        // Verify
+        assertEquals(Bits.MatchNoBits.class, bits.getClass());
+    }
+
+    @SneakyThrows
+    public void testCreateBits_whenCalled_thenReturnBits() {
+        FixedBitSet liveDocBitSet = new FixedBitSet(new long[1], 11);
+        liveDocBitSet.set(2);
+        liveDocBitSet.set(7);
+        liveDocBitSet.set(10);
+
+        FixedBitSet matchedBitSet = new FixedBitSet(new long[1], 11);
+        matchedBitSet.set(1);
+        matchedBitSet.set(2);
+        matchedBitSet.set(4);
+        matchedBitSet.set(9);
+        matchedBitSet.set(10);
+
+        BitSetIterator matchedBitSetIterator = new BitSetIterator(matchedBitSet, 5);
+
+        LeafReader leafReader = mock(LeafReader.class);
+        when(leafReader.getLiveDocs()).thenReturn(liveDocBitSet);
+        when(leafReader.maxDoc()).thenReturn(11);
+
+        LeafReaderContext leafReaderContext = mock(LeafReaderContext.class);
+        when(leafReaderContext.reader()).thenReturn(leafReader);
+
+        Scorer scorer = mock(Scorer.class);
+        when(scorer.iterator()).thenReturn(matchedBitSetIterator);
+
+        Weight weight = mock(Weight.class);
+        when(weight.scorer(leafReaderContext)).thenReturn(scorer);
+
+        // Run
+        Bits bits = queryUtils.createBits(leafReaderContext, weight);
+
+        // Verify
+        FixedBitSet expectedBitSet = matchedBitSet.clone();
+        expectedBitSet.and(liveDocBitSet);
+        assertTrue(areSetBitsEqual(expectedBitSet, bits));
+    }
+
+    private boolean areSetBitsEqual(Bits bits1, Bits bits2) {
+        int minLength = Math.min(bits1.length(), bits2.length());
+
+        for (int i = 0; i < minLength; i++) {
+            if (bits1.get(i) != bits2.get(i)) {
+                return false;
+            }
+        }
+
+        for (int i = minLength; i < bits1.length(); i++) {
+            if (bits1.get(i)) {
+                return false;
+            }
+        }
+
+        for (int i = minLength; i < bits2.length(); i++) {
+            if (bits2.get(i)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/query/common/QueryUtilsTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/common/QueryUtilsTests.java
@@ -42,7 +42,7 @@ public class QueryUtilsTests extends TestCase {
     public void setUp() throws Exception {
         executor = Executors.newSingleThreadExecutor();
         taskExecutor = new TaskExecutor(executor);
-        queryUtils = QueryUtils.getInstance();
+        queryUtils = QueryUtils.INSTANCE;
     }
 
     @SneakyThrows


### PR DESCRIPTION
### Description
[Describe what this change achieves]

- `QueryUtils` - added `getInstance` method to get singleton instance of class to support the latest version of `QueryUtilsTests` tests
- `QueryUtilsTests` - migrated latest tests from k-NN
- `DocAndScoreQueryTests` - migrated last compatible version with our implementation. I noticed there were some changes here https://github.com/opensearch-project/k-NN/pull/2403 for explain for API's. 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

Closes #449 
Parent #390 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
