### PR TITLE
test: engine tests migration

### DIFF
--- a/src/test/java/org/opensearch/knn/index/engine/AbstractKNNLibraryTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/AbstractKNNLibraryTests.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine;
+
+import com.google.common.collect.ImmutableMap;
+import org.opensearch.common.ValidationException;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.*;
+import org.opensearch.knn.index.engine.model.QueryContext;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.opensearch.knn.common.KNNConstants.NAME;
+
+public class AbstractKNNLibraryTests extends KNNTestCase {
+
+    private final static String CURRENT_VERSION = "test-version";
+    private final static String INVALID_METHOD_THROWS_VALIDATION_NAME = "test-method-1";
+    private final static KNNMethod INVALID_METHOD_THROWS_VALIDATION = new AbstractKNNMethod(
+        MethodComponent.Builder.builder(INVALID_METHOD_THROWS_VALIDATION_NAME).addSupportedDataTypes(Set.of(VectorDataType.FLOAT)).build(),
+        Set.of(SpaceType.DEFAULT),
+        new DefaultHnswSearchContext()
+    ) {
+        @Override
+        public ValidationException validate(KNNMethodContext knnMethodContext, KNNMethodConfigContext knnMethodConfigContext) {
+            return new ValidationException();
+        }
+    };
+    private final static String VALID_METHOD_NAME = "test-method-2";
+    private final static KNNLibrarySearchContext VALID_METHOD_CONTEXT = ctx -> ImmutableMap.of(
+        "myparameter",
+        new Parameter.BooleanParameter("myparameter", null, (v, context) -> true)
+    );
+    private final static Map<String, Object> VALID_EXPECTED_MAP = ImmutableMap.of("test-key", "test-param");
+    private final static KNNMethod VALID_METHOD = new AbstractKNNMethod(
+        MethodComponent.Builder.builder(VALID_METHOD_NAME)
+            .setKnnLibraryIndexingContextGenerator(
+                (methodComponent, methodComponentContext, knnMethodConfigContext) -> KNNLibraryIndexingContextImpl.builder()
+                    .parameters(new HashMap<>(VALID_EXPECTED_MAP))
+                    .build()
+            )
+            .addSupportedDataTypes(Set.of(VectorDataType.FLOAT))
+            .build(),
+        Set.of(SpaceType.DEFAULT),
+        VALID_METHOD_CONTEXT
+    ) {
+    };
+    private final static AbstractKNNLibrary TEST_LIBRARY = new TestAbstractKNNLibrary(
+        ImmutableMap.of(INVALID_METHOD_THROWS_VALIDATION_NAME, INVALID_METHOD_THROWS_VALIDATION, VALID_METHOD_NAME, VALID_METHOD),
+        CURRENT_VERSION
+    );
+
+    public void testGetVersion() {
+        assertEquals(CURRENT_VERSION, TEST_LIBRARY.getVersion());
+    }
+
+    public void testValidateMethod() throws IOException {
+        KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder()
+            .versionCreated(org.opensearch.Version.CURRENT)
+            .dimension(10)
+            .vectorDataType(VectorDataType.FLOAT)
+            .build();
+        // Invalid - method not supported
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().field(NAME, "invalid").endObject();
+        Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
+        KNNMethodContext knnMethodContext1 = KNNMethodContext.parse(in);
+        assertNotNull(TEST_LIBRARY.validateMethod(knnMethodContext1, knnMethodConfigContext));
+
+        // Invalid - method validation
+        xContentBuilder = XContentFactory.jsonBuilder().startObject().field(NAME, INVALID_METHOD_THROWS_VALIDATION_NAME).endObject();
+        in = xContentBuilderToMap(xContentBuilder);
+        KNNMethodContext knnMethodContext2 = KNNMethodContext.parse(in);
+        expectThrows(IllegalStateException.class, () -> TEST_LIBRARY.validateMethod(knnMethodContext2, knnMethodConfigContext));
+    }
+
+    public void testEngineSpecificMethods() {
+        QueryContext engineSpecificMethodContext = new QueryContext(VectorQueryType.K);
+        assertNotNull(TEST_LIBRARY.getKNNLibrarySearchContext(VALID_METHOD_NAME));
+        assertTrue(
+            TEST_LIBRARY.getKNNLibrarySearchContext(VALID_METHOD_NAME)
+                .supportedMethodParameters(engineSpecificMethodContext)
+                .containsKey("myparameter")
+        );
+    }
+
+    public void testGetKNNLibraryIndexingContext() {
+        KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder()
+            .versionCreated(org.opensearch.Version.CURRENT)
+            .dimension(10)
+            .vectorDataType(VectorDataType.FLOAT)
+            .build();
+        // Check that map is expected
+        Map<String, Object> expectedMap = new HashMap<>(VALID_EXPECTED_MAP);
+        expectedMap.put(KNNConstants.SPACE_TYPE, SpaceType.DEFAULT.getValue());
+        expectedMap.put(KNNConstants.VECTOR_DATA_TYPE_FIELD, VectorDataType.FLOAT.getValue());
+        KNNMethodContext knnMethodContext = new KNNMethodContext(
+            KNNEngine.DEFAULT,
+            SpaceType.DEFAULT,
+            new MethodComponentContext(VALID_METHOD_NAME, Collections.emptyMap())
+        );
+        assertEquals(
+            expectedMap,
+            TEST_LIBRARY.getKNNLibraryIndexingContext(knnMethodContext, knnMethodConfigContext).getLibraryParameters()
+        );
+
+        // Check when invalid method is passed in
+        KNNMethodContext invalidKnnMethodContext = new KNNMethodContext(
+            KNNEngine.DEFAULT,
+            SpaceType.DEFAULT,
+            new MethodComponentContext("invalid", Collections.emptyMap())
+        );
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> TEST_LIBRARY.getKNNLibraryIndexingContext(invalidKnnMethodContext, knnMethodConfigContext)
+        );
+    }
+
+    private static class TestAbstractKNNLibrary extends AbstractKNNLibrary {
+        public TestAbstractKNNLibrary(Map<String, KNNMethod> methods, String currentVersion) {
+            super(methods, currentVersion);
+        }
+
+        @Override
+        public String getExtension() {
+            return null;
+        }
+
+        @Override
+        public String getCompoundExtension() {
+            return null;
+        }
+
+        @Override
+        public float score(float rawScore, SpaceType spaceType) {
+            return 0;
+        }
+
+        @Override
+        public Float distanceToRadialThreshold(Float distance, SpaceType spaceType) {
+            return 0f;
+        }
+
+        public Float scoreToRadialThreshold(Float score, SpaceType spaceType) {
+            return 0f;
+        }
+
+        @Override
+        public int estimateOverheadInKB(KNNMethodContext knnMethodContext, KNNMethodConfigContext knnMethodConfigContext) {
+            return 0;
+        }
+
+        @Override
+        public Boolean isInitialized() {
+            return null;
+        }
+
+        @Override
+        public void setInitialized(Boolean isInitialized) {
+
+        }
+
+        @Override
+        public ResolvedMethodContext resolveMethod(
+            KNNMethodContext knnMethodContext,
+            KNNMethodConfigContext knnMethodConfigContext,
+            boolean shouldRequireTraining,
+            SpaceType spaceType
+        ) {
+            return null;
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/engine/AbstractKNNMethodTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/AbstractKNNMethodTests.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine;
+
+import com.google.common.collect.ImmutableMap;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.opensearch.knn.common.KNNConstants.NAME;
+import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
+
+public class AbstractKNNMethodTests extends KNNTestCase {
+
+    private static class TestKNNMethod extends AbstractKNNMethod {
+        public TestKNNMethod(MethodComponent methodComponent, Set<SpaceType> spaces, KNNLibrarySearchContext engineSpecificMethodContext) {
+            super(methodComponent, spaces, engineSpecificMethodContext);
+        }
+    }
+
+    /**
+     * Test KNNMethod has space
+     */
+    public void testHasSpace() {
+        String name = "test";
+        KNNMethod knnMethod = new TestKNNMethod(
+            MethodComponent.Builder.builder(name).build(),
+            Set.of(SpaceType.L2, SpaceType.COSINESIMIL),
+            EMPTY_ENGINE_SPECIFIC_CONTEXT
+        );
+        assertTrue(knnMethod.isSpaceTypeSupported(SpaceType.L2));
+        assertTrue(knnMethod.isSpaceTypeSupported(SpaceType.COSINESIMIL));
+        assertFalse(knnMethod.isSpaceTypeSupported(SpaceType.INNER_PRODUCT));
+    }
+
+    /**
+     * Test KNNMethod validate
+     */
+    public void testValidate() throws IOException {
+        KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder()
+            .versionCreated(org.opensearch.Version.CURRENT)
+            .dimension(10)
+            .vectorDataType(VectorDataType.FLOAT)
+            .build();
+        String methodName = "test-method";
+        KNNMethod knnMethod = new TestKNNMethod(
+            MethodComponent.Builder.builder(methodName).addSupportedDataTypes(Set.of(VectorDataType.FLOAT)).build(),
+            Set.of(SpaceType.L2),
+            EMPTY_ENGINE_SPECIFIC_CONTEXT
+        );
+
+        // Invalid space
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, methodName)
+            .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.INNER_PRODUCT.getValue())
+            .endObject();
+        Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
+        KNNMethodContext knnMethodContext1 = KNNMethodContext.parse(in);
+        assertNotNull(knnMethod.validate(knnMethodContext1, knnMethodConfigContext));
+
+        // Invalid methodComponent
+        xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, methodName)
+            .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .startObject(PARAMETERS)
+            .field("invalid", "invalid")
+            .endObject()
+            .endObject();
+        in = xContentBuilderToMap(xContentBuilder);
+        KNNMethodContext knnMethodContext2 = KNNMethodContext.parse(in);
+
+        assertNotNull(knnMethod.validate(knnMethodContext2, knnMethodConfigContext));
+
+        // Valid everything
+        xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, methodName)
+            .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .endObject();
+        in = xContentBuilderToMap(xContentBuilder);
+        KNNMethodContext knnMethodContext3 = KNNMethodContext.parse(in);
+        assertNull(knnMethod.validate(knnMethodContext3, knnMethodConfigContext));
+    }
+
+    /**
+     * Test KNNMethod validateWithData
+     */
+    public void testValidateWithContext() throws IOException {
+        KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder()
+            .versionCreated(org.opensearch.Version.CURRENT)
+            .dimension(4)
+            .vectorDataType(VectorDataType.FLOAT)
+            .build();
+        String methodName = "test-method";
+        KNNMethod knnMethod = new TestKNNMethod(
+            MethodComponent.Builder.builder(methodName).addSupportedDataTypes(Set.of(VectorDataType.FLOAT)).build(),
+            Set.of(SpaceType.L2),
+            EMPTY_ENGINE_SPECIFIC_CONTEXT
+        );
+
+        // Invalid space
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, methodName)
+            .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.INNER_PRODUCT.getValue())
+            .endObject();
+        Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
+        KNNMethodContext knnMethodContext1 = KNNMethodContext.parse(in);
+        assertNotNull(knnMethod.validate(knnMethodContext1, knnMethodConfigContext));
+
+        // Invalid methodComponent
+        xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, methodName)
+            .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .startObject(PARAMETERS)
+            .field("invalid", "invalid")
+            .endObject()
+            .endObject();
+        in = xContentBuilderToMap(xContentBuilder);
+        KNNMethodContext knnMethodContext2 = KNNMethodContext.parse(in);
+        assertNotNull(knnMethod.validate(knnMethodContext2, knnMethodConfigContext));
+
+        // Valid everything
+        xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, methodName)
+            .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .endObject();
+        in = xContentBuilderToMap(xContentBuilder);
+        KNNMethodContext knnMethodContext3 = KNNMethodContext.parse(in);
+        assertNull(knnMethod.validate(knnMethodContext3, knnMethodConfigContext));
+    }
+
+    public void testGetKNNLibraryIndexingContext() {
+        KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder()
+            .versionCreated(org.opensearch.Version.CURRENT)
+            .dimension(4)
+            .vectorDataType(VectorDataType.FLOAT)
+            .build();
+        SpaceType spaceType = SpaceType.DEFAULT;
+        String methodName = "test-method";
+        Map<String, Object> generatedMap = new HashMap<>(ImmutableMap.of("test-key", "test-value"));
+        MethodComponent methodComponent = MethodComponent.Builder.builder(methodName)
+            .setKnnLibraryIndexingContextGenerator(
+                ((methodComponent1, methodComponentContext, methodConfigContext) -> KNNLibraryIndexingContextImpl.builder()
+                    .parameters(methodComponentContext.getParameters())
+                    .build())
+            )
+            .build();
+
+        KNNMethod knnMethod = new TestKNNMethod(methodComponent, Set.of(SpaceType.L2), EMPTY_ENGINE_SPECIFIC_CONTEXT);
+
+        Map<String, Object> expectedMap = new HashMap<>(generatedMap);
+        expectedMap.put(KNNConstants.SPACE_TYPE, spaceType.getValue());
+        expectedMap.put(KNNConstants.VECTOR_DATA_TYPE_FIELD, VectorDataType.FLOAT.getValue());
+
+        assertEquals(
+            expectedMap,
+            knnMethod.getKNNLibraryIndexingContext(
+                new KNNMethodContext(KNNEngine.DEFAULT, spaceType, new MethodComponentContext(methodName, generatedMap)),
+                knnMethodConfigContext
+            ).getLibraryParameters()
+        );
+    }
+
+    public void testGetKNNLibrarySearchContext() {
+        String methodName = "test-method";
+        KNNLibrarySearchContext knnLibrarySearchContext = new DefaultHnswSearchContext();
+        KNNMethod knnMethod = new TestKNNMethod(
+            MethodComponent.Builder.builder(methodName).build(),
+            Set.of(SpaceType.L2),
+            knnLibrarySearchContext
+        );
+        assertEquals(knnLibrarySearchContext, knnMethod.getKNNLibrarySearchContext());
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/engine/AbstractMethodResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/AbstractMethodResolverTests.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine;
+
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.mapper.CompressionLevel;
+import org.opensearch.knn.index.mapper.Mode;
+
+import java.util.Map;
+
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+
+public class AbstractMethodResolverTests extends KNNTestCase {
+
+    private final static String ENCODER_NAME = "test";
+    private final static CompressionLevel DEFAULT_COMPRESSION = CompressionLevel.x8;
+
+    private final static AbstractMethodResolver TEST_RESOLVER = new AbstractMethodResolver() {
+        @Override
+        public ResolvedMethodContext resolveMethod(
+            KNNMethodContext knnMethodContext,
+            KNNMethodConfigContext knnMethodConfigContext,
+            boolean shouldRequireTraining,
+            SpaceType spaceType
+        ) {
+            return null;
+        }
+    };
+
+    private final static Encoder TEST_ENCODER = new Encoder() {
+
+        @Override
+        public MethodComponent getMethodComponent() {
+            return MethodComponent.Builder.builder(ENCODER_NAME).build();
+        }
+
+        @Override
+        public CompressionLevel calculateCompressionLevel(
+            MethodComponentContext encoderContext,
+            KNNMethodConfigContext knnMethodConfigContext
+        ) {
+            return DEFAULT_COMPRESSION;
+        }
+    };
+
+    private final static Map<String, Encoder> ENCODER_MAP = Map.of(ENCODER_NAME, TEST_ENCODER);
+
+    public void testResolveCompressionLevelFromMethodContext() {
+        assertEquals(
+            CompressionLevel.x1,
+            TEST_RESOLVER.resolveCompressionLevelFromMethodContext(
+                new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.DEFAULT, MethodComponentContext.EMPTY),
+                KNNMethodConfigContext.builder().build(),
+                ENCODER_MAP
+            )
+        );
+        assertEquals(
+            DEFAULT_COMPRESSION,
+            TEST_RESOLVER.resolveCompressionLevelFromMethodContext(
+                new KNNMethodContext(
+                    KNNEngine.DEFAULT,
+                    SpaceType.DEFAULT,
+                    new MethodComponentContext(
+                        METHOD_HNSW,
+                        Map.of(METHOD_ENCODER_PARAMETER, new MethodComponentContext(ENCODER_NAME, Map.of()))
+                    )
+                ),
+                KNNMethodConfigContext.builder().build(),
+                ENCODER_MAP
+            )
+        );
+    }
+
+    public void testIsEncoderSpecified() {
+        assertFalse(TEST_RESOLVER.isEncoderSpecified(null));
+        assertFalse(
+            TEST_RESOLVER.isEncoderSpecified(new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.DEFAULT, MethodComponentContext.EMPTY))
+        );
+        assertFalse(
+            TEST_RESOLVER.isEncoderSpecified(
+                new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.DEFAULT, new MethodComponentContext(METHOD_HNSW, Map.of()))
+            )
+        );
+        assertTrue(
+            TEST_RESOLVER.isEncoderSpecified(
+                new KNNMethodContext(
+                    KNNEngine.DEFAULT,
+                    SpaceType.DEFAULT,
+                    new MethodComponentContext(METHOD_HNSW, Map.of(METHOD_ENCODER_PARAMETER, "test"))
+                )
+            )
+        );
+    }
+
+    public void testShouldEncoderBeResolved() {
+        assertFalse(
+            TEST_RESOLVER.shouldEncoderBeResolved(
+                new KNNMethodContext(
+                    KNNEngine.DEFAULT,
+                    SpaceType.DEFAULT,
+                    new MethodComponentContext(METHOD_HNSW, Map.of(METHOD_ENCODER_PARAMETER, "test"))
+                ),
+                KNNMethodConfigContext.builder().build()
+            )
+        );
+        assertFalse(
+            TEST_RESOLVER.shouldEncoderBeResolved(null, KNNMethodConfigContext.builder().compressionLevel(CompressionLevel.x1).build())
+        );
+        assertFalse(
+            TEST_RESOLVER.shouldEncoderBeResolved(
+                null,
+                KNNMethodConfigContext.builder().compressionLevel(CompressionLevel.x1).mode(Mode.ON_DISK).build()
+            )
+        );
+        assertFalse(
+            TEST_RESOLVER.shouldEncoderBeResolved(
+                null,
+                KNNMethodConfigContext.builder().compressionLevel(CompressionLevel.NOT_CONFIGURED).mode(Mode.IN_MEMORY).build()
+            )
+        );
+        assertFalse(
+            TEST_RESOLVER.shouldEncoderBeResolved(
+                null,
+                KNNMethodConfigContext.builder()
+                    .compressionLevel(CompressionLevel.NOT_CONFIGURED)
+                    .mode(Mode.ON_DISK)
+                    .vectorDataType(VectorDataType.BINARY)
+                    .build()
+            )
+        );
+        assertTrue(
+            TEST_RESOLVER.shouldEncoderBeResolved(
+                null,
+                KNNMethodConfigContext.builder()
+                    .compressionLevel(CompressionLevel.NOT_CONFIGURED)
+                    .mode(Mode.ON_DISK)
+                    .vectorDataType(VectorDataType.FLOAT)
+                    .build()
+            )
+        );
+        assertTrue(
+            TEST_RESOLVER.shouldEncoderBeResolved(
+                null,
+                KNNMethodConfigContext.builder()
+                    .compressionLevel(CompressionLevel.x32)
+                    .mode(Mode.ON_DISK)
+                    .vectorDataType(VectorDataType.FLOAT)
+                    .build()
+            )
+        );
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/engine/EngineResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/EngineResolverTests.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine;
+
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.mapper.CompressionLevel;
+import org.opensearch.knn.index.mapper.Mode;
+
+public class EngineResolverTests extends KNNTestCase {
+
+    private static final EngineResolver ENGINE_RESOLVER = EngineResolver.INSTANCE;
+
+    public void testResolveEngine_whenEngineSpecifiedInMethod_thenThatEngine() {
+        assertEquals(
+            KNNEngine.LUCENE,
+            ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().build(),
+                new KNNMethodContext(KNNEngine.LUCENE, SpaceType.DEFAULT, MethodComponentContext.EMPTY),
+                false
+            )
+        );
+    }
+
+    public void testResolveEngine_whenRequiresTraining_thenJvector() {
+        assertEquals(KNNEngine.JVECTOR, ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().build(), null, true));
+    }
+
+    public void testResolveEngine_whenModeAndCompressionAreFalse_thenDefault() {
+        assertEquals(KNNEngine.DEFAULT, ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().build(), null, false));
+        assertEquals(
+            KNNEngine.DEFAULT,
+            ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().build(),
+                new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.UNDEFINED, MethodComponentContext.EMPTY, false),
+                false
+            )
+        );
+    }
+
+    public void testResolveEngine_whenModeSpecifiedAndCompressionIsNotSpecified_thenEngineBasedOnMode() {
+        // When no mode or compression specified, returns DEFAULT
+        assertEquals(KNNEngine.DEFAULT, ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().build(), null, false));
+
+        // When mode is IN_MEMORY and compression not specified, returns LUCENE (line 52: mode != ON_DISK)
+        assertEquals(
+            KNNEngine.LUCENE,
+            ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().mode(Mode.IN_MEMORY).build(),
+                new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.UNDEFINED, MethodComponentContext.EMPTY, false),
+                false
+            )
+        );
+
+        // When mode is ON_DISK and compression not specified, returns JVECTOR (line 52: mode == ON_DISK)
+        assertEquals(
+            KNNEngine.JVECTOR,
+            ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().mode(Mode.ON_DISK).build(),
+                new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.UNDEFINED, MethodComponentContext.EMPTY, false),
+                false
+            )
+        );
+    }
+
+    public void testResolveEngine_whenCompressionIs1x_thenEngineBasedOnMode() {
+        // When mode is ON_DISK with x1 compression, returns JVECTOR (line 52)
+        assertEquals(
+            KNNEngine.JVECTOR,
+            ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().mode(Mode.ON_DISK).compressionLevel(CompressionLevel.x1).build(),
+                null,
+                false
+            )
+        );
+
+        // When mode is IN_MEMORY with x1 compression, returns LUCENE (line 52: mode != ON_DISK)
+        assertEquals(
+            KNNEngine.LUCENE,
+            ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().mode(Mode.IN_MEMORY).compressionLevel(CompressionLevel.x1).build(),
+                null,
+                false
+            )
+        );
+
+        // When only x1 compression specified (no mode), defaults to LUCENE (line 52: mode != ON_DISK)
+        assertEquals(
+            KNNEngine.LUCENE,
+            ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().compressionLevel(CompressionLevel.x1).build(), null, false)
+        );
+    }
+
+    public void testResolveEngine_whenCompressionIs4x_thenEngineIsLucene() {
+        assertEquals(
+            KNNEngine.LUCENE,
+            ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().mode(Mode.ON_DISK).compressionLevel(CompressionLevel.x4).build(),
+                null,
+                false
+            )
+        );
+        assertEquals(
+            KNNEngine.LUCENE,
+            ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().compressionLevel(CompressionLevel.x4).build(), null, false)
+        );
+    }
+
+    public void testResolveEngine_whenConfiguredForHighCompression_thenEngineIsJvector() {
+        // For compressions other than x1 and x4, engine defaults to JVECTOR (line 60)
+
+        // x2 compression
+        assertEquals(
+            KNNEngine.JVECTOR,
+            ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().mode(Mode.ON_DISK).compressionLevel(CompressionLevel.x2).build(),
+                null,
+                false
+            )
+        );
+        assertEquals(
+            KNNEngine.JVECTOR,
+            ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().mode(Mode.IN_MEMORY).compressionLevel(CompressionLevel.x2).build(),
+                null,
+                false
+            )
+        );
+
+        // x8 compression
+        assertEquals(
+            KNNEngine.JVECTOR,
+            ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().mode(Mode.ON_DISK).compressionLevel(CompressionLevel.x8).build(),
+                null,
+                false
+            )
+        );
+        assertEquals(
+            KNNEngine.JVECTOR,
+            ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().mode(Mode.IN_MEMORY).compressionLevel(CompressionLevel.x8).build(),
+                null,
+                false
+            )
+        );
+
+        // x16 compression
+        assertEquals(
+            KNNEngine.JVECTOR,
+            ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().mode(Mode.ON_DISK).compressionLevel(CompressionLevel.x16).build(),
+                null,
+                false
+            )
+        );
+        assertEquals(
+            KNNEngine.JVECTOR,
+            ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().mode(Mode.IN_MEMORY).compressionLevel(CompressionLevel.x16).build(),
+                null,
+                false
+            )
+        );
+
+        // x32 compression
+        assertEquals(
+            KNNEngine.JVECTOR,
+            ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().mode(Mode.ON_DISK).compressionLevel(CompressionLevel.x32).build(),
+                null,
+                false
+            )
+        );
+        assertEquals(
+            KNNEngine.JVECTOR,
+            ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().mode(Mode.IN_MEMORY).compressionLevel(CompressionLevel.x32).build(),
+                null,
+                false
+            )
+        );
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/engine/KNNEngineTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/KNNEngineTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine;
+
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.codec.jvector.JVector;
+import org.opensearch.knn.index.engine.lucene.Lucene;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.opensearch.knn.common.KNNConstants.JVECTOR_NAME;
+import static org.opensearch.knn.common.KNNConstants.LUCENE_NAME;
+
+public class KNNEngineTests extends KNNTestCase {
+    /**
+     * Check that version from engine and library match
+     */
+    public void testDelegateLibraryFunctions() {
+        assertEquals(JVector.INSTANCE.getVersion(), KNNEngine.JVECTOR.getVersion());
+        assertEquals(Lucene.INSTANCE.getVersion(), KNNEngine.LUCENE.getVersion());
+    }
+
+    public void testGetDefaultEngine_thenReturnJVECTOR() {
+        assertEquals(KNNEngine.JVECTOR, KNNEngine.DEFAULT);
+    }
+
+    /**
+     * Test name getter
+     */
+    public void testGetName() {
+        assertEquals(LUCENE_NAME, KNNEngine.LUCENE.getName());
+        assertEquals(JVECTOR_NAME, KNNEngine.JVECTOR.getName());
+    }
+
+    /**
+     * Test engine getter
+     */
+    public void testGetEngine() {
+        assertEquals(KNNEngine.LUCENE, KNNEngine.getEngine(LUCENE_NAME));
+        assertEquals(KNNEngine.JVECTOR, KNNEngine.getEngine(JVECTOR_NAME));
+        expectThrows(IllegalArgumentException.class, () -> KNNEngine.getEngine("invalid"));
+    }
+
+    public void testGetEngineFromPath() {
+        // In opensearch-jvector, getEngineNameFromPath always throws exception (line 76)
+        String anyPath = "test.any";
+        expectThrows(IllegalArgumentException.class, () -> KNNEngine.getEngineNameFromPath(anyPath));
+    }
+
+    public void testMmapFileExtensions() {
+        final List<String> mmapExtensions = Arrays.stream(KNNEngine.values())
+            .flatMap(engine -> engine.mmapFileExtensions().stream())
+            .collect(Collectors.toList());
+        assertNotNull(mmapExtensions);
+        final List<String> expectedSettings = List.of("vex", "vec");
+        assertTrue(expectedSettings.containsAll(mmapExtensions));
+        assertTrue(mmapExtensions.containsAll(expectedSettings));
+    }
+
+    public void testGetEnginesThatCreateCustomSegmentFiles() {
+        // opensearch-jvector returns empty set (line 85)
+        assertTrue(KNNEngine.getEnginesThatCreateCustomSegmentFiles().isEmpty());
+    }
+
+    public void testGetEnginesThatSupportsFilters() {
+        // Only LUCENE supports filters (line 32)
+        assertEquals(1, KNNEngine.getEnginesThatSupportsFilters().size());
+        assertTrue(KNNEngine.getEnginesThatSupportsFilters().contains(KNNEngine.LUCENE));
+    }
+
+    public void testGetMaxDimensionByEngine() {
+        // Both engines support 16,000 dimensions (line 35)
+        assertEquals(16_000, KNNEngine.getMaxDimensionByEngine(KNNEngine.LUCENE));
+        assertEquals(16_000, KNNEngine.getMaxDimensionByEngine(KNNEngine.JVECTOR));
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/engine/KNNMethodContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/KNNMethodContextTests.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine;
+
+import org.opensearch.Version;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
+import com.google.common.collect.ImmutableMap;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.index.mapper.MapperParsingException;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import org.opensearch.core.common.io.stream.StreamInput;
+
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.NAME;
+import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
+
+public class KNNMethodContextTests extends KNNTestCase {
+
+    public void testStreams() throws IOException {
+        KNNEngine knnEngine = KNNEngine.LUCENE;
+        SpaceType spaceType = SpaceType.INNER_PRODUCT;
+        String name = "test-name";
+        Map<String, Object> parameters = ImmutableMap.of("test-p-1", 10, "test-p-2", "string-p");
+
+        MethodComponentContext originalMethodComponent = new MethodComponentContext(name, parameters);
+
+        KNNMethodContext original = new KNNMethodContext(knnEngine, spaceType, originalMethodComponent);
+
+        BytesStreamOutput streamOutput = new BytesStreamOutput();
+        original.writeTo(streamOutput);
+
+        KNNMethodContext copy = new KNNMethodContext(streamOutput.bytes().streamInput());
+
+        assertEquals(original, copy);
+    }
+
+    public void testGetMethodComponent() {
+        MethodComponentContext methodComponent = new MethodComponentContext("test-method", Collections.emptyMap());
+        KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.DEFAULT, methodComponent);
+        assertEquals(methodComponent, knnMethodContext.getMethodComponentContext());
+    }
+
+    public void testGetEngine() {
+        MethodComponentContext methodComponent = new MethodComponentContext("test-method", Collections.emptyMap());
+        KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.DEFAULT, methodComponent);
+        assertEquals(KNNEngine.DEFAULT, knnMethodContext.getKnnEngine());
+    }
+
+    public void testGetSpaceType() {
+        MethodComponentContext methodComponent = new MethodComponentContext("test-method", Collections.emptyMap());
+        KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.L1, methodComponent);
+        assertEquals(SpaceType.L1, knnMethodContext.getSpaceType());
+    }
+
+    public void testParse_invalid() throws IOException {
+        // Invalid input type
+        Integer invalidIn = 12;
+        expectThrows(MapperParsingException.class, () -> KNNMethodContext.parse(invalidIn));
+
+        // Invalid engine type
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().field(KNN_ENGINE, 0).endObject();
+
+        final Map<String, Object> in0 = xContentBuilderToMap(xContentBuilder);
+        expectThrows(MapperParsingException.class, () -> KNNMethodContext.parse(in0));
+
+        // Invalid engine name
+        xContentBuilder = XContentFactory.jsonBuilder().startObject().field(KNN_ENGINE, "invalid").endObject();
+
+        final Map<String, Object> in1 = xContentBuilderToMap(xContentBuilder);
+        expectThrows(MapperParsingException.class, () -> KNNMethodContext.parse(in1));
+
+        // Invalid space type
+        xContentBuilder = XContentFactory.jsonBuilder().startObject().field(METHOD_PARAMETER_SPACE_TYPE, 0).endObject();
+
+        final Map<String, Object> in2 = xContentBuilderToMap(xContentBuilder);
+        expectThrows(MapperParsingException.class, () -> KNNMethodContext.parse(in2));
+
+        // Invalid space name
+        xContentBuilder = XContentFactory.jsonBuilder().startObject().field(METHOD_PARAMETER_SPACE_TYPE, "invalid").endObject();
+
+        final Map<String, Object> in3 = xContentBuilderToMap(xContentBuilder);
+        expectThrows(MapperParsingException.class, () -> KNNMethodContext.parse(in3));
+
+        // Invalid name not set
+        xContentBuilder = XContentFactory.jsonBuilder().startObject().endObject();
+        final Map<String, Object> in4 = xContentBuilderToMap(xContentBuilder);
+        expectThrows(MapperParsingException.class, () -> KNNMethodContext.parse(in4));
+
+        // Invalid name type
+        xContentBuilder = XContentFactory.jsonBuilder().startObject().field(NAME, 13).endObject();
+
+        final Map<String, Object> in5 = xContentBuilderToMap(xContentBuilder);
+        expectThrows(MapperParsingException.class, () -> KNNMethodContext.parse(in5));
+
+        // Invalid parameter type
+        xContentBuilder = XContentFactory.jsonBuilder().startObject().field(PARAMETERS, 13).endObject();
+
+        final Map<String, Object> in6 = xContentBuilderToMap(xContentBuilder);
+        expectThrows(MapperParsingException.class, () -> KNNMethodContext.parse(in6));
+
+        // Invalid key
+        xContentBuilder = XContentFactory.jsonBuilder().startObject().field("invalid", 12).endObject();
+        Map<String, Object> in7 = xContentBuilderToMap(xContentBuilder);
+        expectThrows(MapperParsingException.class, () -> MethodComponentContext.parse(in7));
+    }
+
+    public void testParse_nullParameters() throws IOException {
+        String methodName = "test-method";
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, methodName)
+            .field(PARAMETERS, (String) null)
+            .endObject();
+        Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
+        KNNMethodContext knnMethodContext = KNNMethodContext.parse(in);
+        assertTrue(knnMethodContext.getMethodComponentContext().getParameters().isEmpty());
+    }
+
+    public void testParse_valid() throws IOException {
+        // Simple method with only name set
+        String methodName = "test-method";
+
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().field(NAME, methodName).endObject();
+        Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
+        KNNMethodContext knnMethodContext = KNNMethodContext.parse(in);
+
+        assertEquals(KNNEngine.DEFAULT, knnMethodContext.getKnnEngine());
+        assertEquals(SpaceType.UNDEFINED, knnMethodContext.getSpaceType());
+        assertEquals(methodName, knnMethodContext.getMethodComponentContext().getName());
+        assertTrue(knnMethodContext.getMethodComponentContext().getParameters().isEmpty());
+
+        // Method with parameters
+        String methodParameterKey1 = "p-1";
+        String methodParameterValue1 = "v-1";
+        String methodParameterKey2 = "p-2";
+        Integer methodParameterValue2 = 27;
+
+        xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, methodName)
+            .startObject(PARAMETERS)
+            .field(methodParameterKey1, methodParameterValue1)
+            .field(methodParameterKey2, methodParameterValue2)
+            .endObject()
+            .endObject();
+        in = xContentBuilderToMap(xContentBuilder);
+        knnMethodContext = KNNMethodContext.parse(in);
+
+        assertEquals(methodParameterValue1, knnMethodContext.getMethodComponentContext().getParameters().get(methodParameterKey1));
+        assertEquals(methodParameterValue2, knnMethodContext.getMethodComponentContext().getParameters().get(methodParameterKey2));
+
+        // Method with parameter that is a method context paramet
+
+        // Parameter that is itself a MethodComponentContext
+        xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, methodName)
+            .startObject(PARAMETERS)
+            .startObject(methodParameterKey1)
+            .field(NAME, methodParameterValue1)
+            .endObject()
+            .field(methodParameterKey2, methodParameterValue2)
+            .endObject()
+            .endObject();
+        in = xContentBuilderToMap(xContentBuilder);
+        knnMethodContext = KNNMethodContext.parse(in);
+
+        assertTrue(knnMethodContext.getMethodComponentContext().getParameters().get(methodParameterKey1) instanceof MethodComponentContext);
+        assertEquals(
+            methodParameterValue1,
+            ((MethodComponentContext) knnMethodContext.getMethodComponentContext().getParameters().get(methodParameterKey1)).getName()
+        );
+        assertEquals(methodParameterValue2, knnMethodContext.getMethodComponentContext().getParameters().get(methodParameterKey2));
+    }
+
+    public void testToXContent() throws IOException {
+        String methodName = "test-method";
+        String spaceType = SpaceType.L2.getValue();
+        String knnEngine = KNNEngine.DEFAULT.getName();
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, methodName)
+            .field(METHOD_PARAMETER_SPACE_TYPE, spaceType)
+            .field(KNN_ENGINE, knnEngine)
+            .endObject();
+        Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
+        KNNMethodContext knnMethodContext = KNNMethodContext.parse(in);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        builder = knnMethodContext.toXContent(builder, ToXContent.EMPTY_PARAMS).endObject();
+
+        Map<String, Object> out = xContentBuilderToMap(builder);
+        assertEquals(methodName, out.get(NAME));
+        assertEquals(spaceType, out.get(METHOD_PARAMETER_SPACE_TYPE));
+        assertEquals(knnEngine, out.get(KNN_ENGINE));
+    }
+
+    public void testEquals() {
+        SpaceType spaceType1 = SpaceType.L1;
+        SpaceType spaceType2 = SpaceType.L2;
+        String name1 = "name1";
+        String name2 = "name2";
+        Map<String, Object> parameters1 = ImmutableMap.of("param1", "v1", "param2", 18);
+
+        MethodComponentContext methodComponentContext1 = new MethodComponentContext(name1, parameters1);
+        MethodComponentContext methodComponentContext2 = new MethodComponentContext(name2, parameters1);
+
+        KNNMethodContext methodContext1 = new KNNMethodContext(KNNEngine.DEFAULT, spaceType1, methodComponentContext1);
+        KNNMethodContext methodContext2 = new KNNMethodContext(KNNEngine.DEFAULT, spaceType1, methodComponentContext1);
+        KNNMethodContext methodContext3 = new KNNMethodContext(KNNEngine.DEFAULT, spaceType1, methodComponentContext2);
+        KNNMethodContext methodContext4 = new KNNMethodContext(KNNEngine.DEFAULT, spaceType2, methodComponentContext1);
+        KNNMethodContext methodContext5 = new KNNMethodContext(KNNEngine.DEFAULT, spaceType2, methodComponentContext2);
+
+        assertNotEquals(methodContext1, null);
+        assertEquals(methodContext1, methodContext1);
+        assertEquals(methodContext1, methodContext2);
+        assertNotEquals(methodContext1, methodContext3);
+        assertNotEquals(methodContext1, methodContext4);
+        assertNotEquals(methodContext1, methodContext5);
+    }
+
+    public void testHashCode() {
+        SpaceType spaceType1 = SpaceType.L1;
+        SpaceType spaceType2 = SpaceType.L2;
+        String name1 = "name1";
+        String name2 = "name2";
+        Map<String, Object> parameters1 = ImmutableMap.of("param1", "v1", "param2", 18);
+
+        MethodComponentContext methodComponentContext1 = new MethodComponentContext(name1, parameters1);
+        MethodComponentContext methodComponentContext2 = new MethodComponentContext(name2, parameters1);
+
+        KNNMethodContext methodContext1 = new KNNMethodContext(KNNEngine.DEFAULT, spaceType1, methodComponentContext1);
+        KNNMethodContext methodContext2 = new KNNMethodContext(KNNEngine.DEFAULT, spaceType1, methodComponentContext1);
+        KNNMethodContext methodContext3 = new KNNMethodContext(KNNEngine.DEFAULT, spaceType1, methodComponentContext2);
+        KNNMethodContext methodContext4 = new KNNMethodContext(KNNEngine.DEFAULT, spaceType2, methodComponentContext1);
+        KNNMethodContext methodContext5 = new KNNMethodContext(KNNEngine.DEFAULT, spaceType2, methodComponentContext2);
+
+        assertEquals(methodContext1.hashCode(), methodContext1.hashCode());
+        assertEquals(methodContext1.hashCode(), methodContext2.hashCode());
+        assertNotEquals(methodContext1.hashCode(), methodContext3.hashCode());
+        assertNotEquals(methodContext1.hashCode(), methodContext4.hashCode());
+        assertNotEquals(methodContext1.hashCode(), methodContext5.hashCode());
+    }
+
+    public void testValidateVectorDataType_whenByte_thenValid() {
+        // LUCENE supports BYTE with hnsw method
+        validateValidateVectorDataType(KNNEngine.LUCENE, KNNConstants.METHOD_HNSW, VectorDataType.BYTE, SpaceType.L2, null);
+    }
+
+    public void testValidateVectorDataType_whenFloat_thenValid() {
+        // LUCENE supports FLOAT with hnsw method
+        validateValidateVectorDataType(KNNEngine.LUCENE, KNNConstants.METHOD_HNSW, VectorDataType.FLOAT, SpaceType.L2, null);
+        // JVECTOR supports FLOAT with diskann method
+        validateValidateVectorDataType(KNNEngine.JVECTOR, KNNConstants.DISK_ANN, VectorDataType.FLOAT, SpaceType.L2, null);
+    }
+
+    public void testWriteTo_withNullParameters() throws IOException {
+        MethodComponentContext methodComponent = new MethodComponentContext("test-method", null);
+
+        BytesStreamOutput streamOutput = new BytesStreamOutput();
+        methodComponent.writeTo(streamOutput);
+
+        MethodComponentContext deserialized = new MethodComponentContext(streamOutput.bytes().streamInput());
+
+        // Ensure parameters are empty (not null) for safety
+        assertNotNull(deserialized.getParameters());
+        assertTrue(deserialized.getParameters().isEmpty());
+    }
+
+    public void testWriteToReadFrom_withValidParameters() throws IOException {
+        Map<String, Object> parameters = ImmutableMap.of("param1", 10, "param2", "value");
+        MethodComponentContext original = new MethodComponentContext("test-method", parameters);
+
+        BytesStreamOutput streamOutput = new BytesStreamOutput();
+        original.writeTo(streamOutput);
+
+        MethodComponentContext deserialized = new MethodComponentContext(streamOutput.bytes().streamInput());
+
+        assertEquals(original, deserialized);
+        assertEquals(2, deserialized.getParameters().size());
+        assertEquals(10, deserialized.getParameters().get("param1"));
+        assertEquals("value", deserialized.getParameters().get("param2"));
+    }
+
+    public void testBackwardCompatibility_readFromOldVersion() throws IOException {
+        // Simulating an older version that did not write parameters explicitly
+        BytesStreamOutput streamOutput = new BytesStreamOutput();
+        streamOutput.writeString("old-method");
+        StreamInput streamInput = streamOutput.bytes().streamInput();
+        streamInput.setVersion(Version.V_2_19_0);
+
+        MethodComponentContext deserialized = new MethodComponentContext(streamInput);
+
+        // Ensure parameters are still handled gracefully
+        assertNotNull(deserialized.getParameters());
+        assertTrue(deserialized.getParameters().isEmpty());
+    }
+
+    public void testReadFrom_beforeVersion3_0_0() throws IOException {
+        // Simulate a stream written from a version before 3.0.0 (parameters not explicitly stored)
+        BytesStreamOutput streamOutput = new BytesStreamOutput();
+        streamOutput.writeString("test-method");
+        StreamInput streamInput = streamOutput.bytes().streamInput();
+        streamInput.setVersion(Version.V_2_19_0);
+
+        MethodComponentContext deserialized = new MethodComponentContext(streamInput);
+        // Ensure parameters default to an empty map for older versions
+        assertNotNull(deserialized.getParameters());
+        assertTrue(deserialized.getParameters().isEmpty());
+    }
+
+    private void validateValidateVectorDataType(
+        final KNNEngine knnEngine,
+        final String methodName,
+        final VectorDataType vectorDataType,
+        final SpaceType spaceType,
+        final String expectedErrMsg
+    ) {
+        MethodComponentContext methodComponentContext = new MethodComponentContext(methodName, Collections.emptyMap());
+        KNNMethodContext methodContext = new KNNMethodContext(knnEngine, spaceType, methodComponentContext);
+        KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder()
+            .vectorDataType(vectorDataType)
+            .dimension(8)
+            .versionCreated(Version.CURRENT)
+            .build();
+        if (expectedErrMsg == null) {
+            assertNull(knnEngine.validateMethod(methodContext, knnMethodConfigContext));
+        } else {
+            assertNotNull(knnEngine.validateMethod(methodContext, knnMethodConfigContext));
+        }
+    }
+
+}

