### PR TITLE
fix: forbidden String.format() method invocations in main source files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Update Gradle to 9.4.1 [381](https://github.com/opensearch-project/opensearch-jvector/pull/381)
 ### Documentation
 ### Maintenance
+* Fix String.format() uses the default system locale [465](https://github.com/opensearch-project/opensearch-jvector/pull/465)
 ### Refactoring

--- a/src/main/java/org/opensearch/knn/index/KNNSettings.java
+++ b/src/main/java/org/opensearch/knn/index/KNNSettings.java
@@ -6,8 +6,6 @@
 package org.opensearch.knn.index;
 
 import lombok.extern.log4j.Log4j2;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.opensearch.OpenSearchParseException;
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
@@ -52,7 +50,6 @@ import static org.opensearch.knn.common.featureflags.KNNFeatureFlags.getFeatureF
 @Log4j2
 public class KNNSettings {
 
-    private static final Logger logger = LogManager.getLogger(KNNSettings.class);
     private static KNNSettings INSTANCE;
     private static final OsProbe osProbe = OsProbe.getInstance();
 
@@ -666,7 +663,7 @@ public class KNNSettings {
         client.admin().cluster().updateSettings(clusterUpdateSettingsRequest, new ActionListener<ClusterUpdateSettingsResponse>() {
             @Override
             public void onResponse(ClusterUpdateSettingsResponse clusterUpdateSettingsResponse) {
-                logger.debug(
+                log.debug(
                     "Cluster setting {}, acknowledged: {} ",
                     clusterUpdateSettingsRequest.persistentSettings(),
                     clusterUpdateSettingsResponse.isAcknowledged()
@@ -675,7 +672,7 @@ public class KNNSettings {
 
             @Override
             public void onFailure(Exception e) {
-                logger.info(
+                log.info(
                     "Exception while updating circuit breaker setting {} to {}",
                     clusterUpdateSettingsRequest.persistentSettings(),
                     e.getMessage()
@@ -720,7 +717,7 @@ public class KNNSettings {
 
     public void onIndexModule(IndexModule module) {
         module.addSettingsUpdateConsumer(INDEX_KNN_ALGO_PARAM_EF_SEARCH_SETTING, newVal -> {
-            logger.debug("The value of [KNN] setting [{}] changed to [{}]", KNN_ALGO_PARAM_EF_SEARCH, newVal);
+            log.debug("The value of [KNN] setting [{}] changed to [{}]", KNN_ALGO_PARAM_EF_SEARCH, newVal);
         });
     }
 

--- a/src/main/java/org/opensearch/knn/index/KNNVectorScriptDocValues.java
+++ b/src/main/java/org/opensearch/knn/index/KNNVectorScriptDocValues.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.index;
 
 import java.io.IOException;
+import java.util.Locale;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -49,6 +50,7 @@ public abstract class KNNVectorScriptDocValues extends ScriptDocValues<float[]> 
     public float[] getValue() {
         if (!docExists) {
             String errorMessage = String.format(
+                Locale.ROOT,
                 "One of the document doesn't have a value for field '%s'. "
                     + "This can be avoided by checking if a document has a value for the field or not "
                     + "by doc['%s'].size() == 0 ? 0 : {your script}",

--- a/src/main/java/org/opensearch/knn/index/SpaceType.java
+++ b/src/main/java/org/opensearch/knn/index/SpaceType.java
@@ -183,7 +183,9 @@ public enum SpaceType {
      * @return KNNVectorSimilarityFunction
      */
     public KNNVectorSimilarityFunction getKnnVectorSimilarityFunction() {
-        throw new UnsupportedOperationException(String.format(Locale.ROOT, "Space [%s] does not have a knn vector similarity function", getValue()));
+        throw new UnsupportedOperationException(
+            String.format(Locale.ROOT, "Space [%s] does not have a knn vector similarity function", getValue())
+        );
     }
 
     /**
@@ -253,6 +255,8 @@ public enum SpaceType {
      * @return translated distance
      */
     public float scoreToDistanceTranslation(float score) {
-        throw new UnsupportedOperationException(String.format(Locale.ROOT, "Space [%s] does not have a score to distance translation", getValue()));
+        throw new UnsupportedOperationException(
+            String.format(Locale.ROOT, "Space [%s] does not have a score to distance translation", getValue())
+        );
     }
 }

--- a/src/main/java/org/opensearch/knn/index/SpaceType.java
+++ b/src/main/java/org/opensearch/knn/index/SpaceType.java
@@ -183,7 +183,7 @@ public enum SpaceType {
      * @return KNNVectorSimilarityFunction
      */
     public KNNVectorSimilarityFunction getKnnVectorSimilarityFunction() {
-        throw new UnsupportedOperationException(String.format("Space [%s] does not have a knn vector similarity function", getValue()));
+        throw new UnsupportedOperationException(String.format(Locale.ROOT, "Space [%s] does not have a knn vector similarity function", getValue()));
     }
 
     /**
@@ -253,6 +253,6 @@ public enum SpaceType {
      * @return translated distance
      */
     public float scoreToDistanceTranslation(float score) {
-        throw new UnsupportedOperationException(String.format("Space [%s] does not have a score to distance translation", getValue()));
+        throw new UnsupportedOperationException(String.format(Locale.ROOT, "Space [%s] does not have a score to distance translation", getValue()));
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/BasePerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/BasePerFieldKnnVectorsFormat.java
@@ -19,6 +19,7 @@ import org.opensearch.knn.index.engine.KNNMethodContext;
 import org.opensearch.knn.index.mapper.KNNMappingConfig;
 import org.opensearch.knn.index.mapper.KNNVectorFieldType;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -99,7 +100,7 @@ public abstract class BasePerFieldKnnVectorsFormat extends PerFieldKnnVectorsFor
         }
         KNNVectorFieldType mappedFieldType = (KNNVectorFieldType) mapperService.orElseThrow(
             () -> new IllegalStateException(
-                String.format("Cannot read field type for field [%s] because mapper service is not available", field)
+                String.format(Locale.ROOT, "Cannot read field type for field [%s] because mapper service is not available", field)
             )
         ).fieldType(field);
 

--- a/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
@@ -11,8 +11,6 @@ import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
 import org.opensearch.knn.index.vectorvalues.KNNVectorValuesFactory;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.lucene.codecs.DocValuesConsumer;
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.index.DocValuesType;
@@ -33,8 +31,6 @@ import static org.opensearch.knn.common.FieldInfoExtractor.extractVectorDataType
 @Log4j2
 class KNN80DocValuesConsumer extends DocValuesConsumer {
 
-    private final Logger logger = LogManager.getLogger(KNN80DocValuesConsumer.class);
-
     private final DocValuesConsumer delegatee;
     private final SegmentWriteState state;
 
@@ -53,7 +49,7 @@ class KNN80DocValuesConsumer extends DocValuesConsumer {
             stopWatch.stop();
             long time_in_millis = stopWatch.totalTime().millis();
             KNNGraphValue.REFRESH_TOTAL_TIME_IN_MILLIS.set(KNNGraphValue.REFRESH_TOTAL_TIME_IN_MILLIS.getValue() + time_in_millis);
-            logger.warn("Refresh operation complete in " + time_in_millis + " ms");
+            log.warn("Refresh operation complete in " + time_in_millis + " ms");
         }
     }
 
@@ -89,7 +85,7 @@ class KNN80DocValuesConsumer extends DocValuesConsumer {
                     stopWatch.stop();
                     long time_in_millis = stopWatch.totalTime().millis();
                     KNNGraphValue.MERGE_TOTAL_TIME_IN_MILLIS.set(KNNGraphValue.MERGE_TOTAL_TIME_IN_MILLIS.getValue() + time_in_millis);
-                    logger.warn("Merge operation complete in " + time_in_millis + " ms");
+                    log.warn("Merge operation complete in " + time_in_millis + " ms");
                 }
             }
         } catch (Exception e) {

--- a/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
@@ -49,7 +49,7 @@ class KNN80DocValuesConsumer extends DocValuesConsumer {
             stopWatch.stop();
             long time_in_millis = stopWatch.totalTime().millis();
             KNNGraphValue.REFRESH_TOTAL_TIME_IN_MILLIS.set(KNNGraphValue.REFRESH_TOTAL_TIME_IN_MILLIS.getValue() + time_in_millis);
-            log.warn("Refresh operation complete in " + time_in_millis + " ms");
+            log.warn("Refresh operation complete in {} ms", time_in_millis);
         }
     }
 
@@ -85,7 +85,7 @@ class KNN80DocValuesConsumer extends DocValuesConsumer {
                     stopWatch.stop();
                     long time_in_millis = stopWatch.totalTime().millis();
                     KNNGraphValue.MERGE_TOTAL_TIME_IN_MILLIS.set(KNNGraphValue.MERGE_TOTAL_TIME_IN_MILLIS.getValue() + time_in_millis);
-                    log.warn("Merge operation complete in " + time_in_millis + " ms");
+                    log.warn("Merge operation complete in {} ms", time_in_millis);
                 }
             }
         } catch (Exception e) {

--- a/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
@@ -55,7 +55,7 @@ class KNN80DocValuesConsumer extends DocValuesConsumer {
 
     private boolean isKNNBinaryFieldRequired(FieldInfo field) {
         final KNNEngine knnEngine = extractKNNEngine(field);
-        log.debug(String.format("Read engine [%s] for field [%s]", knnEngine.getName(), field.getName()));
+        log.debug("Read engine [{}] for field [{}]", knnEngine.getName(), field.getName());
         return field.attributes().containsKey(KNNVectorFieldMapper.KNN_FIELD)
             && KNNEngine.getEnginesThatCreateCustomSegmentFiles().stream().anyMatch(engine -> engine == knnEngine);
     }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/KNN990QuantizationStateReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/KNN990QuantizationStateReader.java
@@ -21,6 +21,7 @@ import org.opensearch.knn.quantization.models.quantizationState.QuantizationStat
 import org.opensearch.knn.quantization.models.quantizationState.QuantizationStateReadConfig;
 
 import java.io.IOException;
+import java.util.Locale;
 
 /**
  * Reads quantization states
@@ -75,7 +76,7 @@ public final class KNN990QuantizationStateReader {
             }
 
             if (position == -1 || length == 0) {
-                throw new IllegalArgumentException(String.format("Field %s not found", field));
+                throw new IllegalArgumentException(String.format(Locale.ROOT, "Field %s not found", field));
             }
 
             byte[] stateBytes = readStateBytes(input, position, length);
@@ -89,7 +90,7 @@ public final class KNN990QuantizationStateReader {
                 case FOUR_BIT:
                     return MultiBitScalarQuantizationState.fromByteArray(stateBytes);
                 default:
-                    throw new IllegalArgumentException(String.format("Unexpected scalar quantization type: %s", scalarQuantizationType));
+                    throw new IllegalArgumentException(String.format(Locale.ROOT, "Unexpected scalar quantization type: %s", scalarQuantizationType));
             }
         }
     }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/KNN990QuantizationStateReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/KNN990QuantizationStateReader.java
@@ -90,7 +90,9 @@ public final class KNN990QuantizationStateReader {
                 case FOUR_BIT:
                     return MultiBitScalarQuantizationState.fromByteArray(stateBytes);
                 default:
-                    throw new IllegalArgumentException(String.format(Locale.ROOT, "Unexpected scalar quantization type: %s", scalarQuantizationType));
+                    throw new IllegalArgumentException(
+                        String.format(Locale.ROOT, "Unexpected scalar quantization type: %s", scalarQuantizationType)
+                    );
             }
         }
     }

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorTransformer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorTransformer.java
@@ -20,7 +20,12 @@ import org.opensearch.common.regex.Regex;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.*;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 import static org.opensearch.knn.index.KNNSettings.KNN_DERIVED_SOURCE_ENABLED;
@@ -152,7 +157,7 @@ public class DerivedSourceVectorTransformer {
         if (isNested) {
             ValidationException validationException = new ValidationException();
             validationException.addValidationError(
-                String.format("Nested fields are not supported when [%s] is true.", KNN_DERIVED_SOURCE_ENABLED)
+                String.format(Locale.ROOT, "Nested fields are not supported when [%s] is true.", KNN_DERIVED_SOURCE_ENABLED)
             );
             throw validationException;
 

--- a/src/main/java/org/opensearch/knn/index/codec/util/KNNCodecUtil.java
+++ b/src/main/java/org/opensearch/knn/index/codec/util/KNNCodecUtil.java
@@ -18,6 +18,7 @@ import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
 
 import java.io.IOException;
+import java.util.Locale;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -48,15 +49,15 @@ public class KNNCodecUtil {
     }
 
     public static String buildEngineFileName(String segmentName, String latestBuildVersion, String fieldName, String extension) {
-        return String.format("%s%s%s", buildEngineFilePrefix(segmentName), latestBuildVersion, buildEngineFileSuffix(fieldName, extension));
+        return String.format(Locale.ROOT, "%s%s%s", buildEngineFilePrefix(segmentName), latestBuildVersion, buildEngineFileSuffix(fieldName, extension));
     }
 
     public static String buildEngineFilePrefix(String segmentName) {
-        return String.format("%s_", segmentName);
+        return String.format(Locale.ROOT, "%s_", segmentName);
     }
 
     public static String buildEngineFileSuffix(String fieldName, String extension) {
-        return String.format("_%s%s", fieldName, extension);
+        return String.format(Locale.ROOT, "_%s%s", fieldName, extension);
     }
 
     public static long getTotalLiveDocsCount(final BinaryDocValues binaryDocValues) {

--- a/src/main/java/org/opensearch/knn/index/codec/util/KNNCodecUtil.java
+++ b/src/main/java/org/opensearch/knn/index/codec/util/KNNCodecUtil.java
@@ -49,7 +49,13 @@ public class KNNCodecUtil {
     }
 
     public static String buildEngineFileName(String segmentName, String latestBuildVersion, String fieldName, String extension) {
-        return String.format(Locale.ROOT, "%s%s%s", buildEngineFilePrefix(segmentName), latestBuildVersion, buildEngineFileSuffix(fieldName, extension));
+        return String.format(
+            Locale.ROOT,
+            "%s%s%s",
+            buildEngineFilePrefix(segmentName),
+            latestBuildVersion,
+            buildEngineFileSuffix(fieldName, extension)
+        );
     }
 
     public static String buildEngineFilePrefix(String segmentName) {

--- a/src/main/java/org/opensearch/knn/index/codec/util/KNNVectorSerializerFactory.java
+++ b/src/main/java/org/opensearch/knn/index/codec/util/KNNVectorSerializerFactory.java
@@ -76,7 +76,11 @@ public class KNNVectorSerializerFactory {
             return serializationMode;
         }
         throw new IllegalArgumentException(
-            String.format(Locale.ROOT, "Byte stream cannot be deserialized to array of floats due to invalid length %d", numberOfRemainingBytes)
+            String.format(
+                Locale.ROOT,
+                "Byte stream cannot be deserialized to array of floats due to invalid length %d",
+                numberOfRemainingBytes
+            )
         );
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/util/KNNVectorSerializerFactory.java
+++ b/src/main/java/org/opensearch/knn/index/codec/util/KNNVectorSerializerFactory.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.lucene.util.BytesRef;
 
 import java.io.ObjectStreamConstants;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.opensearch.knn.index.codec.util.SerializationMode.ARRAY;
@@ -75,7 +76,7 @@ public class KNNVectorSerializerFactory {
             return serializationMode;
         }
         throw new IllegalArgumentException(
-            String.format("Byte stream cannot be deserialized to array of floats due to invalid length %d", numberOfRemainingBytes)
+            String.format(Locale.ROOT, "Byte stream cannot be deserialized to array of floats due to invalid length %d", numberOfRemainingBytes)
         );
     }
 

--- a/src/main/java/org/opensearch/knn/index/engine/AbstractKNNLibrary.java
+++ b/src/main/java/org/opensearch/knn/index/engine/AbstractKNNLibrary.java
@@ -109,7 +109,7 @@ public abstract class AbstractKNNLibrary implements KNNLibrary {
     private String validateMethodExists(String methodName) {
         KNNMethod method = methods.get(methodName);
         if (method == null) {
-            return String.format("Invalid method name: %s", methodName);
+            return String.format(Locale.ROOT, "Invalid method name: %s", methodName);
         }
         return null;
     }

--- a/src/main/java/org/opensearch/knn/index/engine/KNNEngine.java
+++ b/src/main/java/org/opensearch/knn/index/engine/KNNEngine.java
@@ -13,6 +13,7 @@ import org.opensearch.knn.index.codec.jvector.JVector;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -63,7 +64,7 @@ public enum KNNEngine implements KNNLibrary {
             return JVECTOR;
         }
 
-        throw new IllegalArgumentException(String.format("Invalid engine type: %s", name));
+        throw new IllegalArgumentException(String.format(Locale.ROOT, "Invalid engine type: %s", name));
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/engine/Parameter.java
+++ b/src/main/java/org/opensearch/knn/index/engine/Parameter.java
@@ -62,14 +62,14 @@ public abstract class Parameter<T> {
             if (!(value instanceof Boolean)) {
                 validationException = new ValidationException();
                 validationException.addValidationError(
-                    String.format("value is not an instance of Boolean for Boolean parameter [%s].", getName())
+                    String.format(Locale.ROOT, "value is not an instance of Boolean for Boolean parameter [%s].", getName())
                 );
                 return validationException;
             }
 
             if (!validator.apply((Boolean) value, knnMethodConfigContext)) {
                 validationException = new ValidationException();
-                validationException.addValidationError(String.format("parameter validation failed for Boolean parameter [%s].", getName()));
+                validationException.addValidationError(String.format(Locale.ROOT, "parameter validation failed for Boolean parameter [%s].", getName()));
             }
             return validationException;
         }
@@ -89,14 +89,14 @@ public abstract class Parameter<T> {
             if (!(value instanceof Integer)) {
                 validationException = new ValidationException();
                 validationException.addValidationError(
-                    String.format("value is not an instance of Integer for Integer parameter [%s].", getName())
+                    String.format(Locale.ROOT, "value is not an instance of Integer for Integer parameter [%s].", getName())
                 );
                 return validationException;
             }
 
             if (!validator.apply((Integer) value, knnMethodConfigContext)) {
                 validationException = new ValidationException();
-                validationException.addValidationError(String.format("parameter validation failed for Integer parameter [%s].", getName()));
+                validationException.addValidationError(String.format(Locale.ROOT, "parameter validation failed for Integer parameter [%s].", getName()));
             }
 
             return validationException;
@@ -165,14 +165,14 @@ public abstract class Parameter<T> {
             if (!(value instanceof String)) {
                 validationException = new ValidationException();
                 validationException.addValidationError(
-                    String.format("value is not an instance of String for String parameter [%s].", getName())
+                    String.format(Locale.ROOT, "value is not an instance of String for String parameter [%s].", getName())
                 );
                 return validationException;
             }
 
             if (!validator.apply((String) value, knnMethodConfigContext)) {
                 validationException = new ValidationException();
-                validationException.addValidationError(String.format("parameter validation failed for String parameter [%s].", getName()));
+                validationException.addValidationError(String.format(Locale.ROOT, "parameter validation failed for String parameter [%s].", getName()));
             }
 
             return validationException;
@@ -216,7 +216,7 @@ public abstract class Parameter<T> {
             if (!(value instanceof MethodComponentContext)) {
                 validationException = new ValidationException();
                 validationException.addValidationError(
-                    String.format("value is not an instance of for MethodComponentContext parameter [%s].", getName())
+                    String.format(Locale.ROOT, "value is not an instance of for MethodComponentContext parameter [%s].", getName())
                 );
                 return validationException;
             }
@@ -224,7 +224,7 @@ public abstract class Parameter<T> {
             if (!validator.apply((MethodComponentContext) value, knnMethodConfigContext)) {
                 validationException = new ValidationException();
                 validationException.addValidationError(
-                    String.format("parameter validation failed for MethodComponentContext parameter [%s].", getName())
+                    String.format(Locale.ROOT, "parameter validation failed for MethodComponentContext parameter [%s].", getName())
                 );
             }
 

--- a/src/main/java/org/opensearch/knn/index/engine/Parameter.java
+++ b/src/main/java/org/opensearch/knn/index/engine/Parameter.java
@@ -69,7 +69,9 @@ public abstract class Parameter<T> {
 
             if (!validator.apply((Boolean) value, knnMethodConfigContext)) {
                 validationException = new ValidationException();
-                validationException.addValidationError(String.format(Locale.ROOT, "parameter validation failed for Boolean parameter [%s].", getName()));
+                validationException.addValidationError(
+                    String.format(Locale.ROOT, "parameter validation failed for Boolean parameter [%s].", getName())
+                );
             }
             return validationException;
         }
@@ -96,7 +98,9 @@ public abstract class Parameter<T> {
 
             if (!validator.apply((Integer) value, knnMethodConfigContext)) {
                 validationException = new ValidationException();
-                validationException.addValidationError(String.format(Locale.ROOT, "parameter validation failed for Integer parameter [%s].", getName()));
+                validationException.addValidationError(
+                    String.format(Locale.ROOT, "parameter validation failed for Integer parameter [%s].", getName())
+                );
             }
 
             return validationException;
@@ -172,7 +176,9 @@ public abstract class Parameter<T> {
 
             if (!validator.apply((String) value, knnMethodConfigContext)) {
                 validationException = new ValidationException();
-                validationException.addValidationError(String.format(Locale.ROOT, "parameter validation failed for String parameter [%s].", getName()));
+                validationException.addValidationError(
+                    String.format(Locale.ROOT, "parameter validation failed for String parameter [%s].", getName())
+                );
             }
 
             return validationException;

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
@@ -149,11 +149,9 @@ public class KNNVectorFieldMapperUtil {
         if (spaceType == null) {
             spaceType = KNNSettings.INDEX_KNN_DEFAULT_SPACE_TYPE;
             log.info(
-                String.format(
-                    "[KNN] The setting \"%s\" was not set for the index. Likely caused by recent version upgrade. Setting the setting to the default value=%s",
-                    METHOD_PARAMETER_SPACE_TYPE,
-                    spaceType
-                )
+                "[KNN] The setting \"{}\" was not set for the index. Likely caused by recent version upgrade. Setting the setting to the default value={}",
+                METHOD_PARAMETER_SPACE_TYPE,
+                spaceType
             );
         }
         return SpaceType.getSpace(spaceType);
@@ -163,11 +161,9 @@ public class KNNVectorFieldMapperUtil {
         String m = indexSettings.get(KNNSettings.INDEX_KNN_ALGO_PARAM_M_SETTING.getKey());
         if (m == null) {
             log.info(
-                String.format(
-                    "[KNN] The setting \"%s\" was not set for the index. Likely caused by recent version upgrade. Setting the setting to the default value=%s",
-                    HNSW_ALGO_M,
-                    KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_M
-                )
+                "[KNN] The setting \"{}\" was not set for the index. Likely caused by recent version upgrade. Setting the setting to the default value={}",
+                HNSW_ALGO_M,
+                KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_M
             );
             return KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_M;
         }
@@ -179,12 +175,10 @@ public class KNNVectorFieldMapperUtil {
         if (efConstruction == null) {
             final int defaultEFConstructionValue = IndexHyperParametersUtil.getHNSWEFConstructionValue(indexVersion);
             log.info(
-                String.format(
-                    "[KNN] The setting \"%s\" was not set for the index. Likely caused by recent version upgrade. "
-                        + "Picking up default value for the index =%s",
-                    HNSW_ALGO_EF_CONSTRUCTION,
-                    defaultEFConstructionValue
-                )
+                "[KNN] The setting \"{}\" was not set for the index. Likely caused by recent version upgrade. "
+                    + "Picking up default value for the index ={}",
+                HNSW_ALGO_EF_CONSTRUCTION,
+                defaultEFConstructionValue
             );
             return defaultEFConstructionValue;
         }

--- a/src/main/java/org/opensearch/knn/index/mapper/MethodFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/MethodFieldMapper.java
@@ -21,6 +21,7 @@ import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
 import org.opensearch.knn.index.engine.qframe.QuantizationConfigParser;
 
 import java.io.IOException;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
@@ -158,7 +159,7 @@ public class MethodFieldMapper extends KNNVectorFieldMapper {
                 XContentFactory.jsonBuilder().map(knnLibraryIndexingContext.getLibraryParameters()).toString()
             );
         } catch (IOException ioe) {
-            throw new RuntimeException(String.format("Unable to create KNNVectorFieldMapper: %s", ioe));
+            throw new RuntimeException(String.format(Locale.ROOT, "Unable to create KNNVectorFieldMapper: %s", ioe));
         }
 
         if (useLuceneBasedVectorField) {

--- a/src/main/java/org/opensearch/knn/index/query/BaseQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/BaseQueryFactory.java
@@ -75,11 +75,9 @@ public abstract class BaseQueryFactory {
         final QueryShardContext queryShardContext = createQueryRequest.getContext()
             .orElseThrow(() -> new RuntimeException("Shard context cannot be null"));
         log.debug(
-            String.format(
-                "Creating query with filter for index [%s], field [%s]",
-                createQueryRequest.getIndexName(),
-                createQueryRequest.getFieldName()
-            )
+            "Creating query with filter for index [{}], field [{}]",
+            createQueryRequest.getIndexName(),
+            createQueryRequest.getFieldName()
         );
         final Query filterQuery;
         try {

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -116,13 +116,13 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
     @Deprecated
     public KNNQueryBuilder(String fieldName, float[] vector) {
         if (Strings.isNullOrEmpty(fieldName)) {
-            throw new IllegalArgumentException(String.format("[%s] requires fieldName", NAME));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] requires fieldName", NAME));
         }
         if (vector == null) {
-            throw new IllegalArgumentException(String.format("[%s] requires query vector", NAME));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] requires query vector", NAME));
         }
         if (vector.length == 0) {
-            throw new IllegalArgumentException(String.format("[%s] query vector is empty", NAME));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] query vector is empty", NAME));
         }
         this.fieldName = fieldName;
         this.vector = vector;
@@ -458,7 +458,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
         if (this.maxDistance != null) {
             if (this.maxDistance < 0 && SpaceType.INNER_PRODUCT.equals(spaceType) == false) {
                 throw new IllegalArgumentException(
-                    String.format("[" + NAME + "] requires distance to be non-negative for space type: %s", spaceType)
+                    String.format(Locale.ROOT, "[" + NAME + "] requires distance to be non-negative for space type: %s", spaceType)
                 );
             }
             radius = knnEngine.distanceToRadialThreshold(this.maxDistance, spaceType);
@@ -467,7 +467,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
         if (this.minScore != null) {
             if (this.minScore > 1 && SpaceType.INNER_PRODUCT.equals(spaceType) == false) {
                 throw new IllegalArgumentException(
-                    String.format("[" + NAME + "] requires score to be in the range [0, 1] for space type: %s", spaceType)
+                    String.format(Locale.ROOT, "[" + NAME + "] requires score to be in the range [0, 1] for space type: %s", spaceType)
                 );
             }
             radius = knnEngine.scoreToRadialThreshold(this.minScore, spaceType);
@@ -476,7 +476,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
         int vectorLength = VectorDataType.BINARY == vectorDataType ? vector.length * Byte.SIZE : vector.length;
         if (fieldDimension != vectorLength) {
             throw new IllegalArgumentException(
-                String.format("Query vector has invalid dimension: %d. Dimension should be: %d", vectorLength, fieldDimension)
+                String.format(Locale.ROOT, "Query vector has invalid dimension: %d. Dimension should be: %d", vectorLength, fieldDimension)
             );
         }
 

--- a/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
@@ -69,7 +69,7 @@ public class RNNQueryFactory extends BaseQueryFactory {
         final Query filterQuery = getFilterQuery(createQueryRequest);
         final Map<String, ?> methodParameters = createQueryRequest.getMethodParameters();
 
-        log.debug(String.format("Creating Lucene r-NN query for index: %s \"\", field: %s \"\", k: %f", indexName, fieldName, radius));
+        log.debug("Creating Lucene r-NN query for index: {} \"\", field: {} \"\", k: {}", indexName, fieldName, radius);
         switch (vectorDataType) {
             case BYTE:
                 return getByteVectorSimilarityQuery(fieldName, byteVector, radius, filterQuery);

--- a/src/main/java/org/opensearch/knn/index/query/parser/KNNQueryBuilderParser.java
+++ b/src/main/java/org/opensearch/knn/index/query/parser/KNNQueryBuilderParser.java
@@ -269,7 +269,9 @@ public final class KNNQueryBuilderParser {
 
     private static float[] floatListToFloatArray(List<Float> floats) {
         if (Objects.isNull(floats) || floats.isEmpty()) {
-            throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] field 'vector' requires to be non-null and non-empty", NAME));
+            throw new IllegalArgumentException(
+                String.format(Locale.ROOT, "[%s] field 'vector' requires to be non-null and non-empty", NAME)
+            );
         }
         float[] vec = new float[floats.size()];
         for (int i = 0; i < floats.size(); i++) {

--- a/src/main/java/org/opensearch/knn/index/query/parser/KNNQueryBuilderParser.java
+++ b/src/main/java/org/opensearch/knn/index/query/parser/KNNQueryBuilderParser.java
@@ -269,7 +269,7 @@ public final class KNNQueryBuilderParser {
 
     private static float[] floatListToFloatArray(List<Float> floats) {
         if (Objects.isNull(floats) || floats.isEmpty()) {
-            throw new IllegalArgumentException(String.format("[%s] field 'vector' requires to be non-null and non-empty", NAME));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] field 'vector' requires to be non-null and non-empty", NAME));
         }
         float[] vec = new float[floats.size()];
         for (int i = 0; i < floats.size(); i++) {

--- a/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
+++ b/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
@@ -143,7 +143,9 @@ public class IndexUtil {
         Object type = fieldMap.get("type");
 
         if (!(type instanceof String) || !KNNVectorFieldMapper.CONTENT_TYPE.equals(type)) {
-            exception.addValidationError(String.format(Locale.ROOT, "Field \"%s\" is not of type %s.", field, KNNVectorFieldMapper.CONTENT_TYPE));
+            exception.addValidationError(
+                String.format(Locale.ROOT, "Field \"%s\" is not of type %s.", field, KNNVectorFieldMapper.CONTENT_TYPE)
+            );
             return exception;
         }
 

--- a/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
+++ b/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
@@ -119,7 +119,7 @@ public class IndexUtil {
 
         // Check field path is valid
         if (StringUtils.isEmpty(field)) {
-            exception.addValidationError(String.format(Locale.ROOT, "Field path is empty."));
+            exception.addValidationError("Field path is empty.");
             return exception;
         }
 
@@ -127,13 +127,13 @@ public class IndexUtil {
 
         // Check field existence
         if (fieldMapping == null) {
-            exception.addValidationError(String.format("Field \"%s\" does not exist.", field));
+            exception.addValidationError(String.format(Locale.ROOT, "Field \"%s\" does not exist.", field));
             return exception;
         }
 
         // Check if field is a map. If not, that is a problem
         if (!(fieldMapping instanceof Map)) {
-            exception.addValidationError(String.format("Field info for \"%s\" is not a map.", field));
+            exception.addValidationError(String.format(Locale.ROOT, "Field info for \"%s\" is not a map.", field));
             return exception;
         }
 
@@ -143,7 +143,7 @@ public class IndexUtil {
         Object type = fieldMap.get("type");
 
         if (!(type instanceof String) || !KNNVectorFieldMapper.CONTENT_TYPE.equals(type)) {
-            exception.addValidationError(String.format("Field \"%s\" is not of type %s.", field, KNNVectorFieldMapper.CONTENT_TYPE));
+            exception.addValidationError(String.format(Locale.ROOT, "Field \"%s\" is not of type %s.", field, KNNVectorFieldMapper.CONTENT_TYPE));
             return exception;
         }
 
@@ -204,6 +204,7 @@ public class IndexUtil {
         if ((Integer) dimension != expectedDimension) {
             exception.addValidationError(
                 String.format(
+                    Locale.ROOT,
                     "Field \"%s\" has dimension %d, which is different from " + "dimension specified in the training request: %d",
                     field,
                     dimension,

--- a/src/main/java/org/opensearch/knn/index/util/KNNClusterUtil.java
+++ b/src/main/java/org/opensearch/knn/index/util/KNNClusterUtil.java
@@ -65,7 +65,8 @@ public class KNNClusterUtil {
             return this.clusterService.state().getNodes().getMinNodeVersion();
         } catch (Exception exception) {
             log.error(
-                String.format("Failed to get cluster minimum node version, returning current node version %s instead.", Version.CURRENT),
+                "Failed to get cluster minimum node version, returning current node version {} instead.",
+                Version.CURRENT,
                 exception
             );
             return Version.CURRENT;

--- a/src/main/java/org/opensearch/knn/index/util/KNNClusterUtil.java
+++ b/src/main/java/org/opensearch/knn/index/util/KNNClusterUtil.java
@@ -64,11 +64,7 @@ public class KNNClusterUtil {
         try {
             return this.clusterService.state().getNodes().getMinNodeVersion();
         } catch (Exception exception) {
-            log.error(
-                "Failed to get cluster minimum node version, returning current node version {} instead.",
-                Version.CURRENT,
-                exception
-            );
+            log.error("Failed to get cluster minimum node version, returning current node version {} instead.", Version.CURRENT, exception);
             return Version.CURRENT;
         }
     }

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringUtil.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringUtil.java
@@ -33,6 +33,7 @@ public class KNNScoringUtil {
         Objects.requireNonNull(inputVector);
         if (queryVector.length != inputVector.length) {
             String errorMessage = String.format(
+                Locale.ROOT,
                 "query vector dimension mismatch. Expected: %d, Given: %d",
                 inputVector.length,
                 queryVector.length
@@ -53,6 +54,7 @@ public class KNNScoringUtil {
         Objects.requireNonNull(inputVector);
         if (queryVector.length != inputVector.length) {
             String errorMessage = String.format(
+                Locale.ROOT,
                 "query vector dimension mismatch. Expected: %d, Given: %d",
                 inputVector.length,
                 queryVector.length

--- a/src/main/java/org/opensearch/knn/search/processor/mmr/MMRUtil.java
+++ b/src/main/java/org/opensearch/knn/search/processor/mmr/MMRUtil.java
@@ -136,6 +136,7 @@ public class MMRUtil {
         if (!nonKnnFields.isEmpty()) {
             throw new IllegalArgumentException(
                 String.format(
+                    Locale.ROOT,
                     "MMR query extension cannot support non knn_vector field [%s].",
                     nonKnnFields.stream()
                         .map(info -> String.format(Locale.ROOT, "%s:%s", info.getIndexName(), info.getFieldPath()))
@@ -163,6 +164,7 @@ public class MMRUtil {
         if (!current.equals(next)) {
             throw new IllegalArgumentException(
                 String.format(
+                    Locale.ROOT,
                     "MMR query extension cannot support different %s [%s, %s] for the knn_vector field at path %s.",
                     fieldDescription,
                     valueFormatter.apply(current),
@@ -209,6 +211,7 @@ public class MMRUtil {
         if (userProvided != null && resolved != null && !userProvided.equals(resolved)) {
             throw new IllegalArgumentException(
                 String.format(
+                    Locale.ROOT,
                     "The %s [%s] provided in the MMR query extension does not match the %s [%s] in target indices.",
                     fieldDescription,
                     valueFormatter.apply(userProvided),
@@ -326,14 +329,14 @@ public class MMRUtil {
             String part = pathParts[i];
             if (!(current instanceof Map<?, ?> map)) {
                 throw new IllegalArgumentException(
-                    String.format("%s: expected object at [%s], but found [%s]", baseError, part, current.getClass().getName())
+                    String.format(Locale.ROOT, "%s: expected object at [%s], but found [%s]", baseError, part, current.getClass().getName())
                 );
             }
 
             current = map.get(part);
             if (current == null) {
                 throw new IllegalArgumentException(
-                    String.format("%s: field path [%s] not found in document source.", baseError, fieldPath)
+                    String.format(Locale.ROOT, "%s: field path [%s] not found in document source.", baseError, fieldPath)
                 );
             }
 
@@ -357,7 +360,7 @@ public class MMRUtil {
                         }
                     } catch (Exception e) {
                         throw new IllegalArgumentException(
-                            String.format("%s: unexpected value at the vector field [%s]. error: %s", baseError, fieldPath, e.getMessage()),
+                            String.format(Locale.ROOT, "%s: unexpected value at the vector field [%s]. error: %s", baseError, fieldPath, e.getMessage()),
                             e
                         );
                     }
@@ -367,6 +370,7 @@ public class MMRUtil {
                 }
                 throw new IllegalArgumentException(
                     String.format(
+                        Locale.ROOT,
                         "%s: expected vector (list of numbers) at field path [%s], but found type [%s]",
                         baseError,
                         fieldPath,
@@ -377,7 +381,7 @@ public class MMRUtil {
         }
 
         // Should never reach here
-        throw new IllegalStateException(String.format("%s: unexpected error resolving field path [%s].", baseError, fieldPath));
+        throw new IllegalStateException(String.format(Locale.ROOT, "%s: unexpected error resolving field path [%s].", baseError, fieldPath));
     }
 
     /**
@@ -426,7 +430,7 @@ public class MMRUtil {
             String fieldType = (String) current.get(TYPE);
             if (ObjectMapper.NESTED_CONTENT_TYPE.equals(fieldType)) {
                 throw new IllegalArgumentException(
-                    String.format("MMR search extension cannot support the field %s because it is in the nested field %s.", fieldPath, part)
+                    String.format(Locale.ROOT, "MMR search extension cannot support the field %s because it is in the nested field %s.", fieldPath, part)
                 );
             }
         }

--- a/src/main/java/org/opensearch/knn/search/processor/mmr/MMRUtil.java
+++ b/src/main/java/org/opensearch/knn/search/processor/mmr/MMRUtil.java
@@ -360,7 +360,13 @@ public class MMRUtil {
                         }
                     } catch (Exception e) {
                         throw new IllegalArgumentException(
-                            String.format(Locale.ROOT, "%s: unexpected value at the vector field [%s]. error: %s", baseError, fieldPath, e.getMessage()),
+                            String.format(
+                                Locale.ROOT,
+                                "%s: unexpected value at the vector field [%s]. error: %s",
+                                baseError,
+                                fieldPath,
+                                e.getMessage()
+                            ),
                             e
                         );
                     }
@@ -381,7 +387,9 @@ public class MMRUtil {
         }
 
         // Should never reach here
-        throw new IllegalStateException(String.format(Locale.ROOT, "%s: unexpected error resolving field path [%s].", baseError, fieldPath));
+        throw new IllegalStateException(
+            String.format(Locale.ROOT, "%s: unexpected error resolving field path [%s].", baseError, fieldPath)
+        );
     }
 
     /**
@@ -430,7 +438,12 @@ public class MMRUtil {
             String fieldType = (String) current.get(TYPE);
             if (ObjectMapper.NESTED_CONTENT_TYPE.equals(fieldType)) {
                 throw new IllegalArgumentException(
-                    String.format(Locale.ROOT, "MMR search extension cannot support the field %s because it is in the nested field %s.", fieldPath, part)
+                    String.format(
+                        Locale.ROOT,
+                        "MMR search extension cannot support the field %s because it is in the nested field %s.",
+                        fieldPath,
+                        part
+                    )
                 );
             }
         }


### PR DESCRIPTION
### Description

Issue: String.format() uses the default system locale, which can cause:
- Inconsistent behavior across different systems/locales
- Potential internationalization bugs in distributed environments
- Unpredictable formatting in production

1. Fixed all forbidden `String.format()` method invocations in main source files by adding `Locale.ROOT` parameter or using parameterized logging. Example entry during build before fix: "Forbidden method invocation: java.lang.String#format(java.lang.String,java.lang.Object[]) [Uses default locale] in org.opensearch.knn.index.codec.KNN80Codec.KNN80DocValuesConsumer (KNN80DocValuesConsumer.java:62)"
2. Remove duplicated logger from files below, one added from Lombok (log), and manually added (logger)
- src/main/java/org/opensearch/knn/index/KNNSettings.java
- src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java

### Related Issues
Resolves https://github.com/opensearch-project/opensearch-jvector/issues/466


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
