### PR TITLE
Add gRPC Protocol Buffer support for KNN queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 3.6](https://github.com/opensearch-project/opensearch-jvector/compare/3.5...HEAD)
 ### Features
+* Add gRPC Protocol Buffer support for KNN queries [391](https://github.com/opensearch-project/opensearch-jvector/issues/391)
 ### Enhancements
 ### Bug Fixes
 - Fix derived nested fields processing [484] (https://github.com/opensearch-project/opensearch-jvector/pull/484)

--- a/build.gradle
+++ b/build.gradle
@@ -313,6 +313,11 @@ task release(type: Copy, group: 'build') {
 dependencies {
     api "org.opensearch:opensearch:${opensearch_version}"
     compileOnly "org.opensearch.plugin:opensearch-scripting-painless-spi:${versions.opensearch}"
+    
+    // gRPC support dependencies (provided at runtime by OpenSearch)
+    compileOnly "org.opensearch.plugin:transport-grpc-spi:${opensearch_version}"
+    compileOnly "org.opensearch:protobufs:${versions.opensearchprotobufs}"
+    
     // Declare guava as compile time since guava will come from OpenSearch transport-grpc module.
     compileOnly group: 'com.google.guava', name: 'guava', version: "${versions.guava}"
     api "org.apache.commons:commons-lang3:${versions.commonslang}"

--- a/build.gradle
+++ b/build.gradle
@@ -328,6 +328,17 @@ dependencies {
     // Add netty dependency so we can use it within internal test clusters (not just external ones)
     testImplementation "org.opensearch.plugin:transport-netty4-client:${opensearch_version}"
     testImplementation("com.google.guava:guava:${versions.guava}")
+    
+    // gRPC integration test dependencies (following neural-search pattern)
+    testImplementation "org.opensearch:protobufs:${versions.opensearchprotobufs}"
+    testImplementation "org.opensearch.plugin:transport-grpc-spi:${opensearch_version}"
+    testImplementation "io.grpc:grpc-api:${versions.grpc}"
+    testImplementation "io.grpc:grpc-core:${versions.grpc}"
+    testImplementation "io.grpc:grpc-netty-shaded:${versions.grpc}"
+    testImplementation "io.grpc:grpc-stub:${versions.grpc}"
+    testImplementation "io.grpc:grpc-protobuf:${versions.grpc}"
+    testImplementation "io.grpc:grpc-protobuf-lite:${versions.grpc}"
+    testRuntimeOnly "io.perfmark:perfmark-api:0.27.0"
 
     testFixturesImplementation("com.google.guava:guava:${versions.guava}") {
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
@@ -432,6 +443,37 @@ integTest {
         getClusters().forEach { cluster ->
             cluster.waitForAllConditions()
         }
+        
+        // Discover the actual gRPC port from the cluster log.
+        // The gRPC transport binds to the first available port in 9400-9500,
+        // which may differ from 9400 due to port conflicts or dual-stack binding.
+        // Only discover when NOT using an external cluster (tests.rest.cluster),
+        // since the Gradle-managed cluster's gRPC port is irrelevant for external clusters.
+        if (System.getProperty("tests.rest.cluster") == null) {
+            getClusters().forEach { cluster ->
+                def logFile = new File(cluster.nodes.first().workingDir.toFile(), "logs/integTest.log")
+                // Retry to handle race condition where gRPC transport hasn't written port to log yet
+                def grpcPort = null
+                for (int attempt = 0; attempt < 10 && grpcPort == null; attempt++) {
+                    if (logFile.exists()) {
+                        def matcher = (logFile.text =~ /Netty4GrpcServerTransport.*publish_address \{([^}]+):(\d+)\}/)
+                        if (matcher.find()) {
+                            grpcPort = matcher.group(2)
+                        }
+                    }
+                    if (grpcPort == null) {
+                        logger.lifecycle("Waiting for gRPC port in log file (attempt ${attempt + 1}/10)...")
+                        Thread.sleep(1000)
+                    }
+                }
+                if (grpcPort != null) {
+                    systemProperty 'tests.grpc.port', grpcPort
+                    logger.lifecycle("Discovered gRPC port: ${grpcPort}")
+                } else {
+                    logger.warn("Could not discover gRPC port from cluster log — gRPC tests will use default port 9400")
+                }
+            }
+        }
     }
 
     // The -Ddebug.es option makes the cluster debuggable; this makes the tests debuggable
@@ -445,6 +487,11 @@ testClusters.integTest { cluster ->
     testDistribution = "ARCHIVE"
     systemProperty "java.security.policy", "file://${project.rootDir}/src/main/plugin-metadata/plugin-security.policy"
     systemProperty 'log4j.configurationFile', "${project.rootDir}/src/test/resources/log4j2.properties"
+    
+    // Enable gRPC transport module (following neural-search pattern)
+    setting("aux.transport.types", "[transport-grpc]")
+    // Bind gRPC to IPv4 loopback to avoid dual-stack port mismatch
+    setting("grpc.bind_host", "127.0.0.1")
 
     // Optionally install security
     if (System.getProperty("security.enabled") != null) {

--- a/src/main/java/org/opensearch/knn/grpc/proto/request/search/query/KNNQueryBuilderProtoConverter.java
+++ b/src/main/java/org/opensearch/knn/grpc/proto/request/search/query/KNNQueryBuilderProtoConverter.java
@@ -29,11 +29,9 @@ public class KNNQueryBuilderProtoConverter implements QueryBuilderProtoConverter
         return QueryContainer.QueryContainerCase.KNN;
     }
 
-
     @Override
     public QueryBuilder fromProto(QueryContainer queryContainer) {
-        if (queryContainer == null ||
-            queryContainer.getQueryContainerCase() != QueryContainer.QueryContainerCase.KNN) {
+        if (queryContainer == null || queryContainer.getQueryContainerCase() != QueryContainer.QueryContainerCase.KNN) {
             throw new IllegalArgumentException("QueryContainer does not contain a KNN query");
         }
 

--- a/src/main/java/org/opensearch/knn/grpc/proto/request/search/query/KNNQueryBuilderProtoConverter.java
+++ b/src/main/java/org/opensearch/knn/grpc/proto/request/search/query/KNNQueryBuilderProtoConverter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.grpc.proto.request.search.query;
+
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.transport.grpc.spi.QueryBuilderProtoConverter;
+import org.opensearch.transport.grpc.spi.QueryBuilderProtoConverterRegistry;
+import org.opensearch.protobufs.QueryContainer;
+
+/**
+ * Converter for KNN queries in JVector plugin.
+ * This class implements the QueryBuilderProtoConverter interface to provide KNN query support
+ * for the gRPC transport plugin.
+ */
+public class KNNQueryBuilderProtoConverter implements QueryBuilderProtoConverter {
+
+    private QueryBuilderProtoConverterRegistry registry;
+
+    @Override
+    public void setRegistry(QueryBuilderProtoConverterRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Override
+    public QueryContainer.QueryContainerCase getHandledQueryCase() {
+        return QueryContainer.QueryContainerCase.KNN;
+    }
+
+
+    @Override
+    public QueryBuilder fromProto(QueryContainer queryContainer) {
+        if (queryContainer == null ||
+            queryContainer.getQueryContainerCase() != QueryContainer.QueryContainerCase.KNN) {
+            throw new IllegalArgumentException("QueryContainer does not contain a KNN query");
+        }
+
+        if (registry == null) {
+            throw new IllegalStateException("QueryBuilderProtoConverterRegistry must be set before calling fromProto");
+        }
+
+        return KNNQueryBuilderProtoUtils.fromProto(queryContainer.getKnn(), registry);
+    }
+}

--- a/src/main/java/org/opensearch/knn/grpc/proto/request/search/query/KNNQueryBuilderProtoUtils.java
+++ b/src/main/java/org/opensearch/knn/grpc/proto/request/search/query/KNNQueryBuilderProtoUtils.java
@@ -114,7 +114,7 @@ public class KNNQueryBuilderProtoUtils {
     /**
      * Converts Protocol Buffer method parameters following the exact same pattern as
      * MethodParametersParser.fromXContent() to ensure consistency.
-     * 
+     *
      * This uses a two-phase conversion:
      * 1. Convert Protocol Buffer ObjectMap to raw Java Map
      * 2. Process through MethodParameter.parse() for type conversion
@@ -150,9 +150,7 @@ public class KNNQueryBuilderProtoUtils {
                 Object parsedValue = parameter.parse(value);
                 processedMethodParameters.put(name, parsedValue);
             } catch (Exception exception) {
-                throw new IllegalArgumentException(
-                    "Error parsing method parameter [" + name + "]: " + exception.getMessage()
-                );
+                throw new IllegalArgumentException("Error parsing method parameter [" + name + "]: " + exception.getMessage());
             }
         }
 
@@ -196,9 +194,7 @@ public class KNNQueryBuilderProtoUtils {
     private RescoreContext convertRescoreContext(KnnQueryRescore rescoreProto) {
         switch (rescoreProto.getKnnQueryRescoreCase()) {
             case ENABLE:
-                return rescoreProto.getEnable() 
-                    ? RescoreContext.getDefault() 
-                    : RescoreContext.EXPLICITLY_DISABLED_RESCORE_CONTEXT;
+                return rescoreProto.getEnable() ? RescoreContext.getDefault() : RescoreContext.EXPLICITLY_DISABLED_RESCORE_CONTEXT;
 
             case CONTEXT:
                 org.opensearch.protobufs.RescoreContext contextProto = rescoreProto.getContext();

--- a/src/main/java/org/opensearch/knn/grpc/proto/request/search/query/KNNQueryBuilderProtoUtils.java
+++ b/src/main/java/org/opensearch/knn/grpc/proto/request/search/query/KNNQueryBuilderProtoUtils.java
@@ -162,7 +162,8 @@ public class KNNQueryBuilderProtoUtils {
      * Handles all supported protobuf value types.
      *
      * @param value The Protocol Buffer Value to convert
-     * @return The converted Java Object, or null if unsupported type
+     * @return The converted Java Object
+     * @throws UnsupportedOperationException if the value type is not supported
      */
     static Object convertObjectMapValue(org.opensearch.protobufs.ObjectMap.Value value) {
         switch (value.getValueCase()) {
@@ -179,8 +180,9 @@ public class KNNQueryBuilderProtoUtils {
             case BOOL:
                 return value.getBool();
             default:
-                // Skip unsupported types
-                return null;
+                throw new UnsupportedOperationException(
+                    "Unsupported ObjectMap.Value type: " + value.getValueCase()
+                );
         }
     }
 

--- a/src/main/java/org/opensearch/knn/grpc/proto/request/search/query/KNNQueryBuilderProtoUtils.java
+++ b/src/main/java/org/opensearch/knn/grpc/proto/request/search/query/KNNQueryBuilderProtoUtils.java
@@ -180,9 +180,7 @@ public class KNNQueryBuilderProtoUtils {
             case BOOL:
                 return value.getBool();
             default:
-                throw new UnsupportedOperationException(
-                    "Unsupported ObjectMap.Value type: " + value.getValueCase()
-                );
+                throw new UnsupportedOperationException("Unsupported ObjectMap.Value type: " + value.getValueCase());
         }
     }
 

--- a/src/main/java/org/opensearch/knn/grpc/proto/request/search/query/KNNQueryBuilderProtoUtils.java
+++ b/src/main/java/org/opensearch/knn/grpc/proto/request/search/query/KNNQueryBuilderProtoUtils.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.grpc.proto.request.search.query;
+
+import lombok.experimental.UtilityClass;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.knn.index.query.KNNQueryBuilder;
+import org.opensearch.knn.index.query.request.MethodParameter;
+import org.opensearch.knn.index.query.rescore.RescoreContext;
+import org.opensearch.transport.grpc.spi.QueryBuilderProtoConverterRegistry;
+import org.opensearch.protobufs.KnnQuery;
+import org.opensearch.protobufs.KnnQueryRescore;
+import org.opensearch.protobufs.QueryContainer;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Utility class for converting KNN Protocol Buffers to OpenSearch objects.
+ * This class provides methods to transform Protocol Buffer representations of KNN queries
+ * into their corresponding OpenSearch KNNQueryBuilder implementations for search operations.
+ */
+@UtilityClass
+public class KNNQueryBuilderProtoUtils {
+
+    /**
+     * Converts a Protocol Buffer KnnQuery to an OpenSearch KNNQueryBuilder.
+     * This method follows the exact same pattern as KNNQueryBuilderParser.fromXContent()
+     * to ensure parsing consistency and compatibility.
+     *
+     * @param knnQueryProto The Protocol Buffer KnnQuery to convert
+     * @param registry The registry to use for converting nested queries (e.g., filters)
+     * @return A configured KNNQueryBuilder instance
+     */
+    public QueryBuilder fromProto(KnnQuery knnQueryProto, QueryBuilderProtoConverterRegistry registry) {
+        // Create builder using the internal parser pattern like XContent parsing
+        KNNQueryBuilder.Builder builder = KNNQueryBuilder.builder();
+
+        // Set field name (equivalent to fieldName parsing in XContent)
+        builder.fieldName(knnQueryProto.getField());
+
+        // Set vector (equivalent to VECTOR_FIELD parsing)
+        builder.vector(convertVector(knnQueryProto.getVectorList()));
+
+        // Set k if present (equivalent to K_FIELD parsing)
+        if (knnQueryProto.getK() > 0) {
+            builder.k(knnQueryProto.getK());
+        }
+
+        // Set maxDistance if present (equivalent to MAX_DISTANCE_FIELD parsing)
+        else if (knnQueryProto.hasMaxDistance()) {
+            builder.maxDistance(knnQueryProto.getMaxDistance());
+        }
+
+        // Set minScore if present (equivalent to MIN_SCORE_FIELD parsing)
+        else if (knnQueryProto.hasMinScore()) {
+            builder.minScore(knnQueryProto.getMinScore());
+        }
+
+        // Set method parameters (equivalent to METHOD_PARAMS_FIELD parsing)
+        if (knnQueryProto.hasMethodParameters()) {
+            Map<String, ?> methodParameters = convertMethodParameters(knnQueryProto.getMethodParameters());
+            builder.methodParameters(methodParameters);
+        }
+
+        // Set filter (equivalent to FILTER_FIELD parsing)
+        if (knnQueryProto.hasFilter()) {
+            QueryContainer filterQueryContainer = knnQueryProto.getFilter();
+            builder.filter(registry.fromProto(filterQueryContainer));
+        }
+
+        // Set rescore (equivalent to RESCORE_FIELD parsing)
+        if (knnQueryProto.hasRescore()) {
+            RescoreContext rescoreContext = convertRescoreContext(knnQueryProto.getRescore());
+            builder.rescoreContext(rescoreContext);
+        }
+
+        // Set boost (equivalent to BOOST_FIELD parsing)
+        if (knnQueryProto.hasBoost()) {
+            builder.boost(knnQueryProto.getBoost());
+        }
+
+        // Set query name (equivalent to NAME_FIELD parsing)
+        if (knnQueryProto.hasXName()) {
+            builder.queryName(knnQueryProto.getXName());
+        }
+
+        // Set expandNested (equivalent to EXPAND_NESTED_FIELD parsing)
+        if (knnQueryProto.hasExpandNestedDocs()) {
+            builder.expandNested(knnQueryProto.getExpandNestedDocs());
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Converts a Protocol Buffer vector list to a float array.
+     *
+     * @param vectorList The Protocol Buffer vector list
+     * @return The converted float array
+     */
+    private float[] convertVector(List<Float> vectorList) {
+        float[] vector = new float[vectorList.size()];
+        for (int i = 0; i < vectorList.size(); i++) {
+            vector[i] = vectorList.get(i);
+        }
+        return vector;
+    }
+
+    /**
+     * Converts Protocol Buffer method parameters following the exact same pattern as
+     * MethodParametersParser.fromXContent() to ensure consistency.
+     * 
+     * This uses a two-phase conversion:
+     * 1. Convert Protocol Buffer ObjectMap to raw Java Map
+     * 2. Process through MethodParameter.parse() for type conversion
+     *
+     * @param objectMap The Protocol Buffer ObjectMap to convert
+     * @return The converted method parameters Map
+     */
+    private Map<String, ?> convertMethodParameters(org.opensearch.protobufs.ObjectMap objectMap) {
+        // Phase 1: Convert Protocol Buffer to raw Map (equivalent to parser.map())
+        Map<String, Object> rawMethodParameters = new HashMap<>();
+        for (Map.Entry<String, org.opensearch.protobufs.ObjectMap.Value> entry : objectMap.getFieldsMap().entrySet()) {
+            String key = entry.getKey();
+            Object value = convertObjectMapValue(entry.getValue());
+            if (value != null) {
+                rawMethodParameters.put(key, value);
+            }
+        }
+
+        // Phase 2: Process through MethodParameter.parse() exactly like XContent parsing does
+        Map<String, Object> processedMethodParameters = new HashMap<>();
+        for (Map.Entry<String, Object> entry : rawMethodParameters.entrySet()) {
+            String name = entry.getKey();
+            Object value = entry.getValue();
+
+            // Find the MethodParameter enum (same as XContent parsing)
+            MethodParameter parameter = MethodParameter.enumOf(name);
+            if (parameter == null) {
+                throw new IllegalArgumentException("unknown method parameter found [" + name + "]");
+            }
+
+            try {
+                // Parse using MethodParameter.parse() - this handles type conversion properly
+                Object parsedValue = parameter.parse(value);
+                processedMethodParameters.put(name, parsedValue);
+            } catch (Exception exception) {
+                throw new IllegalArgumentException(
+                    "Error parsing method parameter [" + name + "]: " + exception.getMessage()
+                );
+            }
+        }
+
+        return processedMethodParameters.isEmpty() ? null : processedMethodParameters;
+    }
+
+    /**
+     * Converts a Protocol Buffer ObjectMap.Value to a Java Object.
+     * Handles all supported protobuf value types.
+     *
+     * @param value The Protocol Buffer Value to convert
+     * @return The converted Java Object, or null if unsupported type
+     */
+    static Object convertObjectMapValue(org.opensearch.protobufs.ObjectMap.Value value) {
+        switch (value.getValueCase()) {
+            case INT32:
+                return value.getInt32();
+            case INT64:
+                return value.getInt64();
+            case FLOAT:
+                return value.getFloat();
+            case DOUBLE:
+                return value.getDouble();
+            case STRING:
+                return value.getString();
+            case BOOL:
+                return value.getBool();
+            default:
+                // Skip unsupported types
+                return null;
+        }
+    }
+
+    /**
+     * Converts a Protocol Buffer KnnQueryRescore to a RescoreContext.
+     * Handles both simple enable/disable and complex rescore contexts.
+     *
+     * @param rescoreProto The Protocol Buffer KnnQueryRescore to convert
+     * @return The converted RescoreContext
+     */
+    private RescoreContext convertRescoreContext(KnnQueryRescore rescoreProto) {
+        switch (rescoreProto.getKnnQueryRescoreCase()) {
+            case ENABLE:
+                return rescoreProto.getEnable() 
+                    ? RescoreContext.getDefault() 
+                    : RescoreContext.EXPLICITLY_DISABLED_RESCORE_CONTEXT;
+
+            case CONTEXT:
+                org.opensearch.protobufs.RescoreContext contextProto = rescoreProto.getContext();
+                return contextProto.hasOversampleFactor()
+                    ? RescoreContext.builder().oversampleFactor(contextProto.getOversampleFactor()).build()
+                    : RescoreContext.getDefault();
+
+            default:
+                return RescoreContext.getDefault();
+        }
+    }
+}

--- a/src/main/resources/META-INF/services/org.opensearch.transport.grpc.spi.QueryBuilderProtoConverter
+++ b/src/main/resources/META-INF/services/org.opensearch.transport.grpc.spi.QueryBuilderProtoConverter
@@ -1,0 +1,1 @@
+org.opensearch.knn.grpc.proto.request.search.query.KNNQueryBuilderProtoConverter

--- a/src/test/java/org/opensearch/knn/grpc/GrpcTestHelper.java
+++ b/src/test/java/org/opensearch/knn/grpc/GrpcTestHelper.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.knn.grpc;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.protobufs.KnnQuery;
+import org.opensearch.protobufs.MatchAllQuery;
+import org.opensearch.protobufs.QueryContainer;
+import org.opensearch.protobufs.SearchRequest;
+import org.opensearch.protobufs.SearchRequestBody;
+import org.opensearch.protobufs.SearchResponse;
+import org.opensearch.protobufs.services.SearchServiceGrpc;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.stub.MetadataUtils;
+import lombok.experimental.UtilityClass;
+
+/**
+ * Helper class providing common gRPC testing utilities for KNN integration tests.
+ * This class provides utilities for creating gRPC channels, building search requests,
+ * and executing searches via gRPC.
+ */
+@UtilityClass
+public class GrpcTestHelper {
+
+    private static final Logger logger = LogManager.getLogger(GrpcTestHelper.class);
+
+    public static final String DEFAULT_GRPC_HOST = "127.0.0.1";
+    public static final int DEFAULT_GRPC_PORT = 9400;
+    public static final int DEFAULT_TIMEOUT_SECONDS = 30;
+
+    /**
+     * Check if gRPC transport is expected to be available.
+     * Returns true when either:
+     * - tests.grpc.port is explicitly set (Gradle-managed cluster discovered the port), or
+     * - tests.rest.cluster is NOT set (local testClusters run where gRPC is configured in build.gradle)
+     *
+     * Returns false when tests.rest.cluster is set but tests.grpc.port is not,
+     * indicating an external cluster that likely doesn't have gRPC transport configured.
+     *
+     * Use with {@code assumeTrue(GrpcTestHelper.isGrpcTransportConfigured())} in test setUp
+     * to gracefully skip gRPC tests in distribution integration tests (opensearch-build test.sh).
+     */
+    public static boolean isGrpcTransportConfigured() {
+        boolean grpcPortExplicitlySet = System.getProperty("tests.grpc.port") != null;
+        boolean externalCluster = System.getProperty("tests.rest.cluster") != null;
+        if (grpcPortExplicitlySet) {
+            logger.info("gRPC port explicitly configured: {}", getGrpcPort());
+            return true;
+        }
+        if (externalCluster) {
+            logger.info(
+                "External cluster detected (tests.rest.cluster={}) without tests.grpc.port — gRPC tests will be skipped",
+                System.getProperty("tests.rest.cluster")
+            );
+            return false;
+        }
+        // Local testClusters run — gRPC is configured in build.gradle
+        logger.info("Local test cluster run — gRPC transport expected to be available");
+        return true;
+    }
+
+    // ===========================================================================================
+    // CHANNEL MANAGEMENT
+    // ===========================================================================================
+
+    public static String getGrpcHost() {
+        return System.getProperty("tests.grpc.host", DEFAULT_GRPC_HOST);
+    }
+
+    public static int getGrpcPort() {
+        return Integer.parseInt(System.getProperty("tests.grpc.port", String.valueOf(DEFAULT_GRPC_PORT)));
+    }
+
+    public static ManagedChannel createGrpcChannel() {
+        return createGrpcChannel(getGrpcHost(), getGrpcPort());
+    }
+
+    public static ManagedChannel createGrpcChannel(String host, int port) {
+        String target = host + ":" + port;
+        logger.info("Creating gRPC channel to target: {}", target);
+        try {
+            ManagedChannel channel = ManagedChannelBuilder.forTarget(target).usePlaintext().build();
+            logger.info("gRPC channel created, state: {}", channel.getState(true));
+            return channel;
+        } catch (Exception e) {
+            logger.error("Failed to create gRPC channel to target: {}. Error: {}", target, e.getMessage(), e);
+            throw new RuntimeException("Failed to create gRPC channel to " + target, e);
+        }
+    }
+
+    public static void shutdownChannel(ManagedChannel channel, int timeoutSeconds) throws InterruptedException {
+        if (channel != null && !channel.isShutdown()) {
+            channel.shutdown();
+            channel.awaitTermination(timeoutSeconds, TimeUnit.SECONDS);
+        }
+    }
+
+    public static void shutdownChannel(ManagedChannel channel) throws InterruptedException {
+        shutdownChannel(channel, 5);
+    }
+
+    // ===========================================================================================
+    // SEARCH REQUEST BUILDERS
+    // ===========================================================================================
+
+    public static SearchRequest buildSearchRequest(String index, QueryContainer query) {
+        return buildSearchRequest(index, query, 10);
+    }
+
+    public static SearchRequest buildSearchRequest(String index, QueryContainer query, int size) {
+        return SearchRequest.newBuilder()
+            .addIndex(index)
+            .setSearchRequestBody(SearchRequestBody.newBuilder().setQuery(query).setSize(size).build())
+            .build();
+    }
+
+    // ===========================================================================================
+    // SEARCH EXECUTION
+    // ===========================================================================================
+
+    public static SearchResponse executeSearch(ManagedChannel channel, SearchRequest request) {
+        return executeSearch(channel, request, DEFAULT_TIMEOUT_SECONDS);
+    }
+
+    public static SearchResponse executeSearch(ManagedChannel channel, SearchRequest request, int timeoutSeconds) {
+        SearchServiceGrpc.SearchServiceBlockingStub stub = SearchServiceGrpc.newBlockingStub(channel)
+            .withDeadlineAfter(timeoutSeconds, TimeUnit.SECONDS);
+
+        if (isSecurityEnabled()) {
+            stub = addBasicAuthentication(stub);
+        }
+
+        return stub.search(request);
+    }
+
+    private static boolean isSecurityEnabled() {
+        return "true".equals(System.getProperty("security.enabled"));
+    }
+
+    private static SearchServiceGrpc.SearchServiceBlockingStub addBasicAuthentication(SearchServiceGrpc.SearchServiceBlockingStub stub) {
+        String username = System.getProperty("user", "admin");
+        String password = System.getProperty("password", "admin");
+        String credentials = username + ":" + password;
+        String encodedCredentials = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+
+        Metadata headers = new Metadata();
+        Metadata.Key<String> authKey = Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
+        headers.put(authKey, "Basic " + encodedCredentials);
+
+        return stub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(headers));
+    }
+
+    // ===========================================================================================
+    // QUERY BUILDERS
+    // ===========================================================================================
+
+    public static QueryContainer createMatchAllQueryContainer() {
+        return QueryContainer.newBuilder().setMatchAll(MatchAllQuery.newBuilder().build()).build();
+    }
+
+    public static QueryContainer createKnnQueryContainer(String field, float[] vector, int k) {
+        KnnQuery.Builder knnBuilder = KnnQuery.newBuilder().setField(field).setK(k);
+        for (float v : vector) {
+            knnBuilder.addVector(v);
+        }
+        return QueryContainer.newBuilder().setKnn(knnBuilder.build()).build();
+    }
+
+}

--- a/src/test/java/org/opensearch/knn/grpc/KNNQueryGrpcIT.java
+++ b/src/test/java/org/opensearch/knn/grpc/KNNQueryGrpcIT.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.knn.grpc;
+
+import static com.carrotsearch.randomizedtesting.RandomizedTest.assumeTrue;
+import static org.opensearch.knn.grpc.GrpcTestHelper.buildSearchRequest;
+import static org.opensearch.knn.grpc.GrpcTestHelper.createKnnQueryContainer;
+import static org.opensearch.knn.grpc.GrpcTestHelper.createMatchAllQueryContainer;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.protobufs.QueryContainer;
+import org.opensearch.protobufs.SearchRequest;
+import org.opensearch.protobufs.SearchResponse;
+
+import io.grpc.ManagedChannel;
+import io.grpc.StatusRuntimeException;
+import lombok.SneakyThrows;
+
+/**
+ * Integration test for gRPC KNN Query functionality.
+ *
+ * This test verifies that KNN queries can be:
+ * 1. Created in Protocol Buffer format
+ * 2. Sent via gRPC to OpenSearch
+ * 3. Executed correctly using JVector engine and return expected results
+ */
+public class KNNQueryGrpcIT extends KNNRestTestCase {
+
+    private static final Logger logger = LogManager.getLogger(KNNQueryGrpcIT.class);
+
+    private static final String TEST_INDEX_NAME = "test-grpc-knn-index";
+    private static final String TEST_VECTOR_FIELD_NAME = "test_vector";
+    private static final int TEST_VECTOR_DIMENSION = 3;
+
+    private ManagedChannel grpcChannel;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        // Skip gRPC tests when gRPC transport is not available on the cluster
+        // (e.g., distribution integration tests via opensearch-build test.sh where
+        // the external cluster doesn't have aux.transport.types configured)
+        assumeTrue("gRPC transport is not configured, skipping gRPC tests", GrpcTestHelper.isGrpcTransportConfigured());
+
+        // Set up test index with vector data
+        initializeTestIndex();
+
+        // Create gRPC channel for tests using the shared helper
+        grpcChannel = GrpcTestHelper.createGrpcChannel();
+    }
+
+    @After
+    public void tearDownGrpc() throws Exception {
+        try {
+            deleteTestIndex();
+        } finally {
+            GrpcTestHelper.shutdownChannel(grpcChannel);
+        }
+    }
+
+    /**
+     * Initialize test index with KNN vector field and sample documents.
+     */
+    @SneakyThrows
+    private void initializeTestIndex() {
+        if (!indexExists(TEST_INDEX_NAME)) {
+            logger.info("Creating test index: {}", TEST_INDEX_NAME);
+
+            // Create index with KNN vector field using JVector engine
+            String indexMapping = String.format(
+                "{\n"
+                    + "  \"settings\": {\n"
+                    + "    \"index\": {\n"
+                    + "      \"knn\": true,\n"
+                    + "      \"number_of_shards\": 1,\n"
+                    + "      \"number_of_replicas\": 0\n"
+                    + "    }\n"
+                    + "  },\n"
+                    + "  \"mappings\": {\n"
+                    + "    \"properties\": {\n"
+                    + "      \"%s\": {\n"
+                    + "        \"type\": \"knn_vector\",\n"
+                    + "        \"dimension\": %d\n"
+                    + "      }\n"
+                    + "    }\n"
+                    + "  }\n"
+                    + "}",
+                TEST_VECTOR_FIELD_NAME,
+                TEST_VECTOR_DIMENSION
+            );
+
+            Request createIndexRequest = new Request("PUT", "/" + TEST_INDEX_NAME);
+            createIndexRequest.setJsonEntity(indexMapping);
+            Response response = client().performRequest(createIndexRequest);
+            assertEquals(200, response.getStatusLine().getStatusCode());
+            logger.info("Test index created successfully");
+
+            // Index sample documents
+            indexTestDocuments();
+
+            // Refresh index to make documents searchable
+            refreshIndex(TEST_INDEX_NAME);
+        }
+    }
+
+    /**
+     * Index sample documents with vector data.
+     */
+    @SneakyThrows
+    private void indexTestDocuments() {
+        // Document 1: [0.1, 0.2, 0.3]
+        String doc1 = String.format("{\"%s\": [0.1, 0.2, 0.3]}", TEST_VECTOR_FIELD_NAME);
+        Request indexDoc1 = new Request("POST", "/" + TEST_INDEX_NAME + "/_doc/1?refresh=true");
+        indexDoc1.setJsonEntity(doc1);
+        client().performRequest(indexDoc1);
+
+        // Document 2: [0.2, 0.3, 0.4]
+        String doc2 = String.format("{\"%s\": [0.2, 0.3, 0.4]}", TEST_VECTOR_FIELD_NAME);
+        Request indexDoc2 = new Request("POST", "/" + TEST_INDEX_NAME + "/_doc/2?refresh=true");
+        indexDoc2.setJsonEntity(doc2);
+        client().performRequest(indexDoc2);
+
+        // Document 3: [0.3, 0.4, 0.5]
+        String doc3 = String.format("{\"%s\": [0.3, 0.4, 0.5]}", TEST_VECTOR_FIELD_NAME);
+        Request indexDoc3 = new Request("POST", "/" + TEST_INDEX_NAME + "/_doc/3?refresh=true");
+        indexDoc3.setJsonEntity(doc3);
+        client().performRequest(indexDoc3);
+
+        logger.info("Indexed 3 test documents");
+    }
+
+    /**
+     * Delete the test index to clean up resources after test execution.
+     */
+    @SneakyThrows
+    private void deleteTestIndex() {
+        try {
+            if (indexExists(TEST_INDEX_NAME)) {
+                logger.info("Deleting test index: {}", TEST_INDEX_NAME);
+                Request deleteRequest = new Request("DELETE", "/" + TEST_INDEX_NAME);
+                Response response = client().performRequest(deleteRequest);
+                if (response.getStatusLine().getStatusCode() == 200) {
+                    logger.info("Successfully deleted test index: {}", TEST_INDEX_NAME);
+                }
+            }
+        } catch (Exception e) {
+            logger.warn("Failed to delete test index {}: {}", TEST_INDEX_NAME, e.getMessage());
+        }
+    }
+
+    // ===========================================================================================
+    // BASIC FUNCTIONALITY TESTS - Verify end-to-end gRPC query execution
+    // ===========================================================================================
+
+    /**
+     * Test gRPC connectivity with a simple MatchAll query.
+     */
+    @SneakyThrows
+    public void testGrpcConnectivityWithMatchAllQuery() {
+        String host = GrpcTestHelper.getGrpcHost();
+        int port = GrpcTestHelper.getGrpcPort();
+        logger.info("Testing gRPC connectivity to {}:{}", host, port);
+
+        try {
+            QueryContainer query = createMatchAllQueryContainer();
+            SearchRequest request = buildSearchRequest(TEST_INDEX_NAME, query);
+
+            SearchResponse response = GrpcTestHelper.executeSearch(grpcChannel, request, 10);
+
+            assertNotNull("Search response should not be null", response);
+            assertTrue("Should have at least one hit", response.getHits().getHitsCount() > 0);
+            logger.info("gRPC connection successful to {}:{}", host, port);
+        } catch (StatusRuntimeException e) {
+            logger.error("Failed to connect via gRPC to {}:{} - {}", host, port, e.getMessage());
+            fail("Cannot connect to gRPC endpoint " + host + ":" + port + " - " + e.getMessage());
+        }
+    }
+
+    /**
+     * Test that a basic KNN query executes via gRPC and returns results.
+     * This validates the complete round-trip: client -> gRPC -> OpenSearch -> JVector -> response
+     */
+    @SneakyThrows
+    public void testBasicKnnQueryReturnsResults() {
+        float[] queryVector = new float[] { 0.15f, 0.25f, 0.35f };
+
+        QueryContainer knnQuery = createKnnQueryContainer(TEST_VECTOR_FIELD_NAME, queryVector, 3);
+        SearchRequest request = buildSearchRequest(TEST_INDEX_NAME, knnQuery, 3);
+
+        SearchResponse response = GrpcTestHelper.executeSearch(grpcChannel, request);
+
+        assertNotNull("Search response should not be null", response);
+        assertTrue("Should have hits", response.getHits().getHitsCount() > 0);
+        assertTrue("Should have at most 3 hits (k=3)", response.getHits().getHitsCount() <= 3);
+        logger.info("KNN query via gRPC returned {} hits", response.getHits().getHitsCount());
+    }
+
+    /**
+     * Test KNN query with k=1 to verify nearest neighbor search.
+     */
+    @SneakyThrows
+    public void testKnnQueryWithK1() {
+        // Query vector very close to document 1: [0.1, 0.2, 0.3]
+        float[] queryVector = new float[] { 0.11f, 0.21f, 0.31f };
+
+        QueryContainer knnQuery = createKnnQueryContainer(TEST_VECTOR_FIELD_NAME, queryVector, 1);
+        SearchRequest request = buildSearchRequest(TEST_INDEX_NAME, knnQuery, 1);
+
+        SearchResponse response = GrpcTestHelper.executeSearch(grpcChannel, request);
+
+        assertNotNull("Search response should not be null", response);
+        assertEquals("Should return exactly 1 hit (k=1)", 1, response.getHits().getHitsCount());
+        logger.info("KNN query with k=1 correctly returned nearest neighbor");
+    }
+
+    /**
+     * Test that KNN query results are ordered by similarity score.
+     */
+    @SneakyThrows
+    public void testKnnQueryResultsAreOrdered() {
+        float[] queryVector = new float[] { 0.15f, 0.25f, 0.35f };
+
+        QueryContainer knnQuery = createKnnQueryContainer(TEST_VECTOR_FIELD_NAME, queryVector, 3);
+        SearchRequest request = buildSearchRequest(TEST_INDEX_NAME, knnQuery, 3);
+
+        SearchResponse response = GrpcTestHelper.executeSearch(grpcChannel, request);
+
+        assertNotNull("Search response should not be null", response);
+        assertTrue("Should have multiple hits", response.getHits().getHitsCount() > 1);
+        logger.info("KNN query via gRPC returned {} hits with valid scores", response.getHits().getHitsCount());
+    }
+
+    // ===========================================================================================
+    // ERROR HANDLING TESTS - Verify proper error responses
+    // ===========================================================================================
+
+    /**
+     * Test search on non-existent index returns proper gRPC error.
+     */
+    @SneakyThrows
+    public void testErrorNonExistentIndex() {
+        float[] queryVector = new float[] { 0.1f, 0.2f, 0.3f };
+
+        QueryContainer knnQuery = createKnnQueryContainer(TEST_VECTOR_FIELD_NAME, queryVector, 3);
+        SearchRequest request = buildSearchRequest("non-existent-index-12345", knnQuery);
+
+        StatusRuntimeException exception = expectThrows(
+            StatusRuntimeException.class,
+            () -> GrpcTestHelper.executeSearch(grpcChannel, request)
+        );
+
+        assertNotNull("Should throw exception for non-existent index", exception);
+        logger.info("Non-existent index test correctly threw exception: {}", exception.getStatus().getCode());
+    }
+
+    /**
+     * Test KNN query with invalid vector dimension returns proper error.
+     */
+    @SneakyThrows
+    public void testErrorInvalidVectorDimension() {
+        // Index expects 3 dimensions, but we provide 5
+        float[] invalidVector = new float[] { 0.1f, 0.2f, 0.3f, 0.4f, 0.5f };
+
+        QueryContainer knnQuery = createKnnQueryContainer(TEST_VECTOR_FIELD_NAME, invalidVector, 3);
+        SearchRequest request = buildSearchRequest(TEST_INDEX_NAME, knnQuery);
+
+        StatusRuntimeException exception = expectThrows(
+            StatusRuntimeException.class,
+            () -> GrpcTestHelper.executeSearch(grpcChannel, request)
+        );
+
+        assertNotNull("Should throw exception for invalid vector dimension", exception);
+        assertTrue(
+            "Error should indicate dimension mismatch",
+            exception.getMessage().contains("dimension")
+                || exception.getStatus().getCode().name().equals("INVALID_ARGUMENT")
+                || exception.getStatus().getCode().name().equals("INTERNAL")
+        );
+        logger.info("Invalid vector dimension test correctly threw exception: {}", exception.getStatus().getCode());
+    }
+
+    /**
+     * Test KNN query with invalid k value (k=0) returns proper error.
+     */
+    @SneakyThrows
+    public void testErrorInvalidKValue() {
+        float[] queryVector = new float[] { 0.1f, 0.2f, 0.3f };
+
+        // k=0 is invalid
+        QueryContainer knnQuery = createKnnQueryContainer(TEST_VECTOR_FIELD_NAME, queryVector, 0);
+        SearchRequest request = buildSearchRequest(TEST_INDEX_NAME, knnQuery);
+
+        StatusRuntimeException exception = expectThrows(
+            StatusRuntimeException.class,
+            () -> GrpcTestHelper.executeSearch(grpcChannel, request)
+        );
+
+        assertNotNull("Should throw exception for invalid k value", exception);
+        assertTrue(
+            "Error should indicate invalid k",
+            exception.getMessage().contains("k")
+                || exception.getStatus().getCode().name().equals("INVALID_ARGUMENT")
+                || exception.getStatus().getCode().name().equals("INTERNAL")
+        );
+        logger.info("Invalid k value test correctly threw exception: {}", exception.getStatus().getCode());
+    }
+}

--- a/src/test/java/org/opensearch/knn/grpc/proto/request/search/query/KNNQueryBuilderProtoConverterTests.java
+++ b/src/test/java/org/opensearch/knn/grpc/proto/request/search/query/KNNQueryBuilderProtoConverterTests.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.grpc.proto.request.search.query;
+
+import org.junit.Before;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.knn.index.query.KNNQueryBuilder;
+import org.opensearch.protobufs.KnnQuery;
+import org.opensearch.protobufs.QueryContainer;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.grpc.spi.QueryBuilderProtoConverterRegistry;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for KNNQueryBuilderProtoConverter.
+ * Tests the SPI interface implementation and delegation to Utils.
+ */
+public class KNNQueryBuilderProtoConverterTests extends OpenSearchTestCase {
+
+    private KNNQueryBuilderProtoConverter converter;
+    private QueryBuilderProtoConverterRegistry mockRegistry;
+
+    @Before
+    public void setup() {
+        converter = new KNNQueryBuilderProtoConverter();
+        mockRegistry = mock(QueryBuilderProtoConverterRegistry.class);
+    }
+
+    /**
+     * Test that registry injection works.
+     */
+    public void testSetRegistry() {
+        converter.setRegistry(mockRegistry);
+        // No exception means success - registry is stored internally
+    }
+
+    /**
+     * Test that getHandledQueryCase returns KNN.
+     */
+    public void testGetHandledQueryCase() {
+        assertEquals(QueryContainer.QueryContainerCase.KNN, converter.getHandledQueryCase());
+    }
+
+    /**
+     * Test fromProto delegates to Utils correctly.
+     */
+    public void testFromProto_DelegatesToUtils() {
+        converter.setRegistry(mockRegistry);
+
+        KnnQuery knnQuery = KnnQuery.newBuilder()
+            .setField("test_field")
+            .addVector(1.0f)
+            .addVector(2.0f)
+            .addVector(3.0f)
+            .setK(5)
+            .build();
+
+        QueryContainer queryContainer = QueryContainer.newBuilder().setKnn(knnQuery).build();
+
+        QueryBuilder result = converter.fromProto(queryContainer);
+
+        assertNotNull(result);
+        assertTrue(result instanceof KNNQueryBuilder);
+        KNNQueryBuilder knnQueryBuilder = (KNNQueryBuilder) result;
+        assertEquals("test_field", knnQueryBuilder.fieldName());
+        assertEquals((Object) Integer.valueOf(5), (Object) knnQueryBuilder.getK());
+    }
+
+    /**
+     * Test fromProto with all optional fields.
+     */
+    public void testFromProto_WithAllFields() {
+        converter.setRegistry(mockRegistry);
+
+        KnnQuery knnQuery = KnnQuery.newBuilder()
+            .setField("vector_field")
+            .addVector(0.1f)
+            .addVector(0.2f)
+            .addVector(0.3f)
+            .setK(10)
+            .setBoost(2.0f)
+            .setXName("test_query")
+            .setExpandNestedDocs(true)
+            .build();
+
+        QueryContainer queryContainer = QueryContainer.newBuilder().setKnn(knnQuery).build();
+
+        QueryBuilder result = converter.fromProto(queryContainer);
+
+        assertTrue(result instanceof KNNQueryBuilder);
+        KNNQueryBuilder knnQueryBuilder = (KNNQueryBuilder) result;
+        assertEquals("vector_field", knnQueryBuilder.fieldName());
+        assertEquals((Object) Integer.valueOf(10), (Object) knnQueryBuilder.getK());
+        assertEquals(2.0f, knnQueryBuilder.boost(), 0.001f);
+        assertEquals("test_query", knnQueryBuilder.queryName());
+        assertTrue(knnQueryBuilder.getExpandNested());
+    }
+
+    /**
+     * Test that fromProto throws exception when registry not set.
+     */
+    public void testFromProto_WithoutRegistry_ThrowsException() {
+        // Don't set registry
+        KnnQuery knnQuery = KnnQuery.newBuilder()
+            .setField("test_field")
+            .addVector(1.0f)
+            .setK(5)
+            .build();
+
+        QueryContainer queryContainer = QueryContainer.newBuilder().setKnn(knnQuery).build();
+
+        expectThrows(IllegalStateException.class, () -> {
+            converter.fromProto(queryContainer);
+        });
+    }
+
+    /**
+     * Test that fromProto throws exception for wrong query type.
+     */
+    public void testFromProto_WrongQueryType_ThrowsException() {
+        converter.setRegistry(mockRegistry);
+
+        // Create QueryContainer with Term query instead of KNN
+        QueryContainer queryContainer = QueryContainer.newBuilder().build();
+
+        expectThrows(IllegalArgumentException.class, () -> {
+            converter.fromProto(queryContainer);
+        });
+    }
+
+    /**
+     * Test error handling for invalid KNN query (missing field).
+     */
+    public void testFromProto_InvalidQuery_ThrowsException() {
+        converter.setRegistry(mockRegistry);
+
+        KnnQuery knnQuery = KnnQuery.newBuilder()
+            .addVector(1.0f)
+            .setK(5)
+            .build(); // Missing field name
+
+        QueryContainer queryContainer = QueryContainer.newBuilder().setKnn(knnQuery).build();
+
+        expectThrows(IllegalArgumentException.class, () -> {
+            converter.fromProto(queryContainer);
+        });
+    }
+
+    /**
+     * Test that converter can be instantiated (for SPI).
+     */
+    public void testInstantiation() {
+        KNNQueryBuilderProtoConverter newConverter = new KNNQueryBuilderProtoConverter();
+        assertNotNull(newConverter);
+        assertEquals(QueryContainer.QueryContainerCase.KNN, newConverter.getHandledQueryCase());
+    }
+}

--- a/src/test/java/org/opensearch/knn/grpc/proto/request/search/query/KNNQueryBuilderProtoConverterTests.java
+++ b/src/test/java/org/opensearch/knn/grpc/proto/request/search/query/KNNQueryBuilderProtoConverterTests.java
@@ -51,13 +51,7 @@ public class KNNQueryBuilderProtoConverterTests extends OpenSearchTestCase {
     public void testFromProto_DelegatesToUtils() {
         converter.setRegistry(mockRegistry);
 
-        KnnQuery knnQuery = KnnQuery.newBuilder()
-            .setField("test_field")
-            .addVector(1.0f)
-            .addVector(2.0f)
-            .addVector(3.0f)
-            .setK(5)
-            .build();
+        KnnQuery knnQuery = KnnQuery.newBuilder().setField("test_field").addVector(1.0f).addVector(2.0f).addVector(3.0f).setK(5).build();
 
         QueryContainer queryContainer = QueryContainer.newBuilder().setKnn(knnQuery).build();
 
@@ -105,17 +99,11 @@ public class KNNQueryBuilderProtoConverterTests extends OpenSearchTestCase {
      */
     public void testFromProto_WithoutRegistry_ThrowsException() {
         // Don't set registry
-        KnnQuery knnQuery = KnnQuery.newBuilder()
-            .setField("test_field")
-            .addVector(1.0f)
-            .setK(5)
-            .build();
+        KnnQuery knnQuery = KnnQuery.newBuilder().setField("test_field").addVector(1.0f).setK(5).build();
 
         QueryContainer queryContainer = QueryContainer.newBuilder().setKnn(knnQuery).build();
 
-        expectThrows(IllegalStateException.class, () -> {
-            converter.fromProto(queryContainer);
-        });
+        expectThrows(IllegalStateException.class, () -> { converter.fromProto(queryContainer); });
     }
 
     /**
@@ -127,9 +115,7 @@ public class KNNQueryBuilderProtoConverterTests extends OpenSearchTestCase {
         // Create QueryContainer with Term query instead of KNN
         QueryContainer queryContainer = QueryContainer.newBuilder().build();
 
-        expectThrows(IllegalArgumentException.class, () -> {
-            converter.fromProto(queryContainer);
-        });
+        expectThrows(IllegalArgumentException.class, () -> { converter.fromProto(queryContainer); });
     }
 
     /**
@@ -138,16 +124,11 @@ public class KNNQueryBuilderProtoConverterTests extends OpenSearchTestCase {
     public void testFromProto_InvalidQuery_ThrowsException() {
         converter.setRegistry(mockRegistry);
 
-        KnnQuery knnQuery = KnnQuery.newBuilder()
-            .addVector(1.0f)
-            .setK(5)
-            .build(); // Missing field name
+        KnnQuery knnQuery = KnnQuery.newBuilder().addVector(1.0f).setK(5).build(); // Missing field name
 
         QueryContainer queryContainer = QueryContainer.newBuilder().setKnn(knnQuery).build();
 
-        expectThrows(IllegalArgumentException.class, () -> {
-            converter.fromProto(queryContainer);
-        });
+        expectThrows(IllegalArgumentException.class, () -> { converter.fromProto(queryContainer); });
     }
 
     /**

--- a/src/test/java/org/opensearch/knn/grpc/proto/request/search/query/KNNQueryBuilderProtoUtilsTests.java
+++ b/src/test/java/org/opensearch/knn/grpc/proto/request/search/query/KNNQueryBuilderProtoUtilsTests.java
@@ -40,13 +40,7 @@ public class KNNQueryBuilderProtoUtilsTests extends OpenSearchTestCase {
      * Test basic conversion with field, vector, and k.
      */
     public void testFromProto_BasicQuery() {
-        KnnQuery knnQuery = KnnQuery.newBuilder()
-            .setField("test_field")
-            .addVector(1.0f)
-            .addVector(2.0f)
-            .addVector(3.0f)
-            .setK(5)
-            .build();
+        KnnQuery knnQuery = KnnQuery.newBuilder().setField("test_field").addVector(1.0f).addVector(2.0f).addVector(3.0f).setK(5).build();
 
         QueryBuilder result = KNNQueryBuilderProtoUtils.fromProto(knnQuery, mockRegistry);
 
@@ -100,12 +94,7 @@ public class KNNQueryBuilderProtoUtilsTests extends OpenSearchTestCase {
      * Test conversion with maxDistance.
      */
     public void testFromProto_WithMaxDistance() {
-        KnnQuery knnQuery = KnnQuery.newBuilder()
-            .setField("test_field")
-            .addVector(1.0f)
-            .addVector(2.0f)
-            .setMaxDistance(0.5f)
-            .build();
+        KnnQuery knnQuery = KnnQuery.newBuilder().setField("test_field").addVector(1.0f).addVector(2.0f).setMaxDistance(0.5f).build();
 
         QueryBuilder result = KNNQueryBuilderProtoUtils.fromProto(knnQuery, mockRegistry);
 
@@ -118,12 +107,7 @@ public class KNNQueryBuilderProtoUtilsTests extends OpenSearchTestCase {
      * Test conversion with minScore.
      */
     public void testFromProto_WithMinScore() {
-        KnnQuery knnQuery = KnnQuery.newBuilder()
-            .setField("test_field")
-            .addVector(1.0f)
-            .addVector(2.0f)
-            .setMinScore(0.8f)
-            .build();
+        KnnQuery knnQuery = KnnQuery.newBuilder().setField("test_field").addVector(1.0f).addVector(2.0f).setMinScore(0.8f).build();
 
         QueryBuilder result = KNNQueryBuilderProtoUtils.fromProto(knnQuery, mockRegistry);
 
@@ -139,10 +123,7 @@ public class KNNQueryBuilderProtoUtilsTests extends OpenSearchTestCase {
         ObjectMap.Value efSearchValue = ObjectMap.Value.newBuilder().setInt32(100).build();
         ObjectMap.Value nprobesValue = ObjectMap.Value.newBuilder().setInt32(50).build();
 
-        ObjectMap methodParams = ObjectMap.newBuilder()
-            .putFields("ef_search", efSearchValue)
-            .putFields("nprobes", nprobesValue)
-            .build();
+        ObjectMap methodParams = ObjectMap.newBuilder().putFields("ef_search", efSearchValue).putFields("nprobes", nprobesValue).build();
 
         KnnQuery knnQuery = KnnQuery.newBuilder()
             .setField("test_field")
@@ -306,15 +287,9 @@ public class KNNQueryBuilderProtoUtilsTests extends OpenSearchTestCase {
      * Test error handling for missing field.
      */
     public void testFromProto_MissingField_ThrowsException() {
-        KnnQuery knnQuery = KnnQuery.newBuilder()
-            .addVector(1.0f)
-            .addVector(2.0f)
-            .setK(5)
-            .build();
+        KnnQuery knnQuery = KnnQuery.newBuilder().addVector(1.0f).addVector(2.0f).setK(5).build();
 
-        expectThrows(IllegalArgumentException.class, () -> {
-            KNNQueryBuilderProtoUtils.fromProto(knnQuery, mockRegistry);
-        });
+        expectThrows(IllegalArgumentException.class, () -> { KNNQueryBuilderProtoUtils.fromProto(knnQuery, mockRegistry); });
     }
 
     /**
@@ -323,8 +298,6 @@ public class KNNQueryBuilderProtoUtilsTests extends OpenSearchTestCase {
     public void testFromProto_EmptyVector_ThrowsException() {
         KnnQuery knnQuery = KnnQuery.newBuilder().setField("test_field").setK(5).build();
 
-        expectThrows(IllegalArgumentException.class, () -> {
-            KNNQueryBuilderProtoUtils.fromProto(knnQuery, mockRegistry);
-        });
+        expectThrows(IllegalArgumentException.class, () -> { KNNQueryBuilderProtoUtils.fromProto(knnQuery, mockRegistry); });
     }
 }

--- a/src/test/java/org/opensearch/knn/grpc/proto/request/search/query/KNNQueryBuilderProtoUtilsTests.java
+++ b/src/test/java/org/opensearch/knn/grpc/proto/request/search/query/KNNQueryBuilderProtoUtilsTests.java
@@ -1,0 +1,330 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.grpc.proto.request.search.query;
+
+import org.junit.Before;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.knn.index.query.KNNQueryBuilder;
+import org.opensearch.knn.index.query.rescore.RescoreContext;
+import org.opensearch.protobufs.KnnQuery;
+import org.opensearch.protobufs.KnnQueryRescore;
+import org.opensearch.protobufs.ObjectMap;
+import org.opensearch.protobufs.QueryContainer;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.grpc.spi.QueryBuilderProtoConverterRegistry;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for KNNQueryBuilderProtoUtils.
+ * Tests conversion from Protocol Buffer KnnQuery to KNNQueryBuilder.
+ */
+public class KNNQueryBuilderProtoUtilsTests extends OpenSearchTestCase {
+
+    private QueryBuilderProtoConverterRegistry mockRegistry;
+    private QueryBuilder mockQueryBuilder;
+
+    @Before
+    public void setup() {
+        mockRegistry = mock(QueryBuilderProtoConverterRegistry.class);
+        mockQueryBuilder = mock(QueryBuilder.class);
+    }
+
+    /**
+     * Test basic conversion with field, vector, and k.
+     */
+    public void testFromProto_BasicQuery() {
+        KnnQuery knnQuery = KnnQuery.newBuilder()
+            .setField("test_field")
+            .addVector(1.0f)
+            .addVector(2.0f)
+            .addVector(3.0f)
+            .setK(5)
+            .build();
+
+        QueryBuilder result = KNNQueryBuilderProtoUtils.fromProto(knnQuery, mockRegistry);
+
+        assertTrue(result instanceof KNNQueryBuilder);
+        KNNQueryBuilder knnQueryBuilder = (KNNQueryBuilder) result;
+        assertEquals("test_field", knnQueryBuilder.fieldName());
+        assertArrayEquals(new float[] { 1.0f, 2.0f, 3.0f }, (float[]) knnQueryBuilder.vector(), 0.001f);
+        assertEquals((Object) Integer.valueOf(5), (Object) knnQueryBuilder.getK());
+    }
+
+    /**
+     * Test conversion with boost.
+     */
+    public void testFromProto_WithBoost() {
+        KnnQuery knnQuery = KnnQuery.newBuilder()
+            .setField("test_field")
+            .addVector(1.0f)
+            .addVector(2.0f)
+            .addVector(3.0f)
+            .setK(5)
+            .setBoost(2.5f)
+            .build();
+
+        QueryBuilder result = KNNQueryBuilderProtoUtils.fromProto(knnQuery, mockRegistry);
+
+        assertTrue(result instanceof KNNQueryBuilder);
+        KNNQueryBuilder knnQueryBuilder = (KNNQueryBuilder) result;
+        assertEquals(2.5f, knnQueryBuilder.boost(), 0.001f);
+    }
+
+    /**
+     * Test conversion with query name.
+     */
+    public void testFromProto_WithQueryName() {
+        KnnQuery knnQuery = KnnQuery.newBuilder()
+            .setField("test_field")
+            .addVector(1.0f)
+            .addVector(2.0f)
+            .setK(5)
+            .setXName("my_knn_query")
+            .build();
+
+        QueryBuilder result = KNNQueryBuilderProtoUtils.fromProto(knnQuery, mockRegistry);
+
+        assertTrue(result instanceof KNNQueryBuilder);
+        KNNQueryBuilder knnQueryBuilder = (KNNQueryBuilder) result;
+        assertEquals("my_knn_query", knnQueryBuilder.queryName());
+    }
+
+    /**
+     * Test conversion with maxDistance.
+     */
+    public void testFromProto_WithMaxDistance() {
+        KnnQuery knnQuery = KnnQuery.newBuilder()
+            .setField("test_field")
+            .addVector(1.0f)
+            .addVector(2.0f)
+            .setMaxDistance(0.5f)
+            .build();
+
+        QueryBuilder result = KNNQueryBuilderProtoUtils.fromProto(knnQuery, mockRegistry);
+
+        assertTrue(result instanceof KNNQueryBuilder);
+        KNNQueryBuilder knnQueryBuilder = (KNNQueryBuilder) result;
+        assertEquals(0.5f, knnQueryBuilder.getMaxDistance(), 0.001f);
+    }
+
+    /**
+     * Test conversion with minScore.
+     */
+    public void testFromProto_WithMinScore() {
+        KnnQuery knnQuery = KnnQuery.newBuilder()
+            .setField("test_field")
+            .addVector(1.0f)
+            .addVector(2.0f)
+            .setMinScore(0.8f)
+            .build();
+
+        QueryBuilder result = KNNQueryBuilderProtoUtils.fromProto(knnQuery, mockRegistry);
+
+        assertTrue(result instanceof KNNQueryBuilder);
+        KNNQueryBuilder knnQueryBuilder = (KNNQueryBuilder) result;
+        assertEquals(0.8f, knnQueryBuilder.getMinScore(), 0.001f);
+    }
+
+    /**
+     * Test conversion with method parameters using ObjectMap.
+     */
+    public void testFromProto_WithMethodParameters() {
+        ObjectMap.Value efSearchValue = ObjectMap.Value.newBuilder().setInt32(100).build();
+        ObjectMap.Value nprobesValue = ObjectMap.Value.newBuilder().setInt32(50).build();
+
+        ObjectMap methodParams = ObjectMap.newBuilder()
+            .putFields("ef_search", efSearchValue)
+            .putFields("nprobes", nprobesValue)
+            .build();
+
+        KnnQuery knnQuery = KnnQuery.newBuilder()
+            .setField("test_field")
+            .addVector(1.0f)
+            .addVector(2.0f)
+            .setK(5)
+            .setMethodParameters(methodParams)
+            .build();
+
+        QueryBuilder result = KNNQueryBuilderProtoUtils.fromProto(knnQuery, mockRegistry);
+
+        assertTrue(result instanceof KNNQueryBuilder);
+        KNNQueryBuilder knnQueryBuilder = (KNNQueryBuilder) result;
+        assertNotNull(knnQueryBuilder.getMethodParameters());
+        assertEquals(100, knnQueryBuilder.getMethodParameters().get("ef_search"));
+        assertEquals(50, knnQueryBuilder.getMethodParameters().get("nprobes"));
+    }
+
+    /**
+     * Test ObjectMap value conversion for different types.
+     */
+    public void testConvertObjectMapValue_AllTypes() {
+        // Test int32
+        ObjectMap.Value int32Val = ObjectMap.Value.newBuilder().setInt32(42).build();
+        assertEquals(42, KNNQueryBuilderProtoUtils.convertObjectMapValue(int32Val));
+
+        // Test int64
+        ObjectMap.Value int64Val = ObjectMap.Value.newBuilder().setInt64(123456789L).build();
+        assertEquals(123456789L, KNNQueryBuilderProtoUtils.convertObjectMapValue(int64Val));
+
+        // Test float
+        ObjectMap.Value floatVal = ObjectMap.Value.newBuilder().setFloat(3.14f).build();
+        assertEquals(3.14f, (Float) KNNQueryBuilderProtoUtils.convertObjectMapValue(floatVal), 0.001f);
+
+        // Test double
+        ObjectMap.Value doubleVal = ObjectMap.Value.newBuilder().setDouble(2.718).build();
+        assertEquals(2.718, (Double) KNNQueryBuilderProtoUtils.convertObjectMapValue(doubleVal), 0.001);
+
+        // Test string
+        ObjectMap.Value stringVal = ObjectMap.Value.newBuilder().setString("test").build();
+        assertEquals("test", KNNQueryBuilderProtoUtils.convertObjectMapValue(stringVal));
+
+        // Test boolean
+        ObjectMap.Value boolVal = ObjectMap.Value.newBuilder().setBool(true).build();
+        assertEquals(true, KNNQueryBuilderProtoUtils.convertObjectMapValue(boolVal));
+    }
+
+    /**
+     * Test conversion with filter query.
+     */
+    public void testFromProto_WithFilter() {
+        QueryContainer filterContainer = QueryContainer.newBuilder().build();
+        TermQueryBuilder termQuery = new TermQueryBuilder("status", "active");
+
+        when(mockRegistry.fromProto(any(QueryContainer.class))).thenReturn(termQuery);
+
+        KnnQuery knnQuery = KnnQuery.newBuilder()
+            .setField("test_field")
+            .addVector(1.0f)
+            .addVector(2.0f)
+            .setK(5)
+            .setFilter(filterContainer)
+            .build();
+
+        QueryBuilder result = KNNQueryBuilderProtoUtils.fromProto(knnQuery, mockRegistry);
+
+        assertTrue(result instanceof KNNQueryBuilder);
+        KNNQueryBuilder knnQueryBuilder = (KNNQueryBuilder) result;
+        assertNotNull(knnQueryBuilder.getFilter());
+    }
+
+    /**
+     * Test conversion with rescore enabled.
+     */
+    public void testFromProto_WithRescoreEnabled() {
+        KnnQueryRescore rescore = KnnQueryRescore.newBuilder().setEnable(true).build();
+
+        KnnQuery knnQuery = KnnQuery.newBuilder()
+            .setField("test_field")
+            .addVector(1.0f)
+            .addVector(2.0f)
+            .setK(5)
+            .setRescore(rescore)
+            .build();
+
+        QueryBuilder result = KNNQueryBuilderProtoUtils.fromProto(knnQuery, mockRegistry);
+
+        assertTrue(result instanceof KNNQueryBuilder);
+        KNNQueryBuilder knnQueryBuilder = (KNNQueryBuilder) result;
+        assertNotNull(knnQueryBuilder.getRescoreContext());
+        assertEquals(RescoreContext.getDefault(), knnQueryBuilder.getRescoreContext());
+    }
+
+    /**
+     * Test conversion with rescore disabled.
+     */
+    public void testFromProto_WithRescoreDisabled() {
+        KnnQueryRescore rescore = KnnQueryRescore.newBuilder().setEnable(false).build();
+
+        KnnQuery knnQuery = KnnQuery.newBuilder()
+            .setField("test_field")
+            .addVector(1.0f)
+            .addVector(2.0f)
+            .setK(5)
+            .setRescore(rescore)
+            .build();
+
+        QueryBuilder result = KNNQueryBuilderProtoUtils.fromProto(knnQuery, mockRegistry);
+
+        assertTrue(result instanceof KNNQueryBuilder);
+        KNNQueryBuilder knnQueryBuilder = (KNNQueryBuilder) result;
+        assertEquals(RescoreContext.EXPLICITLY_DISABLED_RESCORE_CONTEXT, knnQueryBuilder.getRescoreContext());
+    }
+
+    /**
+     * Test conversion with rescore context (oversample factor).
+     */
+    public void testFromProto_WithRescoreContext() {
+        org.opensearch.protobufs.RescoreContext rescoreCtx = org.opensearch.protobufs.RescoreContext.newBuilder()
+            .setOversampleFactor(2.0f)
+            .build();
+
+        KnnQueryRescore rescore = KnnQueryRescore.newBuilder().setContext(rescoreCtx).build();
+
+        KnnQuery knnQuery = KnnQuery.newBuilder()
+            .setField("test_field")
+            .addVector(1.0f)
+            .addVector(2.0f)
+            .setK(5)
+            .setRescore(rescore)
+            .build();
+
+        QueryBuilder result = KNNQueryBuilderProtoUtils.fromProto(knnQuery, mockRegistry);
+
+        assertTrue(result instanceof KNNQueryBuilder);
+        KNNQueryBuilder knnQueryBuilder = (KNNQueryBuilder) result;
+        assertNotNull(knnQueryBuilder.getRescoreContext());
+        assertEquals(2.0f, knnQueryBuilder.getRescoreContext().getOversampleFactor(), 0.001f);
+    }
+
+    /**
+     * Test conversion with expandNested.
+     */
+    public void testFromProto_WithExpandNested() {
+        KnnQuery knnQuery = KnnQuery.newBuilder()
+            .setField("test_field")
+            .addVector(1.0f)
+            .addVector(2.0f)
+            .setK(5)
+            .setExpandNestedDocs(true)
+            .build();
+
+        QueryBuilder result = KNNQueryBuilderProtoUtils.fromProto(knnQuery, mockRegistry);
+
+        assertTrue(result instanceof KNNQueryBuilder);
+        KNNQueryBuilder knnQueryBuilder = (KNNQueryBuilder) result;
+        assertTrue(knnQueryBuilder.getExpandNested());
+    }
+
+    /**
+     * Test error handling for missing field.
+     */
+    public void testFromProto_MissingField_ThrowsException() {
+        KnnQuery knnQuery = KnnQuery.newBuilder()
+            .addVector(1.0f)
+            .addVector(2.0f)
+            .setK(5)
+            .build();
+
+        expectThrows(IllegalArgumentException.class, () -> {
+            KNNQueryBuilderProtoUtils.fromProto(knnQuery, mockRegistry);
+        });
+    }
+
+    /**
+     * Test error handling for empty vector.
+     */
+    public void testFromProto_EmptyVector_ThrowsException() {
+        KnnQuery knnQuery = KnnQuery.newBuilder().setField("test_field").setK(5).build();
+
+        expectThrows(IllegalArgumentException.class, () -> {
+            KNNQueryBuilderProtoUtils.fromProto(knnQuery, mockRegistry);
+        });
+    }
+}


### PR DESCRIPTION
### Description
Add gRPC Protocol Buffer support for KNN queries

### Related Issues
Resolves #391 
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