--- a/src/test/java/org/opensearch/knn/index/engine/MethodComponentContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/MethodComponentContextTests.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.index.mapper.MapperParsingException;
+import org.opensearch.knn.KNNTestCase;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.opensearch.knn.common.KNNConstants.NAME;
+import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
+
+public class MethodComponentContextTests extends KNNTestCase {
+
+    private static final String TEST_METHOD = "test-method";
+    private static final String ENCODER = "encoder";
+
+    public void testConstructor() {
+        String name = "test-component";
+        Map<String, Object> parameters = Map.of("param1", 10, "param2", "value");
+
+        MethodComponentContext context = new MethodComponentContext(name, parameters);
+
+        assertEquals(name, context.getName());
+        assertEquals(parameters, context.getParameters());
+    }
+
+    public void testCopyConstructor_withSimpleParameters() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("param1", 10);
+        parameters.put("param2", true);
+
+        MethodComponentContext original = new MethodComponentContext("test-component", parameters);
+        MethodComponentContext copy = new MethodComponentContext(original);
+
+        assertEquals(original.getName(), copy.getName());
+        assertEquals(original.getParameters(), copy.getParameters());
+
+        // Verify deep copy
+        copy.getParameters().put("param3", 20);
+        assertFalse(original.getParameters().containsKey("param3"));
+    }
+
+    public void testCopyConstructor_withNestedContext() {
+        MethodComponentContext nestedContext = new MethodComponentContext("nested", Map.of("nested_param", 5));
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("param1", 10);
+        parameters.put(ENCODER, nestedContext);
+
+        MethodComponentContext original = new MethodComponentContext("parent", parameters);
+        MethodComponentContext copy = new MethodComponentContext(original);
+
+        MethodComponentContext copiedNested = (MethodComponentContext) copy.getParameters().get(ENCODER);
+        MethodComponentContext originalNested = (MethodComponentContext) original.getParameters().get(ENCODER);
+
+        assertNotSame(originalNested, copiedNested);
+        assertEquals(originalNested.getName(), copiedNested.getName());
+    }
+
+    public void testCopyConstructor_withNull() {
+        MethodComponentContext nullContext = null;
+        expectThrows(IllegalArgumentException.class, () -> new MethodComponentContext(nullContext));
+    }
+
+    public void testParse_withValidInput() throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, TEST_METHOD)
+            .startObject(PARAMETERS)
+            .field("param1", 10)
+            .field("param2", true)
+            .endObject()
+            .endObject();
+
+        Map<String, Object> in = xContentBuilderToMap(builder);
+        MethodComponentContext context = MethodComponentContext.parse(in);
+
+        assertEquals(TEST_METHOD, context.getName());
+        assertEquals(10, context.getParameters().get("param1"));
+        assertEquals(true, context.getParameters().get("param2"));
+    }
+
+    public void testParse_withNestedContext() throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, "parent")
+            .startObject(PARAMETERS)
+            .field("param1", 10)
+            .startObject(ENCODER)
+            .field(NAME, "nested")
+            .startObject(PARAMETERS)
+            .field("nested_param", 5)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        Map<String, Object> in = xContentBuilderToMap(builder);
+        MethodComponentContext context = MethodComponentContext.parse(in);
+
+        MethodComponentContext encoderContext = (MethodComponentContext) context.getParameters().get(ENCODER);
+        assertEquals("nested", encoderContext.getName());
+        assertEquals(5, encoderContext.getParameters().get("nested_param"));
+    }
+
+    public void testParse_withNullParameters() throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, TEST_METHOD)
+            .field(PARAMETERS, (String) null)
+            .endObject();
+
+        Map<String, Object> in = xContentBuilderToMap(builder);
+        MethodComponentContext context = MethodComponentContext.parse(in);
+
+        assertTrue(context.getParameters().isEmpty());
+    }
+
+    public void testParse_withMissingName() throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(PARAMETERS)
+            .field("param1", 10)
+            .endObject()
+            .endObject();
+
+        Map<String, Object> in = xContentBuilderToMap(builder);
+        expectThrows(MapperParsingException.class, () -> MethodComponentContext.parse(in));
+    }
+
+    public void testParse_withInvalidInputType() {
+        expectThrows(MapperParsingException.class, () -> MethodComponentContext.parse("invalid"));
+    }
+
+    public void testParse_withInvalidNameType() {
+        Map<String, Object> invalidName = Map.of(NAME, 123, PARAMETERS, Map.of());
+        expectThrows(MapperParsingException.class, () -> MethodComponentContext.parse(invalidName));
+    }
+
+    public void testParse_withInvalidParametersType() {
+        Map<String, Object> invalidParams = Map.of(NAME, TEST_METHOD, PARAMETERS, "invalid");
+        expectThrows(MapperParsingException.class, () -> MethodComponentContext.parse(invalidParams));
+    }
+
+    public void testParse_withInvalidParameterKey() {
+        Map<String, Object> invalidKey = Map.of(NAME, TEST_METHOD, "invalid_key", "value");
+        expectThrows(MapperParsingException.class, () -> MethodComponentContext.parse(invalidKey));
+    }
+
+    public void testToXContent_withSimpleParameters() throws IOException {
+        MethodComponentContext context = new MethodComponentContext(TEST_METHOD, Map.of("param1", 10, "param2", true));
+
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        context.toXContent(builder, null);
+        builder.endObject();
+
+        Map<String, Object> result = xContentBuilderToMap(builder);
+        assertEquals(TEST_METHOD, result.get(NAME));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> resultParams = (Map<String, Object>) result.get(PARAMETERS);
+        assertEquals(10, resultParams.get("param1"));
+        assertEquals(true, resultParams.get("param2"));
+    }
+
+    public void testToXContent_withNestedContext() throws IOException {
+        MethodComponentContext nestedContext = new MethodComponentContext("nested", Map.of("nested_param", 5));
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("param1", 10);
+        parameters.put(ENCODER, nestedContext);
+
+        MethodComponentContext context = new MethodComponentContext("parent", parameters);
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        context.toXContent(builder, null);
+        builder.endObject();
+
+        Map<String, Object> result = xContentBuilderToMap(builder);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> encoderMap = (Map<String, Object>) ((Map<String, Object>) result.get(PARAMETERS)).get(ENCODER);
+        assertEquals("nested", encoderMap.get(NAME));
+    }
+
+    public void testToXContent_withNullParameters() throws IOException {
+        MethodComponentContext context = new MethodComponentContext(TEST_METHOD, null);
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        context.toXContent(builder, null);
+        builder.endObject();
+
+        Map<String, Object> result = xContentBuilderToMap(builder);
+        assertNull(result.get(PARAMETERS));
+    }
+
+    public void testSerialization_withSimpleParameters() throws IOException {
+        MethodComponentContext original = new MethodComponentContext(TEST_METHOD, Map.of("param1", 10, "param2", true));
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        original.writeTo(output);
+
+        StreamInput input = output.bytes().streamInput();
+        MethodComponentContext deserialized = new MethodComponentContext(input);
+
+        assertEquals(original.getName(), deserialized.getName());
+        assertEquals(original.getParameters(), deserialized.getParameters());
+    }
+
+    public void testSerialization_withNestedContext() throws IOException {
+        MethodComponentContext nestedContext = new MethodComponentContext("nested", Map.of("nested_param", 5));
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("param1", 10);
+        parameters.put(ENCODER, nestedContext);
+
+        MethodComponentContext original = new MethodComponentContext("parent", parameters);
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        original.writeTo(output);
+
+        StreamInput input = output.bytes().streamInput();
+        MethodComponentContext deserialized = new MethodComponentContext(input);
+
+        assertEquals(original.getName(), deserialized.getName());
+
+        MethodComponentContext deserializedNested = (MethodComponentContext) deserialized.getParameters().get(ENCODER);
+        assertEquals("nested", deserializedNested.getName());
+        assertEquals(5, deserializedNested.getParameters().get("nested_param"));
+    }
+
+    public void testEquals() {
+        MethodComponentContext context1 = new MethodComponentContext(TEST_METHOD, Map.of("param1", 10));
+        MethodComponentContext context2 = new MethodComponentContext(TEST_METHOD, Map.of("param1", 10));
+        MethodComponentContext context3 = new MethodComponentContext(TEST_METHOD, Map.of("param1", 20));
+        MethodComponentContext context4 = new MethodComponentContext("different", Map.of("param1", 10));
+
+        assertEquals(context1, context2);
+        assertNotEquals(context1, context3);
+        assertNotEquals(context1, context4);
+        assertNotEquals(context1, null);
+        assertNotEquals(context1, "string");
+    }
+
+    public void testHashCode() {
+        MethodComponentContext context1 = new MethodComponentContext(TEST_METHOD, Map.of("param1", 10));
+        MethodComponentContext context2 = new MethodComponentContext(TEST_METHOD, Map.of("param1", 10));
+
+        assertEquals(context1.hashCode(), context2.hashCode());
+    }
+
+    public void testFromClusterStateString_withSimpleParameters() {
+        MethodComponentContext context = MethodComponentContext.fromClusterStateString("{name=test;parameters=[param1=10;param2=5;]}");
+
+        assertEquals("test", context.getName());
+        assertEquals(10, context.getParameters().get("param1"));
+        assertEquals(5, context.getParameters().get("param2"));
+    }
+
+    public void testFromClusterStateString_withNestedContext() {
+        MethodComponentContext context = MethodComponentContext.fromClusterStateString(
+            "{name=parent;parameters=[param1=10;encoder={name=nested;parameters=[nested_param=5;]};]}"
+        );
+
+        assertEquals("parent", context.getName());
+
+        MethodComponentContext nestedContext = (MethodComponentContext) context.getParameters().get(ENCODER);
+        assertEquals("nested", nestedContext.getName());
+        assertEquals(5, nestedContext.getParameters().get("nested_param"));
+    }
+
+    public void testFromClusterStateString_withBooleanParameters() {
+        MethodComponentContext context = MethodComponentContext.fromClusterStateString(
+            "{name=test;parameters=[param1=true;param2=false;]}"
+        );
+
+        assertEquals(true, context.getParameters().get("param1"));
+        assertEquals(false, context.getParameters().get("param2"));
+    }
+
+    public void testFromClusterStateString_withInvalidFormat() {
+        expectThrows(IllegalArgumentException.class, () -> MethodComponentContext.fromClusterStateString("invalid"));
+    }
+
+    public void testFromClusterStateString_withMissingClosingBrace() {
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> MethodComponentContext.fromClusterStateString("{name=test;parameters=[param1=10;]")
+        );
+    }
+
+    public void testFromClusterStateString_withInvalidParameterValue() {
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> MethodComponentContext.fromClusterStateString("{name=test;parameters=[param1=invalid_value;]}")
+        );
+    }
+
+    public void testRoundTrip_XContent() throws IOException {
+        MethodComponentContext nestedContext = new MethodComponentContext("nested", Map.of("nested_param", 5));
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("param1", 10);
+        parameters.put("param2", true);
+        parameters.put(ENCODER, nestedContext);
+
+        MethodComponentContext original = new MethodComponentContext(TEST_METHOD, parameters);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        original.toXContent(builder, null);
+        builder.endObject();
+
+        Map<String, Object> map = xContentBuilderToMap(builder);
+        MethodComponentContext parsedContext = MethodComponentContext.parse(map);
+
+        assertEquals(original, parsedContext);
+    }
+
+    public void testRoundTrip_Serialization() throws IOException {
+        MethodComponentContext nestedContext = new MethodComponentContext("nested", Map.of("nested_param", 5));
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("param1", 10);
+        parameters.put("param2", true);
+        parameters.put(ENCODER, nestedContext);
+
+        MethodComponentContext original = new MethodComponentContext(TEST_METHOD, parameters);
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        original.writeTo(output);
+
+        StreamInput input = output.bytes().streamInput();
+        MethodComponentContext deserializedContext = new MethodComponentContext(input);
+
+        assertEquals(original, deserializedContext);
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/engine/MethodComponentTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/MethodComponentTests.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine;
+
+import com.google.common.collect.ImmutableMap;
+import org.opensearch.Version;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.mapper.CompressionLevel;
+import org.opensearch.knn.index.mapper.Mode;
+import org.opensearch.knn.index.util.IndexHyperParametersUtil;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+import static org.opensearch.knn.common.KNNConstants.NAME;
+import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
+
+public class MethodComponentTests extends KNNTestCase {
+    /**
+     * Test name getter
+     */
+    public void testGetName() {
+        String name = "test";
+        MethodComponent methodComponent = MethodComponent.Builder.builder(name).build();
+        assertEquals(name, methodComponent.getName());
+    }
+
+    /**
+     * Test parameter getter
+     */
+    public void testGetParameters() {
+        String name = "test";
+        String paramKey = "key";
+        MethodComponent methodComponent = MethodComponent.Builder.builder(name)
+            .addParameter(paramKey, new Parameter.IntegerParameter(paramKey, 1, (v, context) -> v > 0))
+            .build();
+        assertEquals(1, methodComponent.getParameters().size());
+        assertTrue(methodComponent.getParameters().containsKey(paramKey));
+    }
+
+    /**
+     * Test validation
+     */
+    public void testValidate() throws IOException {
+        // Invalid parameter key
+        String methodName = "test-method";
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, methodName)
+            .startObject(PARAMETERS)
+            .field("invalid", "invalid")
+            .endObject()
+            .endObject();
+        KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder()
+            .dimension(1)
+            .versionCreated(Version.CURRENT)
+            .vectorDataType(VectorDataType.FLOAT)
+            .build();
+        Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
+        MethodComponentContext componentContext1 = MethodComponentContext.parse(in);
+
+        MethodComponent methodComponent1 = MethodComponent.Builder.builder(methodName)
+            .addSupportedDataTypes(Set.of(VectorDataType.FLOAT))
+            .build();
+        assertNotNull(methodComponent1.validate(componentContext1, knnMethodConfigContext));
+
+        // Invalid parameter type
+        xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, methodName)
+            .startObject(PARAMETERS)
+            .field("valid", "invalid")
+            .endObject()
+            .endObject();
+        in = xContentBuilderToMap(xContentBuilder);
+        MethodComponentContext componentContext2 = MethodComponentContext.parse(in);
+
+        MethodComponent methodComponent2 = MethodComponent.Builder.builder(methodName)
+            .addSupportedDataTypes(Set.of(VectorDataType.FLOAT))
+            .addParameter("valid", new Parameter.IntegerParameter("valid", 1, (v, context) -> v > 0))
+            .build();
+        assertNotNull(methodComponent2.validate(componentContext2, knnMethodConfigContext));
+
+        // valid configuration
+        xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, methodName)
+            .startObject(PARAMETERS)
+            .field("valid1", 16)
+            .field("valid2", 128)
+            .endObject()
+            .endObject();
+        in = xContentBuilderToMap(xContentBuilder);
+        MethodComponentContext componentContext3 = MethodComponentContext.parse(in);
+
+        MethodComponent methodComponent3 = MethodComponent.Builder.builder(methodName)
+            .addSupportedDataTypes(Set.of(VectorDataType.FLOAT))
+            .addParameter("valid1", new Parameter.IntegerParameter("valid1", 1, (v, context) -> v > 0))
+            .addParameter("valid2", new Parameter.IntegerParameter("valid2", 1, (v, context) -> v > 0))
+            .build();
+        assertNull(methodComponent3.validate(componentContext3, knnMethodConfigContext));
+
+        // valid configuration - empty parameters
+        xContentBuilder = XContentFactory.jsonBuilder().startObject().field(NAME, methodName).endObject();
+        in = xContentBuilderToMap(xContentBuilder);
+        MethodComponentContext componentContext4 = MethodComponentContext.parse(in);
+
+        MethodComponent methodComponent4 = MethodComponent.Builder.builder(methodName)
+            .addSupportedDataTypes(Set.of(VectorDataType.FLOAT))
+            .addParameter("valid1", new Parameter.IntegerParameter("valid1", 1, (v, context) -> v > 0))
+            .addParameter("valid2", new Parameter.IntegerParameter("valid2", 1, (v, context) -> v > 0))
+            .build();
+        assertNull(methodComponent4.validate(componentContext4, knnMethodConfigContext));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testGetAsMap_withoutGenerator() throws IOException {
+        String methodName = "test-method";
+        String parameterName1 = "valid1";
+        String parameterName2 = "valid2";
+        int default1 = 4;
+        int default2 = 5;
+
+        MethodComponent methodComponent = MethodComponent.Builder.builder(methodName)
+            .addParameter(parameterName1, new Parameter.IntegerParameter(parameterName1, default1, (v, context) -> v > 0))
+            .addParameter(parameterName2, new Parameter.IntegerParameter(parameterName2, default2, (v, context) -> v > 0))
+            .build();
+
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, methodName)
+            .startObject(PARAMETERS)
+            .field(parameterName1, 16)
+            .field(parameterName2, 128)
+            .endObject()
+            .endObject();
+        Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
+        MethodComponentContext methodComponentContext = MethodComponentContext.parse(in);
+
+        assertEquals(
+            in,
+            methodComponent.getKNNLibraryIndexingContext(
+                methodComponentContext,
+                KNNMethodConfigContext.builder().versionCreated(Version.CURRENT).build()
+            ).getLibraryParameters()
+        );
+
+        xContentBuilder = XContentFactory.jsonBuilder().startObject().field(NAME, methodName).endObject();
+        in = xContentBuilderToMap(xContentBuilder);
+        methodComponentContext = MethodComponentContext.parse(in);
+
+        KNNLibraryIndexingContext methodAsMap = methodComponent.getKNNLibraryIndexingContext(
+            methodComponentContext,
+            KNNMethodConfigContext.builder().versionCreated(Version.CURRENT).build()
+        );
+        assertEquals(default1, ((Map<String, Object>) methodAsMap.getLibraryParameters().get(PARAMETERS)).get(parameterName1));
+        assertEquals(default2, ((Map<String, Object>) methodAsMap.getLibraryParameters().get(PARAMETERS)).get(parameterName2));
+    }
+
+    public void testGetAsMap_withGenerator() throws IOException {
+        String methodName = "test-method";
+        Map<String, Object> generatedMap = ImmutableMap.of("test-key", "test-value");
+        MethodComponent methodComponent = MethodComponent.Builder.builder(methodName)
+            .addParameter("valid1", new Parameter.IntegerParameter("valid1", 1, (v, context) -> v > 0))
+            .addParameter("valid2", new Parameter.IntegerParameter("valid2", 1, (v, context) -> v > 0))
+            .setKnnLibraryIndexingContextGenerator(
+                (methodComponent1, methodComponentContext, knnMethodConfigContext) -> KNNLibraryIndexingContextImpl.builder()
+                    .parameters(generatedMap)
+                    .build()
+            )
+            .build();
+
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().field(NAME, methodName).endObject();
+        Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
+        MethodComponentContext methodComponentContext = MethodComponentContext.parse(in);
+
+        assertEquals(
+            generatedMap,
+            methodComponent.getKNNLibraryIndexingContext(
+                methodComponentContext,
+                KNNMethodConfigContext.builder().versionCreated(Version.CURRENT).build()
+            ).getLibraryParameters()
+        );
+    }
+
+    public void testBuilder() {
+        String name = "test";
+        MethodComponent.Builder builder = MethodComponent.Builder.builder(name);
+        MethodComponent methodComponent = builder.build();
+
+        assertEquals(0, methodComponent.getParameters().size());
+        assertEquals(name, methodComponent.getName());
+
+        builder.addParameter("test", new Parameter.IntegerParameter("test", 1, (v, context) -> v > 0));
+        methodComponent = builder.build();
+
+        assertEquals(1, methodComponent.getParameters().size());
+
+        Map<String, Object> generatedMap = ImmutableMap.of("test-key", "test-value");
+        builder.setKnnLibraryIndexingContextGenerator(
+            (methodComponent1, methodComponentContext, knnMethodConfigContext) -> KNNLibraryIndexingContextImpl.builder()
+                .parameters(generatedMap)
+                .build()
+        );
+        methodComponent = builder.build();
+
+        assertEquals(
+            generatedMap,
+            methodComponent.getKNNLibraryIndexingContext(null, KNNMethodConfigContext.builder().versionCreated(Version.CURRENT).build())
+                .getLibraryParameters()
+        );
+    }
+
+    /**
+     * Test the new flow where EF_SEARCH and EF_CONSTRUCTION are set for ON_DISK mode
+     * with binary quantization compression levels.
+     */
+    public void testGetParameterMapWithDefaultsAdded_forOnDiskWithBinaryQuantization() {
+        // Set up MethodComponent and context
+        String methodName = "test-method";
+        String parameterEFSearch = "ef_search";
+        String parameterEFConstruction = "ef_construction";
+
+        MethodComponent methodComponent = MethodComponent.Builder.builder(methodName)
+            .addParameter(parameterEFSearch, new Parameter.IntegerParameter(parameterEFSearch, 512, (v, context) -> v > 0))
+            .addParameter(parameterEFConstruction, new Parameter.IntegerParameter(parameterEFConstruction, 512, (v, context) -> v > 0))
+            .build();
+
+        // Simulate ON_DISK mode and binary quantization compression levels
+        KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder()
+            .versionCreated(Version.CURRENT)
+            .mode(Mode.ON_DISK)  // ON_DISK mode
+            .compressionLevel(CompressionLevel.x32)  // Binary quantization compression level
+            .build();
+
+        MethodComponentContext methodComponentContext = new MethodComponentContext(methodName, Map.of());
+
+        // Retrieve parameter map with defaults added
+        Map<String, Object> resultMap = MethodComponent.getParameterMapWithDefaultsAdded(
+            methodComponentContext,
+            methodComponent,
+            knnMethodConfigContext
+        );
+
+        // Check that binary quantization values are used
+        assertEquals(IndexHyperParametersUtil.getBinaryQuantizationEFSearchValue(), resultMap.get(parameterEFSearch));
+        assertEquals(IndexHyperParametersUtil.getBinaryQuantizationEFConstructionValue(), resultMap.get(parameterEFConstruction));
+    }
+
+}

