### PR TITLE
test: potential fix for JVectorConcurrentQueryTests.java by extending timeout

### DIFF
--- a/src/test/java/org/opensearch/knn/index/engine/JVectorConcurrentQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/JVectorConcurrentQueryTests.java
@@ -5,9 +5,11 @@
 package org.opensearch.knn.index.engine;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.junit.Test;
 import org.opensearch.client.Request;
+import org.opensearch.client.RequestOptions;
 import org.opensearch.client.Response;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
@@ -45,7 +47,6 @@ import static org.opensearch.knn.index.engine.CommonTestUtils.DIMENSION;
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 1)
 @ThreadLeakFilters(defaultFilters = true, filters = { ThreadLeakFiltersForTests.class })
 public class JVectorConcurrentQueryTests extends OpenSearchIntegTestCase {
-
     private static final int NUM_VECTORS = 100;
     private static final int NUM_QUERIES = 10;
     private static final int NUM_CONCURRENT_QUERIES = 10; // Will be equivalent to the number of threads
@@ -251,6 +252,9 @@ public class JVectorConcurrentQueryTests extends OpenSearchIntegTestCase {
     protected Response searchKNNIndex(String index, String query, int resultSize) throws IOException {
         Request request = new Request("POST", "/" + index + "/_search");
         request.setJsonEntity(query);
+        request.setOptions(
+            RequestOptions.DEFAULT.toBuilder().setRequestConfig(RequestConfig.custom().setResponseTimeout(60, TimeUnit.SECONDS).build())
+        );
 
         request.addParameter("size", Integer.toString(resultSize));
         request.addParameter("search_type", "query_then_fetch");


### PR DESCRIPTION
### Description
[Describe what this change achieves]

After investigation and running the tests continuously, I was able to get the error and stacktrace of the error.
From the error encountered, it seems that the issue is about timeout in RestClient. A Rest request (query req) was timed out from the error messages and it caused a thread to fail. Hence, errors were logged and assertion failed. 

The fix applied is to align the timeout of RestClient to 60 seconds which now appears to be working just fine. Tried running the test case over 1000+ runs and not yet encountered any failures. @reta also verified it in the comments of this PR.

<details>
<summary><b><i>Error from the run:</i></b></summary>

```bash
1> [2026-04-28 12:58:38.512][ERROR][ query-thread-2][org.opensearch.knn.index.engine.JVectorConcurrentQueryTests]  Query thread encountered an error
  1> java.net.SocketTimeoutException: 30000 MILLISECONDS
  1> 	at org.opensearch.client.RestClient.extractAndWrapCause(RestClient.java:1319)
  1> 	at org.opensearch.client.RestClient.performRequest(RestClient.java:370)
  1> 	at org.opensearch.client.RestClient.performRequest(RestClient.java:358)
  1> 	at org.opensearch.knn.index.engine.JVectorConcurrentQueryTests.searchKNNIndex(JVectorConcurrentQueryTests.java:260)
  1> 	at org.opensearch.knn.index.engine.JVectorConcurrentQueryTests.searchKNNIndex(JVectorConcurrentQueryTests.java:245)
  1> 	at org.opensearch.knn.index.engine.JVectorConcurrentQueryTests.searchKNNIndex(JVectorConcurrentQueryTests.java:238)
  1> 	at org.opensearch.knn.index.engine.JVectorConcurrentQueryTests.lambda$testConcurrentJVectorQueries$0(JVectorConcurrentQueryTests.java:104)
  1> 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:545)
  1> 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328)
  1> 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
  1> 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
  1> 	at java.base/java.lang.Thread.run(Thread.java:1474)
  1> Caused by: java.net.SocketTimeoutException: 30000 MILLISECONDS
  1> 	at org.apache.hc.core5.io.SocketTimeoutExceptionFactory.create(SocketTimeoutExceptionFactory.java:50)
  1> 	at org.apache.hc.core5.http.impl.nio.AbstractHttp1StreamDuplexer.onTimeout(AbstractHttp1StreamDuplexer.java:407)
  1> 	at org.apache.hc.core5.http.impl.nio.AbstractHttp1IOEventHandler.timeout(AbstractHttp1IOEventHandler.java:82)
  1> 	at org.apache.hc.core5.http.impl.nio.ClientHttp1IOEventHandler.timeout(ClientHttp1IOEventHandler.java:41)
  1> 	at org.apache.hc.core5.reactor.InternalDataChannel.onTimeout(InternalDataChannel.java:166)
  1> 	at org.apache.hc.core5.reactor.InternalChannel.checkTimeout(InternalChannel.java:67)
  1> 	at org.apache.hc.core5.reactor.SingleCoreIOReactor.checkTimeout(SingleCoreIOReactor.java:261)
  1> 	at org.apache.hc.core5.reactor.SingleCoreIOReactor.validateActiveChannels(SingleCoreIOReactor.java:183)
  1> 	at org.apache.hc.core5.reactor.SingleCoreIOReactor.doExecute(SingleCoreIOReactor.java:143)
  1> 	at org.apache.hc.core5.reactor.AbstractSingleCoreIOReactor.execute(AbstractSingleCoreIOReactor.java:92)
  1> 	at org.apache.hc.core5.reactor.IOReactorWorker.run(IOReactorWorker.java:44)
  1> 	... 1 more
2> REPRODUCE WITH: ./gradlew ':test' --tests 'org.opensearch.knn.index.engine.JVectorConcurrentQueryTests.testConcurrentJVectorQueries' -Dtests.seed=331157454312AC66 -Dtests.security.manager=false -Dtests.locale=nn-Latn-NO -Dtests.timezone=CET -Druntime.java=25
  2> java.lang.AssertionError: Errors were encountered during concurrent querying
        at __randomizedtesting.SeedInfo.seed([331157454312AC66:DC79377627F1360E]:0)
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.assertTrue(Assert.java:42)
        at org.junit.Assert.assertFalse(Assert.java:65)
        at org.opensearch.knn.index.engine.JVectorConcurrentQueryTests.testConcurrentJVectorQueries(JVectorConcurrentQueryTests.java:135)
  2> NOTE: leaving temporary files on disk at: opensearch-jvector/build/testrun/test/temp/org.opensearch.knn.index.engine.JVectorConcurrentQueryTests_331157454312AC66-001
  2> NOTE: test params are: codec=Asserting(Lucene104): {index_uuid=PostingsFormat(name=Lucene104), _id=PostingsFormat(name=Lucene104), type=PostingsFormat(name=Lucene104)}, docValues:{_seq_no=DocValuesFormat(name=Asserting), test_field=DocValuesFormat(name=Asserting), _primary_term=DocValuesFormat(name=Asserting), _version=DocValuesFormat(name=Asserting)}, maxPointsInLeafNode=983, maxMBSortInHeap=6.2539758270587775, sim=Asserting(RandomSimilarity(queryNorm=false): {}), locale=nn-Latn-NO, timezone=CET
  2> NOTE: Mac OS X 26.3.1 aarch64/Oracle Corporation 25.0.2 (64-bit)/cpus=14,threads=9,free=269683048,total=536870912
  2> NOTE: All tests run in this JVM: [JVectorConcurrentQueryTests]

1 test completed, 1 failed

FAILURE: Build failed with an exception.
```
</details>

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

Closes #385 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
