### PR TITLE
Fix derived nested fields processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 ### Enhancements
 ### Bug Fixes
+- Fix derived nested fields processing [484] (https://github.com/opensearch-project/opensearch-jvector/pull/484)
 ### Infrastructure
 * Upgrade Lucene to 10.4.0 [292] (https://github.com/opensearch-project/opensearch-jvector/pull/292)
 * Upgrade jvector from 4.0.0-rc.6 to 4.0.0-rc.8 [370](https://github.com/opensearch-project/opensearch-jvector/pull/370)

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorTransformer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorTransformer.java
@@ -7,7 +7,6 @@ package org.opensearch.knn.index.codec.derivedsource;
 
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.index.SegmentReadState;
-import org.opensearch.common.ValidationException;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentHelper;
@@ -23,12 +22,9 @@ import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-
-import static org.opensearch.knn.index.KNNSettings.KNN_DERIVED_SOURCE_ENABLED;
 
 @Log4j2
 public class DerivedSourceVectorTransformer {
@@ -155,14 +151,7 @@ public class DerivedSourceVectorTransformer {
         // We only need the offset for the nested fields. If there aren't any, we can skip
         int offset = 0;
         if (isNested) {
-            ValidationException validationException = new ValidationException();
-            validationException.addValidationError(
-                String.format(Locale.ROOT, "Nested fields are not supported when [%s] is true.", KNN_DERIVED_SOURCE_ENABLED)
-            );
-            throw validationException;
-
-            // TODO: Uncomment this when derived source nested field is fixed.
-            // offset = derivedSourceLuceneHelper.getFirstChild(docId);
+            offset = derivedSourceLuceneHelper.getFirstChild(docId);
         }
 
         // For each vector field, add in the source. The per field injectors are responsible for skipping if

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/NestedPerFieldDerivedVectorTransformer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/NestedPerFieldDerivedVectorTransformer.java
@@ -48,7 +48,7 @@ public class NestedPerFieldDerivedVectorTransformer extends AbstractPerFieldDeri
 
     @Override
     public void setCurrentDoc(int offset, int docId) throws IOException {
-        vectorValues = KNNVectorValuesFactory.getVectorValues(
+        vectorValues = KNNVectorValuesFactory.getDerivedVectorValues(
             childFieldInfo,
             derivedSourceReaders.getDocValuesProducer(),
             derivedSourceReaders.getKnnVectorsReader()

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/NestedPerFieldDerivedVectorTransformer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/NestedPerFieldDerivedVectorTransformer.java
@@ -48,7 +48,7 @@ public class NestedPerFieldDerivedVectorTransformer extends AbstractPerFieldDeri
 
     @Override
     public void setCurrentDoc(int offset, int docId) throws IOException {
-        vectorValues = KNNVectorValuesFactory.getDerivedVectorValues(
+        vectorValues = KNNVectorValuesFactory.getDerivedSourcesVectorValues(
             childFieldInfo,
             derivedSourceReaders.getDocValuesProducer(),
             derivedSourceReaders.getKnnVectorsReader()

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/RootPerFieldDerivedVectorTransformer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/RootPerFieldDerivedVectorTransformer.java
@@ -28,7 +28,7 @@ public class RootPerFieldDerivedVectorTransformer extends AbstractPerFieldDerive
      */
     public RootPerFieldDerivedVectorTransformer(FieldInfo fieldInfo, DerivedSourceReaders derivedSourceReaders) {
         this.fieldInfo = fieldInfo;
-        this.vectorValuesSupplier = () -> KNNVectorValuesFactory.getDerivedVectorValues(
+        this.vectorValuesSupplier = () -> KNNVectorValuesFactory.getDerivedSourcesVectorValues(
             fieldInfo,
             derivedSourceReaders.getDocValuesProducer(),
             derivedSourceReaders.getKnnVectorsReader()

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/RootPerFieldDerivedVectorTransformer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/RootPerFieldDerivedVectorTransformer.java
@@ -28,7 +28,7 @@ public class RootPerFieldDerivedVectorTransformer extends AbstractPerFieldDerive
      */
     public RootPerFieldDerivedVectorTransformer(FieldInfo fieldInfo, DerivedSourceReaders derivedSourceReaders) {
         this.fieldInfo = fieldInfo;
-        this.vectorValuesSupplier = () -> KNNVectorValuesFactory.getVectorValues(
+        this.vectorValuesSupplier = () -> KNNVectorValuesFactory.getDerivedVectorValues(
             fieldInfo,
             derivedSourceReaders.getDocValuesProducer(),
             derivedSourceReaders.getKnnVectorsReader()

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFloatVectorValues.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFloatVectorValues.java
@@ -96,6 +96,10 @@ public class JVectorFloatVectorValues extends FloatVectorValues {
         };
     }
 
+    /**
+     * Constructs an iterator that iterates over vectors that have corresponding nodes in the graph (skipping the gaps with non-live / NO_VECTORS nodes).
+     * @return an iterator that iterates over vectors that have corresponding nodes in the graph (skipping the gaps with non-live / NO_VECTORS nodes)
+     */
     public DocIndexIterator vectorIterator() {
         return new DocIndexIterator() {
             private int docId = -1;

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFloatVectorValues.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFloatVectorValues.java
@@ -96,6 +96,49 @@ public class JVectorFloatVectorValues extends FloatVectorValues {
         };
     }
 
+    public DocIndexIterator vectorIterator() {
+        return new DocIndexIterator() {
+            private int docId = -1;
+            private final Bits liveNodes = view.liveNodes();
+
+            @Override
+            public long cost() {
+                return size();
+            }
+
+            @Override
+            public int index() {
+                return graphNodeIdToDocMap.getJVectorNodeId(docId);
+            }
+
+            @Override
+            public int docID() {
+                return docId;
+            }
+
+            @Override
+            public int nextDoc() throws IOException {
+                // Advance to the next node docId starts from -1 which is why we need to increment docId by 1
+                // until maxDoc is reached. If the document has vector field but no value (== null), the NO_MORE_DOCS
+                // is going to be returned by this method.
+                while (docId < graphNodeIdToDocMap.getMaxDoc() - 1) {
+                    docId++;
+                    if (liveNodes.get(docId) && index() != NO_VECTOR) {
+                        return docId;
+                    }
+                }
+                docId = NO_MORE_DOCS;
+
+                return docId;
+            }
+
+            @Override
+            public int advance(int target) throws IOException {
+                return slowAdvance(target);
+            }
+        };
+    }
+
     @Override
     public float[] vectorValue(int i) throws IOException {
         try {

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -524,7 +524,7 @@ public class JVectorWriter extends KnnVectorsWriter {
 
         @Override
         public void addValue(int docID, T vectorValue) throws IOException {
-            log.trace("Adding value {} to field {} in segment {}", vectorValue, fieldInfo.name, segmentName);
+            log.trace("Adding value {} to field {} in segment {} for document {}", vectorValue, fieldInfo.name, segmentName, docID);
             if (docID == lastDocID) {
                 throw new IllegalArgumentException(
                     "VectorValuesField \""

--- a/src/main/java/org/opensearch/knn/index/vectorvalues/KNNVectorValuesFactory.java
+++ b/src/main/java/org/opensearch/knn/index/vectorvalues/KNNVectorValuesFactory.java
@@ -126,15 +126,14 @@ public final class KNNVectorValuesFactory {
     }
 
     /**
-     * Returns a {@link KNNVectorValues} for the given {@link FieldInfo} and {@link KnnVectorsReader} that support derived
-     * vector values.
+     * Returns a {@link KNNVectorValues} for the given {@link FieldInfo} and {@link LeafReader} that support derived sources
      *
      * @param fieldInfo {@link FieldInfo}
      * @param docValuesProducer {@link DocValuesProducer}
      * @param knnVectorsReader {@link KnnVectorsReader}
      * @return {@link KNNVectorValues}
      */
-    public static <T> KNNVectorValues<T> getDerivedVectorValues(
+    public static <T> KNNVectorValues<T> getDerivedSourcesVectorValues(
         final FieldInfo fieldInfo,
         final DocValuesProducer docValuesProducer,
         final KnnVectorsReader knnVectorsReader

--- a/src/main/java/org/opensearch/knn/index/vectorvalues/KNNVectorValuesFactory.java
+++ b/src/main/java/org/opensearch/knn/index/vectorvalues/KNNVectorValuesFactory.java
@@ -126,14 +126,15 @@ public final class KNNVectorValuesFactory {
     }
 
     /**
-     * Returns a {@link KNNVectorValues} for the given {@link FieldInfo} and {@link LeafReader}
+     * Returns a {@link KNNVectorValues} for the given {@link FieldInfo} and {@link KnnVectorsReader} that support derived
+     * vector values.
      *
      * @param fieldInfo {@link FieldInfo}
      * @param docValuesProducer {@link DocValuesProducer}
      * @param knnVectorsReader {@link KnnVectorsReader}
      * @return {@link KNNVectorValues}
      */
-    public static <T> KNNVectorValues<T> getVectorValues(
+    public static <T> KNNVectorValues<T> getDerivedVectorValues(
         final FieldInfo fieldInfo,
         final DocValuesProducer docValuesProducer,
         final KnnVectorsReader knnVectorsReader

--- a/src/main/java/org/opensearch/knn/index/vectorvalues/KNNVectorValuesFactory.java
+++ b/src/main/java/org/opensearch/knn/index/vectorvalues/KNNVectorValuesFactory.java
@@ -22,6 +22,7 @@ import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.opensearch.knn.common.FieldInfoExtractor;
 import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.codec.jvector.JVectorFloatVectorValues;
 
 import java.io.IOException;
 import java.util.Map;
@@ -151,7 +152,12 @@ public final class KNNVectorValuesFactory {
             } else {
                 throw new IllegalArgumentException("Invalid Vector encoding provided, hence cannot return VectorValues");
             }
-            return getVectorValues(vectorDataType, new KNNVectorValuesIterator.DocIdsIteratorValues(knnVectorValues));
+
+            if (knnVectorValues instanceof JVectorFloatVectorValues jfvv) {
+                return getVectorValues(vectorDataType, new KNNVectorValuesIterator.DocIdsIteratorValues(jfvv));
+            } else {
+                return getVectorValues(vectorDataType, new KNNVectorValuesIterator.DocIdsIteratorValues(knnVectorValues));
+            }
         } else if (docValuesProducer != null) {
             return getVectorValues(
                 FieldInfoExtractor.extractVectorDataType(fieldInfo),

--- a/src/main/java/org/opensearch/knn/index/vectorvalues/KNNVectorValuesIterator.java
+++ b/src/main/java/org/opensearch/knn/index/vectorvalues/KNNVectorValuesIterator.java
@@ -14,6 +14,7 @@ import org.apache.lucene.index.DocsWithFieldSet;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.index.KnnVectorValues;
+import org.opensearch.knn.index.codec.jvector.JVectorFloatVectorValues;
 import org.opensearch.knn.index.codec.util.KNNCodecUtil;
 
 import java.io.IOException;
@@ -79,6 +80,11 @@ public interface KNNVectorValuesIterator {
         @Getter
         @Setter
         private Object lastAccessedVector = null;
+
+        DocIdsIteratorValues(@NonNull final JVectorFloatVectorValues knnVectorValues) {
+            this.docIdSetIterator = knnVectorValues.vectorIterator();
+            this.knnVectorValues = knnVectorValues;
+        }
 
         DocIdsIteratorValues(@NonNull final KnnVectorValues knnVectorValues) {
             this.docIdSetIterator = knnVectorValues.iterator();

--- a/src/test/java/org/opensearch/knn/index/vectorvalues/KNNVectorValuesFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/vectorvalues/KNNVectorValuesFactoryTests.java
@@ -81,7 +81,7 @@ public class KNNVectorValuesFactoryTests extends KNNTestCase {
 
         Assert.assertThrows(
             IllegalArgumentException.class,
-            () -> KNNVectorValuesFactory.getVectorValues(fieldInfo, docValuesProducer, reader)
+            () -> KNNVectorValuesFactory.getDerivedVectorValues(fieldInfo, docValuesProducer, reader)
         );
     }
 
@@ -98,7 +98,11 @@ public class KNNVectorValuesFactoryTests extends KNNTestCase {
         // Checking for byte vectors
         Mockito.when(fieldInfo.getVectorEncoding()).thenReturn(VectorEncoding.BYTE);
         Mockito.when(reader.getByteVectorValues("test_field")).thenReturn(new TestVectorValues.PreDefinedByteVectorValues(byteArrayList));
-        final KNNVectorValues<byte[]> byteVectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, docValuesProducer, reader);
+        final KNNVectorValues<byte[]> byteVectorValues = KNNVectorValuesFactory.getDerivedVectorValues(
+            fieldInfo,
+            docValuesProducer,
+            reader
+        );
         byteVectorValues.nextDoc();
         Assert.assertArrayEquals(byteArrayList.getFirst(), byteVectorValues.getVector());
 
@@ -106,7 +110,11 @@ public class KNNVectorValuesFactoryTests extends KNNTestCase {
         Mockito.when(fieldInfo.getVectorEncoding()).thenReturn(VectorEncoding.FLOAT32);
         Mockito.when(reader.getFloatVectorValues("test_field"))
             .thenReturn(new TestVectorValues.PreDefinedFloatVectorValues(floatArrayList));
-        final KNNVectorValues<float[]> floatVectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, docValuesProducer, reader);
+        final KNNVectorValues<float[]> floatVectorValues = KNNVectorValuesFactory.getDerivedVectorValues(
+            fieldInfo,
+            docValuesProducer,
+            reader
+        );
         floatVectorValues.nextDoc();
         Assert.assertArrayEquals(floatArrayList.getFirst(), floatVectorValues.getVector(), 0.0f);
 
@@ -115,7 +123,11 @@ public class KNNVectorValuesFactoryTests extends KNNTestCase {
         Mockito.when(fieldInfo.hasVectorValues()).thenReturn(false);
         Mockito.when(reader.getByteVectorValues("test_field")).thenReturn(new TestVectorValues.PreDefinedByteVectorValues(byteArrayList));
         Mockito.when(docValuesProducer.getBinary(fieldInfo)).thenReturn(new TestVectorValues.ConstantVectorBinaryDocValues(1, 1, 2));
-        final KNNVectorValues<float[]> binaryVectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, docValuesProducer, reader);
+        final KNNVectorValues<float[]> binaryVectorValues = KNNVectorValuesFactory.getDerivedVectorValues(
+            fieldInfo,
+            docValuesProducer,
+            reader
+        );
         byteVectorValues.nextDoc();
         Assert.assertArrayEquals(new float[] { 2 }, binaryVectorValues.getVector(), 0);
     }
@@ -123,10 +135,10 @@ public class KNNVectorValuesFactoryTests extends KNNTestCase {
     public void testGetVectorValuesUsingDocValuesProducer_whenInvalidInput_thenException() {
         final FieldInfo fieldInfo = Mockito.mock(FieldInfo.class);
         Mockito.when(fieldInfo.hasVectorValues()).thenReturn(false);
-        Assert.assertThrows(IllegalArgumentException.class, () -> KNNVectorValuesFactory.getVectorValues(fieldInfo, null, null));
+        Assert.assertThrows(IllegalArgumentException.class, () -> KNNVectorValuesFactory.getDerivedVectorValues(fieldInfo, null, null));
 
         Mockito.when(fieldInfo.hasVectorValues()).thenReturn(true);
-        Assert.assertThrows(IllegalArgumentException.class, () -> KNNVectorValuesFactory.getVectorValues(fieldInfo, null, null));
+        Assert.assertThrows(IllegalArgumentException.class, () -> KNNVectorValuesFactory.getDerivedVectorValues(fieldInfo, null, null));
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/index/vectorvalues/KNNVectorValuesFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/vectorvalues/KNNVectorValuesFactoryTests.java
@@ -81,7 +81,7 @@ public class KNNVectorValuesFactoryTests extends KNNTestCase {
 
         Assert.assertThrows(
             IllegalArgumentException.class,
-            () -> KNNVectorValuesFactory.getDerivedVectorValues(fieldInfo, docValuesProducer, reader)
+            () -> KNNVectorValuesFactory.getDerivedSourcesVectorValues(fieldInfo, docValuesProducer, reader)
         );
     }
 
@@ -98,7 +98,7 @@ public class KNNVectorValuesFactoryTests extends KNNTestCase {
         // Checking for byte vectors
         Mockito.when(fieldInfo.getVectorEncoding()).thenReturn(VectorEncoding.BYTE);
         Mockito.when(reader.getByteVectorValues("test_field")).thenReturn(new TestVectorValues.PreDefinedByteVectorValues(byteArrayList));
-        final KNNVectorValues<byte[]> byteVectorValues = KNNVectorValuesFactory.getDerivedVectorValues(
+        final KNNVectorValues<byte[]> byteVectorValues = KNNVectorValuesFactory.getDerivedSourcesVectorValues(
             fieldInfo,
             docValuesProducer,
             reader
@@ -110,7 +110,7 @@ public class KNNVectorValuesFactoryTests extends KNNTestCase {
         Mockito.when(fieldInfo.getVectorEncoding()).thenReturn(VectorEncoding.FLOAT32);
         Mockito.when(reader.getFloatVectorValues("test_field"))
             .thenReturn(new TestVectorValues.PreDefinedFloatVectorValues(floatArrayList));
-        final KNNVectorValues<float[]> floatVectorValues = KNNVectorValuesFactory.getDerivedVectorValues(
+        final KNNVectorValues<float[]> floatVectorValues = KNNVectorValuesFactory.getDerivedSourcesVectorValues(
             fieldInfo,
             docValuesProducer,
             reader
@@ -123,7 +123,7 @@ public class KNNVectorValuesFactoryTests extends KNNTestCase {
         Mockito.when(fieldInfo.hasVectorValues()).thenReturn(false);
         Mockito.when(reader.getByteVectorValues("test_field")).thenReturn(new TestVectorValues.PreDefinedByteVectorValues(byteArrayList));
         Mockito.when(docValuesProducer.getBinary(fieldInfo)).thenReturn(new TestVectorValues.ConstantVectorBinaryDocValues(1, 1, 2));
-        final KNNVectorValues<float[]> binaryVectorValues = KNNVectorValuesFactory.getDerivedVectorValues(
+        final KNNVectorValues<float[]> binaryVectorValues = KNNVectorValuesFactory.getDerivedSourcesVectorValues(
             fieldInfo,
             docValuesProducer,
             reader
@@ -135,10 +135,16 @@ public class KNNVectorValuesFactoryTests extends KNNTestCase {
     public void testGetVectorValuesUsingDocValuesProducer_whenInvalidInput_thenException() {
         final FieldInfo fieldInfo = Mockito.mock(FieldInfo.class);
         Mockito.when(fieldInfo.hasVectorValues()).thenReturn(false);
-        Assert.assertThrows(IllegalArgumentException.class, () -> KNNVectorValuesFactory.getDerivedVectorValues(fieldInfo, null, null));
+        Assert.assertThrows(
+            IllegalArgumentException.class,
+            () -> KNNVectorValuesFactory.getDerivedSourcesVectorValues(fieldInfo, null, null)
+        );
 
         Mockito.when(fieldInfo.hasVectorValues()).thenReturn(true);
-        Assert.assertThrows(IllegalArgumentException.class, () -> KNNVectorValuesFactory.getDerivedVectorValues(fieldInfo, null, null));
+        Assert.assertThrows(
+            IllegalArgumentException.class,
+            () -> KNNVectorValuesFactory.getDerivedSourcesVectorValues(fieldInfo, null, null)
+        );
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
+++ b/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
@@ -23,7 +23,6 @@ import java.util.*;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.opensearch.knn.DerivedSourceUtils.*;
-import static org.opensearch.knn.index.KNNSettings.KNN_DERIVED_SOURCE_ENABLED;
 
 /**
  * Integration tests for derived source feature for vector fields. Currently, with derived source, there are
@@ -94,16 +93,8 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
 
     @SneakyThrows
     public void testNestedField() {
-        try {
-            List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts = getNestedIndexContexts("derivedit", true);
-            testDerivedSourceE2E(indexConfigContexts);
-        } catch (Exception excp) {
-            // TODO: Remove this check when nested fields are supported with derived sources.
-            assertTrue(excp.getMessage().contains("validation_exception"));
-            assertTrue(
-                excp.getMessage().contains(String.format("Nested fields are not supported when [%s] is true.", KNN_DERIVED_SOURCE_ENABLED))
-            );
-        }
+        List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts = getNestedIndexContexts("derivedit", true);
+        testDerivedSourceE2E(indexConfigContexts);
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
+++ b/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
@@ -93,8 +93,88 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
 
     @SneakyThrows
     public void testNestedField() {
-        List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts = getNestedIndexContexts("derivedit", true);
+        List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts = getNestedIndexContexts("derivedit", true, true);
         testDerivedSourceE2E(indexConfigContexts);
+    }
+
+    @SneakyThrows
+    public void testNestedFieldWithNullables() {
+        List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts = getNestedIndexContexts("derivedit", true, true);
+        assertEquals(6, indexConfigContexts.size());
+
+        assertTrue(1 < indexConfigContexts.size());
+        DerivedSourceUtils.IndexConfigContext derivedSourceEnabledContext = indexConfigContexts.get(0);
+        DerivedSourceUtils.IndexConfigContext derivedSourceDisabledContext = indexConfigContexts.get(1);
+
+        createKnnIndex(
+            derivedSourceEnabledContext.indexName,
+            derivedSourceEnabledContext.getSettings(),
+            derivedSourceEnabledContext.getMapping()
+        );
+        createKnnIndex(
+            derivedSourceDisabledContext.indexName,
+            derivedSourceDisabledContext.getSettings(),
+            derivedSourceDisabledContext.getMapping()
+        );
+        // make sure that both index has same routing settings
+        assertEquals(derivedSourceEnabledContext.isRoutingEnabled, derivedSourceDisabledContext.isRoutingEnabled);
+
+        // Build all docs with null fields
+        for (int i = 0; i < derivedSourceDisabledContext.docCount; i++) {
+            String doc1 = "{}";
+            String doc2 = "{}";
+
+            // using doc id as routing value, which is default
+            addKnnDoc(
+                derivedSourceEnabledContext.getIndexName(),
+                String.valueOf(i + 1),
+                doc1,
+                derivedSourceEnabledContext.isRoutingEnabled ? String.valueOf(i + 1) : null
+            );
+            addKnnDoc(
+                derivedSourceDisabledContext.getIndexName(),
+                String.valueOf(i + 1),
+                doc2,
+                derivedSourceDisabledContext.isRoutingEnabled ? String.valueOf(i + 1) : null
+            );
+        }
+        refreshAllIndices();
+
+        assertDocsMatch(
+            derivedSourceDisabledContext.docCount,
+            derivedSourceDisabledContext.indexName,
+            derivedSourceEnabledContext.indexName,
+            derivedSourceEnabledContext.isRoutingEnabled
+        );
+
+        // Update all docs with random field vectors
+        for (int i = 0; i < derivedSourceDisabledContext.docCount; i++) {
+            String doc1 = derivedSourceEnabledContext.buildDoc();
+            String doc2 = derivedSourceDisabledContext.buildDoc();
+
+            assertEquals(doc1, doc2);
+            // using doc id as routing value, which is default
+            updateKnnDoc(
+                derivedSourceEnabledContext.getIndexName(),
+                String.valueOf(i + 1),
+                doc1,
+                derivedSourceEnabledContext.isRoutingEnabled ? String.valueOf(i + 1) : null
+            );
+            updateKnnDoc(
+                derivedSourceDisabledContext.getIndexName(),
+                String.valueOf(i + 1),
+                doc2,
+                derivedSourceDisabledContext.isRoutingEnabled ? String.valueOf(i + 1) : null
+            );
+        }
+        refreshAllIndices();
+
+        assertDocsMatch(
+            derivedSourceDisabledContext.docCount,
+            derivedSourceDisabledContext.indexName,
+            derivedSourceEnabledContext.indexName,
+            derivedSourceEnabledContext.isRoutingEnabled
+        );
     }
 
     @SneakyThrows

--- a/src/testFixtures/java/org/opensearch/knn/DerivedSourceTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/DerivedSourceTestCase.java
@@ -494,7 +494,11 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
      *     }
      *   }
      */
-    protected List<DerivedSourceUtils.IndexConfigContext> getNestedIndexContexts(String testSuitePrefix, boolean addRandom) {
+    protected List<DerivedSourceUtils.IndexConfigContext> getNestedIndexContexts(
+        String testSuitePrefix,
+        boolean addRandom,
+        boolean addNull
+    ) {
         List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts = new ArrayList<>();
         long consistentRandomSeed = random().nextLong();
         for (Tuple<String, Boolean> index : INDEX_PREFIX_TO_ENABLED) {
@@ -514,6 +518,7 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
                                     DerivedSourceUtils.KNNVectorFieldTypeContext.builder()
                                         .dimension(dimensionSupplier.get())
                                         .fieldPath("object_1.test_vector")
+                                        .nullProb(addNull ? DerivedSourceUtils.DEFAULT_NULL_PROB : 0)
                                         .build(),
                                     DerivedSourceUtils.NestedFieldContext.builder()
                                         .fieldPath("object_1.nested_1")
@@ -522,12 +527,15 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
                                                 DerivedSourceUtils.KNNVectorFieldTypeContext.builder()
                                                     .dimension(dimensionSupplier.get())
                                                     .fieldPath("object_1.nested_1.test_vector")
+                                                    .nullProb(addNull ? DerivedSourceUtils.DEFAULT_NULL_PROB : 0)
                                                     .build()
                                             )
                                         )
+                                        .nullProb(addNull ? DerivedSourceUtils.DEFAULT_NULL_PROB : 0)
                                         .build()
                                 )
                             )
+                            .nullProb(addNull ? DerivedSourceUtils.DEFAULT_NULL_PROB : 0)
                             .build(),
                         DerivedSourceUtils.NestedFieldContext.builder()
                             .fieldPath("nested_1")
@@ -536,10 +544,12 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
                                     DerivedSourceUtils.KNNVectorFieldTypeContext.builder()
                                         .dimension(dimensionSupplier.get())
                                         .fieldPath("nested_1.test_vector")
+                                        .nullProb(addNull ? DerivedSourceUtils.DEFAULT_NULL_PROB : 0)
                                         .build(),
                                     DerivedSourceUtils.KNNVectorFieldTypeContext.builder()
                                         .dimension(dimensionSupplier.get())
                                         .fieldPath("nested_1.update_vector")
+                                        .nullProb(addNull ? DerivedSourceUtils.DEFAULT_NULL_PROB : 0)
                                         .isUpdate(true)
                                         .build(),
                                     DerivedSourceUtils.ObjectFieldContext.builder()
@@ -549,13 +559,16 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
                                                 DerivedSourceUtils.KNNVectorFieldTypeContext.builder()
                                                     .dimension(dimensionSupplier.get())
                                                     .fieldPath("nested_1.object_1.test_vector")
+                                                    .nullProb(addNull ? DerivedSourceUtils.DEFAULT_NULL_PROB : 0)
                                                     .build(),
                                                 DerivedSourceUtils.IntFieldType.builder().fieldPath("nested_1.object_1.test-int").build()
                                             )
                                         )
+                                        .nullProb(addNull ? DerivedSourceUtils.DEFAULT_NULL_PROB : 0)
                                         .build()
                                 )
                             )
+                            .nullProb(addNull ? DerivedSourceUtils.DEFAULT_NULL_PROB : 0)
                             .build(),
                         DerivedSourceUtils.NestedFieldContext.builder()
                             .fieldPath("nested_2")
@@ -565,11 +578,13 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
                                     DerivedSourceUtils.KNNVectorFieldTypeContext.builder()
                                         .dimension(dimensionSupplier.get())
                                         .fieldPath("nested_2.test_vector")
+                                        .nullProb(addNull ? DerivedSourceUtils.DEFAULT_NULL_PROB : 0)
                                         .build(),
                                     DerivedSourceUtils.KNNVectorFieldTypeContext.builder()
                                         .fieldPath("nested_2.update_vector")
                                         .isUpdate(true)
                                         .dimension(dimensionSupplier.get())
+                                        .nullProb(addNull ? DerivedSourceUtils.DEFAULT_NULL_PROB : 0)
                                         .build(),
                                     DerivedSourceUtils.NestedFieldContext.builder()
                                         .fieldPath("nested_2.nested_3")
@@ -578,11 +593,13 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
                                                 DerivedSourceUtils.KNNVectorFieldTypeContext.builder()
                                                     .dimension(dimensionSupplier.get())
                                                     .fieldPath("nested_2.nested_3.test_vector")
+                                                    .nullProb(addNull ? DerivedSourceUtils.DEFAULT_NULL_PROB : 0)
                                                     .build(),
                                                 DerivedSourceUtils.KNNVectorFieldTypeContext.builder()
                                                     .dimension(dimensionSupplier.get())
                                                     .fieldPath("nested_2.nested_3.update_vector")
                                                     .isUpdate(true)
+                                                    .nullProb(addNull ? DerivedSourceUtils.DEFAULT_NULL_PROB : 0)
                                                     .build(),
                                                 DerivedSourceUtils.IntFieldType.builder().fieldPath("nested_2.nested_3.test-int").build()
                                             )
@@ -590,15 +607,18 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
                                         .build()
                                 )
                             )
+                            .nullProb(addNull ? DerivedSourceUtils.DEFAULT_NULL_PROB : 0)
                             .build(),
                         DerivedSourceUtils.KNNVectorFieldTypeContext.builder()
                             .dimension(dimensionSupplier.get())
                             .fieldPath("test_vector")
+                            .nullProb(addNull ? DerivedSourceUtils.DEFAULT_NULL_PROB : 0)
                             .build(),
                         DerivedSourceUtils.KNNVectorFieldTypeContext.builder()
                             .dimension(dimensionSupplier.get())
                             .fieldPath("update_vector")
                             .isUpdate(true)
+                            .nullProb(addNull ? DerivedSourceUtils.DEFAULT_NULL_PROB : 0)
                             .build(),
                         DerivedSourceUtils.TextFieldType.builder().fieldPath("test-text").build(),
                         DerivedSourceUtils.IntFieldType.builder().fieldPath("test-int").build()

--- a/src/testFixtures/java/org/opensearch/knn/DerivedSourceUtils.java
+++ b/src/testFixtures/java/org/opensearch/knn/DerivedSourceUtils.java
@@ -33,9 +33,8 @@ public class DerivedSourceUtils {
     public static final int TEST_DIMENSION = 16;
     protected static final int DOCS = 500;
 
-    // TODO: set null_prob to 0.03f and skip_prob to 0.1f once the merge issues are fixed.
-    public static final float DEFAULT_NULL_PROB = 0.00f;
-    public static final float DEFAULT_SKIP_PROB = 0.00f;
+    public static final float DEFAULT_NULL_PROB = 0.03f;
+    public static final float DEFAULT_SKIP_PROB = 0.1f;
 
     protected static final Settings DERIVED_ENABLED_SETTINGS = Settings.builder()
         .put(

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -667,6 +667,21 @@ public class KNNRestTestCase extends ODFERestTestCase {
         assertEquals(request.getEndpoint() + ": failed", RestStatus.CREATED, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
     }
 
+    /**
+     * Updates a doc where document is represented as a string.
+     */
+    protected void updateKnnDoc(final String index, final String docId, final String document, final String routingValue)
+        throws IOException {
+        String endpoint = String.join("/", index, "_doc", docId);
+        if (!StringUtils.isEmpty(routingValue)) {
+            endpoint = endpoint + "?" + "routing=" + routingValue;
+        }
+        Request request = new Request("PUT", endpoint);
+        request.setJsonEntity(document);
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+    }
+
     protected <T> void addNonKNNDoc(String index, String docId, String fieldName, String text) throws IOException {
         Request request = new Request("POST", "/" + index + "/_doc/" + docId + "?refresh=true");
 


### PR DESCRIPTION
### Description
Attempt to dix derived nested fields processing by introducing specialized vector values iterator that skips over documents without vectors. The minimal reproducer for the issue:

```
curl -X PUT http://localhost:9200/test-index -H "Content-Type: application/json" -d '
{
     "settings": {
        "index.knn": true,
         "index.knn.derived_source.enabled": true
     },
     "mappings" : {
       "properties" : {
         "nested_1" : {
           "type" : "nested",
           "properties" : {
             "test_vector" : {
               "type" : "knn_vector",
               "dimension" : 5
             }
           }
         },
         "object_1" : {
           "properties" : {
             "nested_1" : {
               "type" : "nested",
               "properties" : {
                 "test_vector" : {
                   "type" : "knn_vector",
                   "dimension" : 5
                 }
               }
             }
           }
         }
       }
     }
   }'
```

```
curl -X POST http://localhost:9200/test-index/_doc/1 -H "Content-Type: application/json" -d '
{
  "object_1": {
    "nested_1": {
      "test_vector": [0.42010623, 0.746439, 0.75870866, 0.71277267, 0.5341964]
    }
  },
  "nested_1": {
    "test_vector": [0.033954084, 0.9570153, 0.024319232, 0.27655363, 0.7269214]
  }
}'
```

```
curl 'http://localhost:9200/test-index/_search?pretty'
```

In addition to tests we have, run a lot of generartors:
```
Using index: "pub-vector-index"
Created index: "pub-vector-index"
Creating 10000 random documents: "pub-vector-index"
Documents:
 - with vectors 6018
 - with nested vectors 4011
 - with object nested vectors 3943
 - with all vectors 1982
 - without vectors 3982
 - total 10000
Deleted 2000 (20%) random documents: "pub-vector-index"
Refreshing pub-vector-index
Documents:
 - with vectors 4833
 - with nested vectors 3219
 - with object nested vectors 3169
 - with all vectors 1600
 - without vectors 3167
 - total 8000
```

### Related Issues
Related to https://github.com/opensearch-project/opensearch-jvector/issues/418

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