--- a/src/test/java/org/opensearch/knn/index/engine/ParameterTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/ParameterTests.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine;
+
+import com.google.common.collect.ImmutableMap;
+import org.opensearch.Version;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.common.ValidationException;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.engine.Parameter.IntegerParameter;
+import org.opensearch.knn.index.engine.Parameter.StringParameter;
+import org.opensearch.knn.index.engine.Parameter.MethodComponentContextParameter;
+
+import java.util.Map;
+import java.util.Set;
+
+public class ParameterTests extends KNNTestCase {
+    /**
+     * Test default default value getter
+     */
+    public void testGetDefaultValue() {
+        String defaultValue = "test-default";
+        Parameter<String> parameter = new Parameter<String>("test", defaultValue, (v, context) -> true) {
+            @Override
+            public ValidationException validate(Object value, KNNMethodConfigContext context) {
+                return null;
+            }
+        };
+
+        assertEquals(defaultValue, parameter.getDefaultValue());
+    }
+
+    /**
+     * Test integer parameter validate
+     */
+    public void testIntegerParameter_validate() {
+        final IntegerParameter parameter = new IntegerParameter("test", 1, (v, context) -> v > 0);
+        KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder()
+            .dimension(1)
+            .versionCreated(Version.CURRENT)
+            .vectorDataType(VectorDataType.FLOAT)
+            .build();
+        // Invalid type
+        assertNotNull(parameter.validate("String", knnMethodConfigContext));
+
+        // Invalid value
+        assertNotNull(parameter.validate(-1, knnMethodConfigContext));
+
+        // valid value
+        assertNull(parameter.validate(12, knnMethodConfigContext));
+    }
+
+    /**
+     * Test integer parameter validate
+     */
+    public void testIntegerParameter_validateWithContext() {
+        final IntegerParameter parameter = new IntegerParameter("test", 1, (v, context) -> v > 0 && v > context.getDimension());
+
+        KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder().dimension(0).build();
+
+        // Invalid type
+        assertNotNull(parameter.validate("String", knnMethodConfigContext));
+
+        // Invalid value
+        assertNotNull(parameter.validate(-1, knnMethodConfigContext));
+
+        // valid value
+        assertNull(parameter.validate(12, knnMethodConfigContext));
+    }
+
+    public void testStringParameter_validate() {
+        final StringParameter parameter = new StringParameter("test_parameter", "default_value", (v, context) -> "test".equals(v));
+        KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder()
+            .dimension(1)
+            .versionCreated(Version.CURRENT)
+            .vectorDataType(VectorDataType.FLOAT)
+            .build();
+        // Invalid type
+        assertNotNull(parameter.validate(5, knnMethodConfigContext));
+
+        // null
+        assertNotNull(parameter.validate(null, knnMethodConfigContext));
+
+        // valid value
+        assertNull(parameter.validate("test", knnMethodConfigContext));
+    }
+
+    public void testStringParameter_validateWithData() {
+        final StringParameter parameter = new StringParameter("test_parameter", "default_value", (v, context) -> {
+            if (context.getDimension() > 0) {
+                return "test".equals(v);
+            }
+            return false;
+        });
+
+        KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder().dimension(1).build();
+
+        // Invalid type
+        assertNotNull(parameter.validate(5, knnMethodConfigContext));
+
+        // null
+        assertNotNull(parameter.validate(null, knnMethodConfigContext));
+
+        // valid value
+        assertNull(parameter.validate("test", knnMethodConfigContext));
+
+        knnMethodConfigContext.setDimension(0);
+
+        // invalid value
+        assertNotNull(parameter.validate("test", knnMethodConfigContext));
+    }
+
+    public void testDoubleParameter_validate() {
+        final Parameter.DoubleParameter parameter = new Parameter.DoubleParameter("test_parameter", 1.0, (v, context) -> v >= 0);
+        KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder()
+            .dimension(1)
+            .versionCreated(Version.CURRENT)
+            .vectorDataType(VectorDataType.FLOAT)
+            .build();
+        // valid value
+        assertNull(parameter.validate(0.9, knnMethodConfigContext));
+
+        // Invalid type
+        assertNotNull(parameter.validate(true, knnMethodConfigContext));
+
+        // Invalid type
+        assertNotNull(parameter.validate(-1, knnMethodConfigContext));
+
+    }
+
+    public void testDoubleParameter_validateWithData() {
+        final Parameter.DoubleParameter parameter = new Parameter.DoubleParameter(
+            "test",
+            1.0,
+            (v, context) -> v > 0 && v > context.getDimension()
+        );
+
+        KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder().dimension(0).build();
+
+        // Invalid type
+        assertNotNull(parameter.validate("String", knnMethodConfigContext));
+
+        // Invalid value
+        assertNotNull(parameter.validate(-1, knnMethodConfigContext));
+
+        // valid value
+        assertNull(parameter.validate(1.2, knnMethodConfigContext));
+    }
+
+    public void testMethodComponentContextParameter_validate() {
+        String methodComponentName1 = "method-1";
+        String parameterKey1 = "parameter_key_1";
+        Integer parameterValue1 = 12;
+
+        Map<String, Object> defaultParameterMap = ImmutableMap.of(parameterKey1, parameterValue1);
+        MethodComponentContext methodComponentContext = new MethodComponentContext(methodComponentName1, defaultParameterMap);
+
+        KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder()
+            .dimension(1)
+            .versionCreated(Version.CURRENT)
+            .vectorDataType(VectorDataType.FLOAT)
+            .build();
+
+        Map<String, MethodComponent> methodComponentMap = ImmutableMap.of(
+            methodComponentName1,
+            MethodComponent.Builder.builder(parameterKey1)
+                .addSupportedDataTypes(Set.of(VectorDataType.FLOAT))
+                .addParameter(parameterKey1, new IntegerParameter(parameterKey1, 1, (v, context) -> v > 0))
+                .build()
+        );
+
+        final MethodComponentContextParameter parameter = new MethodComponentContextParameter(
+            "test",
+            methodComponentContext,
+            methodComponentMap
+        );
+
+        // Invalid type
+        assertNotNull(parameter.validate(17, knnMethodConfigContext));
+        assertNotNull(parameter.validate("invalid-value", knnMethodConfigContext));
+
+        // Invalid value
+        String invalidMethodComponentName = "invalid-method";
+        MethodComponentContext invalidMethodComponentContext1 = new MethodComponentContext(invalidMethodComponentName, defaultParameterMap);
+        assertNotNull(parameter.validate(invalidMethodComponentContext1, knnMethodConfigContext));
+
+        String invalidParameterKey = "invalid-parameter";
+        Map<String, Object> invalidParameterMap1 = ImmutableMap.of(invalidParameterKey, parameterValue1);
+        MethodComponentContext invalidMethodComponentContext2 = new MethodComponentContext(methodComponentName1, invalidParameterMap1);
+        assertNotNull(parameter.validate(invalidMethodComponentContext2, knnMethodConfigContext));
+
+        String invalidParameterValue = "invalid-value";
+        Map<String, Object> invalidParameterMap2 = ImmutableMap.of(parameterKey1, invalidParameterValue);
+        MethodComponentContext invalidMethodComponentContext3 = new MethodComponentContext(methodComponentName1, invalidParameterMap2);
+        assertNotNull(parameter.validate(invalidMethodComponentContext3, knnMethodConfigContext));
+
+        // valid value
+        assertNull(parameter.validate(methodComponentContext, knnMethodConfigContext));
+    }
+
+    public void testMethodComponentContextParameter_validateWithData() {
+        String methodComponentName1 = "method-1";
+        String parameterKey1 = "parameter_key_1";
+        Integer parameterValue1 = 12;
+
+        Map<String, Object> defaultParameterMap = ImmutableMap.of(parameterKey1, parameterValue1);
+        MethodComponentContext methodComponentContext = new MethodComponentContext(methodComponentName1, defaultParameterMap);
+
+        Map<String, MethodComponent> methodComponentMap = ImmutableMap.of(
+            methodComponentName1,
+            MethodComponent.Builder.builder(parameterKey1)
+                .addSupportedDataTypes(Set.of(VectorDataType.FLOAT))
+                .addParameter(parameterKey1, new IntegerParameter(parameterKey1, 1, (v, context) -> v > 0 && v > context.getDimension()))
+                .build()
+        );
+
+        final MethodComponentContextParameter parameter = new MethodComponentContextParameter(
+            "test",
+            methodComponentContext,
+            methodComponentMap
+        );
+
+        KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder()
+            .dimension(0)
+            .vectorDataType(VectorDataType.FLOAT)
+            .versionCreated(Version.CURRENT)
+            .build();
+
+        // Invalid type
+        assertNotNull(parameter.validate("invalid-value", knnMethodConfigContext));
+
+        // Invalid value
+        String invalidMethodComponentName = "invalid-method";
+        MethodComponentContext invalidMethodComponentContext1 = new MethodComponentContext(invalidMethodComponentName, defaultParameterMap);
+        assertNotNull(parameter.validate(invalidMethodComponentContext1, knnMethodConfigContext));
+
+        String invalidParameterKey = "invalid-parameter";
+        Map<String, Object> invalidParameterMap1 = ImmutableMap.of(invalidParameterKey, parameterValue1);
+        MethodComponentContext invalidMethodComponentContext2 = new MethodComponentContext(methodComponentName1, invalidParameterMap1);
+        assertNotNull(parameter.validate(invalidMethodComponentContext2, knnMethodConfigContext));
+
+        String invalidParameterValue = "invalid-value";
+        Map<String, Object> invalidParameterMap2 = ImmutableMap.of(parameterKey1, invalidParameterValue);
+        MethodComponentContext invalidMethodComponentContext3 = new MethodComponentContext(methodComponentName1, invalidParameterMap2);
+        assertNotNull(parameter.validate(invalidMethodComponentContext3, knnMethodConfigContext));
+
+        // valid value
+        assertNull(parameter.validate(methodComponentContext, knnMethodConfigContext));
+    }
+
+    public void testMethodComponentContextParameter_getMethodComponent() {
+        String methodComponentName1 = "method-1";
+        String parameterKey1 = "parameter_key_1";
+        Integer parameterValue1 = 12;
+
+        Map<String, Object> defaultParameterMap = ImmutableMap.of(parameterKey1, parameterValue1);
+        MethodComponentContext methodComponentContext = new MethodComponentContext(methodComponentName1, defaultParameterMap);
+
+        Map<String, MethodComponent> methodComponentMap = ImmutableMap.of(
+            methodComponentName1,
+            MethodComponent.Builder.builder(parameterKey1)
+                .addParameter(parameterKey1, new IntegerParameter(parameterKey1, 1, (v, context) -> v > 0))
+                .build()
+        );
+
+        final MethodComponentContextParameter parameter = new MethodComponentContextParameter(
+            "test",
+            methodComponentContext,
+            methodComponentMap
+        );
+
+        // Test when method component is available
+        assertEquals(methodComponentMap.get(methodComponentName1), parameter.getMethodComponent(methodComponentName1));
+
+        // test when method component is not available
+        String invalidMethod = "invalid-method";
+        assertNull(parameter.getMethodComponent(invalidMethod));
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/engine/SpaceTypeResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/SpaceTypeResolverTests.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine;
+
+import lombok.SneakyThrows;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.mapper.MapperParsingException;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.KNNSettings;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
+
+import static org.opensearch.Version.CURRENT;
+import static org.opensearch.knn.index.KNNSettings.KNN_INDEX;
+
+public class SpaceTypeResolverTests extends KNNTestCase {
+
+    private static final SpaceTypeResolver SPACE_TYPE_RESOLVER = SpaceTypeResolver.INSTANCE;
+    private static final Settings DONT_CARE_SETTINGS = null;
+    private static final VectorDataType DONT_CARE_VECTOR_DATA = null;
+
+    private void assertResolveSpaceType(
+        KNNMethodContext knnMethodContext,
+        String topLevelSpaceTypeString,
+        Settings indexSettings,
+        VectorDataType vectorDataType,
+        SpaceType expectedSpaceType
+    ) {
+        assertEquals(
+            expectedSpaceType,
+            SPACE_TYPE_RESOLVER.resolveSpaceType(knnMethodContext, topLevelSpaceTypeString, DONT_CARE_SETTINGS, vectorDataType)
+        );
+    }
+
+    public void testResolveSpaceType_whenNoConfigProvided_thenFallbackToVectorDataType() {
+        final Settings emptySettings = Settings.builder().put(settings(CURRENT).build()).put(KNN_INDEX, true).build();
+        final Settings settings = Settings.builder().put(settings(CURRENT).build()).put(KNN_INDEX, true).build();
+
+        final KNNMethodContext methodContext = new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.COSINESIMIL, MethodComponentContext.EMPTY);
+        final KNNMethodContext emptyMethodContext = new KNNMethodContext(
+            KNNEngine.DEFAULT,
+            SpaceType.UNDEFINED,
+            MethodComponentContext.EMPTY
+        );
+        final KNNMethodContext nullMethodContext = null;
+
+        assertResolveSpaceType(
+            methodContext,
+            SpaceType.COSINESIMIL.getValue(),
+            settings,
+            VectorDataType.BYTE,
+            methodContext.getSpaceType()
+        );
+        assertResolveSpaceType(
+            methodContext,
+            SpaceType.COSINESIMIL.getValue(),
+            settings,
+            VectorDataType.FLOAT,
+            methodContext.getSpaceType()
+        );
+        assertResolveSpaceType(
+            methodContext,
+            SpaceType.COSINESIMIL.getValue(),
+            settings,
+            VectorDataType.BINARY,
+            methodContext.getSpaceType()
+        );
+        assertResolveSpaceType(
+            methodContext,
+            SpaceType.COSINESIMIL.getValue(),
+            emptySettings,
+            VectorDataType.BYTE,
+            methodContext.getSpaceType()
+        );
+        assertResolveSpaceType(
+            methodContext,
+            SpaceType.COSINESIMIL.getValue(),
+            emptySettings,
+            VectorDataType.FLOAT,
+            methodContext.getSpaceType()
+        );
+        assertResolveSpaceType(
+            methodContext,
+            SpaceType.COSINESIMIL.getValue(),
+            emptySettings,
+            VectorDataType.BINARY,
+            methodContext.getSpaceType()
+        );
+        assertResolveSpaceType(methodContext, "", settings, VectorDataType.BYTE, methodContext.getSpaceType());
+        assertResolveSpaceType(methodContext, "", settings, VectorDataType.FLOAT, methodContext.getSpaceType());
+        assertResolveSpaceType(methodContext, "", settings, VectorDataType.BINARY, methodContext.getSpaceType());
+        assertResolveSpaceType(methodContext, "", emptySettings, VectorDataType.BYTE, methodContext.getSpaceType());
+        assertResolveSpaceType(methodContext, "", emptySettings, VectorDataType.FLOAT, methodContext.getSpaceType());
+        assertResolveSpaceType(methodContext, "", emptySettings, VectorDataType.BINARY, methodContext.getSpaceType());
+        assertResolveSpaceType(emptyMethodContext, SpaceType.COSINESIMIL.getValue(), settings, VectorDataType.BYTE, SpaceType.COSINESIMIL);
+        assertResolveSpaceType(emptyMethodContext, SpaceType.COSINESIMIL.getValue(), settings, VectorDataType.FLOAT, SpaceType.COSINESIMIL);
+        assertResolveSpaceType(
+            emptyMethodContext,
+            SpaceType.COSINESIMIL.getValue(),
+            settings,
+            VectorDataType.BINARY,
+            SpaceType.COSINESIMIL
+        );
+        assertResolveSpaceType(
+            emptyMethodContext,
+            SpaceType.COSINESIMIL.getValue(),
+            emptySettings,
+            VectorDataType.BYTE,
+            SpaceType.COSINESIMIL
+        );
+        assertResolveSpaceType(
+            emptyMethodContext,
+            SpaceType.COSINESIMIL.getValue(),
+            emptySettings,
+            VectorDataType.FLOAT,
+            SpaceType.COSINESIMIL
+        );
+        assertResolveSpaceType(
+            emptyMethodContext,
+            SpaceType.COSINESIMIL.getValue(),
+            emptySettings,
+            VectorDataType.BINARY,
+            SpaceType.COSINESIMIL
+        );
+        assertResolveSpaceType(
+            emptyMethodContext,
+            "",
+            settings,
+            VectorDataType.BYTE,
+            SpaceType.getSpace(KNNSettings.INDEX_KNN_DEFAULT_SPACE_TYPE)
+        );
+        assertResolveSpaceType(
+            emptyMethodContext,
+            "",
+            settings,
+            VectorDataType.FLOAT,
+            SpaceType.getSpace(KNNSettings.INDEX_KNN_DEFAULT_SPACE_TYPE)
+        );
+        assertResolveSpaceType(emptyMethodContext, "", settings, VectorDataType.BINARY, SpaceType.getSpace(SpaceType.HAMMING.name()));
+        assertResolveSpaceType(emptyMethodContext, "", emptySettings, VectorDataType.BYTE, SpaceType.DEFAULT);
+        assertResolveSpaceType(emptyMethodContext, "", emptySettings, VectorDataType.FLOAT, SpaceType.DEFAULT);
+        assertResolveSpaceType(emptyMethodContext, "", emptySettings, VectorDataType.BINARY, SpaceType.DEFAULT_BINARY);
+        assertResolveSpaceType(nullMethodContext, SpaceType.COSINESIMIL.getValue(), settings, VectorDataType.BYTE, SpaceType.COSINESIMIL);
+        assertResolveSpaceType(nullMethodContext, SpaceType.COSINESIMIL.getValue(), settings, VectorDataType.FLOAT, SpaceType.COSINESIMIL);
+        assertResolveSpaceType(nullMethodContext, SpaceType.COSINESIMIL.getValue(), settings, VectorDataType.BINARY, SpaceType.COSINESIMIL);
+        assertResolveSpaceType(
+            nullMethodContext,
+            SpaceType.COSINESIMIL.getValue(),
+            emptySettings,
+            VectorDataType.BYTE,
+            SpaceType.COSINESIMIL
+        );
+        assertResolveSpaceType(
+            nullMethodContext,
+            SpaceType.COSINESIMIL.getValue(),
+            emptySettings,
+            VectorDataType.FLOAT,
+            SpaceType.COSINESIMIL
+        );
+        assertResolveSpaceType(
+            nullMethodContext,
+            SpaceType.COSINESIMIL.getValue(),
+            emptySettings,
+            VectorDataType.BINARY,
+            SpaceType.COSINESIMIL
+        );
+        assertResolveSpaceType(
+            nullMethodContext,
+            "",
+            settings,
+            VectorDataType.BYTE,
+            SpaceType.getSpace(KNNSettings.INDEX_KNN_DEFAULT_SPACE_TYPE)
+        );
+        assertResolveSpaceType(
+            nullMethodContext,
+            "",
+            settings,
+            VectorDataType.FLOAT,
+            SpaceType.getSpace(KNNSettings.INDEX_KNN_DEFAULT_SPACE_TYPE)
+        );
+        assertResolveSpaceType(nullMethodContext, "", settings, VectorDataType.BINARY, SpaceType.getSpace(SpaceType.HAMMING.name()));
+        assertResolveSpaceType(nullMethodContext, "", emptySettings, VectorDataType.BYTE, SpaceType.DEFAULT);
+        assertResolveSpaceType(nullMethodContext, "", emptySettings, VectorDataType.FLOAT, SpaceType.DEFAULT);
+        assertResolveSpaceType(nullMethodContext, "", emptySettings, VectorDataType.BINARY, SpaceType.DEFAULT_BINARY);
+    }
+
+    final Settings settings = Settings.builder().put(settings(CURRENT).build()).put(KNN_INDEX, true).build();
+
+    @SneakyThrows
+    public void testResolveSpaceType_whenMethodSpaceTypeAndTopLevelSpecified_thenThrowIfConflict() {
+        expectThrows(
+            MapperParsingException.class,
+            () -> SPACE_TYPE_RESOLVER.resolveSpaceType(
+                new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.L2, MethodComponentContext.EMPTY),
+                SpaceType.INNER_PRODUCT.getValue(),
+                settings,
+                DONT_CARE_VECTOR_DATA
+            )
+        );
+        assertEquals(
+            SpaceType.DEFAULT,
+            SPACE_TYPE_RESOLVER.resolveSpaceType(
+                new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.DEFAULT, MethodComponentContext.EMPTY),
+                SpaceType.DEFAULT.getValue(),
+                settings,
+                DONT_CARE_VECTOR_DATA
+            )
+        );
+        assertEquals(
+            SpaceType.DEFAULT,
+            SPACE_TYPE_RESOLVER.resolveSpaceType(
+                new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.DEFAULT, MethodComponentContext.EMPTY),
+                SpaceType.UNDEFINED.getValue(),
+                settings,
+                DONT_CARE_VECTOR_DATA
+            )
+        );
+        assertEquals(
+            SpaceType.DEFAULT,
+            SPACE_TYPE_RESOLVER.resolveSpaceType(
+                new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.UNDEFINED, MethodComponentContext.EMPTY),
+                SpaceType.DEFAULT.getValue(),
+                settings,
+                DONT_CARE_VECTOR_DATA
+            )
+        );
+
+        // method (undefined) -> top level (undefined) -> settings (undefined) -> Default Space Type
+        assertEquals(
+            SpaceType.DEFAULT,
+            SPACE_TYPE_RESOLVER.resolveSpaceType(
+                new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.UNDEFINED, MethodComponentContext.EMPTY),
+                SpaceType.UNDEFINED.getValue(),
+                settings,
+                VectorDataType.BYTE
+            )
+        );
+
+        assertEquals(
+            SpaceType.DEFAULT,
+            SPACE_TYPE_RESOLVER.resolveSpaceType(
+                new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.UNDEFINED, MethodComponentContext.EMPTY),
+                SpaceType.UNDEFINED.getValue(),
+                settings,
+                VectorDataType.FLOAT
+            )
+        );
+
+        assertEquals(
+            SpaceType.DEFAULT_BINARY,
+            SPACE_TYPE_RESOLVER.resolveSpaceType(
+                new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.UNDEFINED, MethodComponentContext.EMPTY),
+                SpaceType.UNDEFINED.getValue(),
+                settings,
+                VectorDataType.BINARY
+            )
+        );
+    }
+
+    @SneakyThrows
+    public void testResolveSpaceType_whenSpaceTypeSpecifiedOnce_thenReturnValue() {
+        assertEquals(
+            SpaceType.L1,
+            SPACE_TYPE_RESOLVER.resolveSpaceType(
+                new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.L1, MethodComponentContext.EMPTY),
+                "",
+                settings,
+                null
+            )
+        );
+        assertEquals(
+            SpaceType.INNER_PRODUCT,
+            SPACE_TYPE_RESOLVER.resolveSpaceType(null, SpaceType.INNER_PRODUCT.getValue(), settings, null)
+        );
+    }
+}


### PR DESCRIPTION
### Description
[Describe what this change achieves]

- `EngineResolverTests` - added tests to match our `EngineResolver` class since k-NN repo has additional engines that we don’t use. Also, noticed some comments in `EngineResolver` that seems to be outdated.
- `KNNEngineTests` - added tests to match our `KNNEngine` class implementation
- `KNNMethodContextTests` - added tests to match our `KNNMethodContext` class implementation
- `MethodComponentContextTests` - added tests , this was not on k-NN repo

Rest all were migrated from k-NN latest implementation as they were compatible.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

Closes #458 
Parent #390 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
