### PR TITLE
Fix flaky org.opensearch.knn.index.codec.jvector.JVectorWriterMergeTests.testLeadingSegmentMergeDisabled by lowering recall

### DIFF
--- a/src/test/java/org/opensearch/knn/index/codec/jvector/JVectorWriterMergeTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/JVectorWriterMergeTests.java
@@ -414,7 +414,7 @@ public class JVectorWriterMergeTests extends LuceneTestCase {
                     .build()
             )
             .overqueryFactor(20)
-            .minimumRecall(0.99)
+            .minimumRecall(0.98)
             .build();
         runScenario(scenario);
     }
@@ -460,7 +460,7 @@ public class JVectorWriterMergeTests extends LuceneTestCase {
             )
             .round(MergeTestRound.builder().segmentSizes(List.of(400)).build())
             .overqueryFactor(20)
-            .minimumRecall(0.99)
+            .minimumRecall(0.98)
             .build();
         runScenarioWithPool(scenario, singleThreadGraphMergePool);
     }


### PR DESCRIPTION
### Description
Fix flaky org.opensearch.knn.index.codec.jvector.JVectorWriterMergeTests.testLeadingSegmentMergeDisabled by lowering recall

### Related Issues
Closes https://github.com/opensearch-project/opensearch-jvector/issues/295

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
