### PR TITLE
Add support for MAXIMUM_INNER_PRODUCT similarity in jVector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 * Add gRPC Protocol Buffer support for KNN queries [391](https://github.com/opensearch-project/opensearch-jvector/issues/391)
 * Support derived source for knn with other fields [474] (https://github.com/opensearch-project/opensearch-jvector/pull/488)
+* Add support for MAXIMUM_INNER_PRODUCT similarity function in jVector engine ([#206](https://github.com/opensearch-project/opensearch-jvector/pull/494))
 ### Enhancements
 ### Bug Fixes
 - Fix derived nested fields processing [484] (https://github.com/opensearch-project/opensearch-jvector/pull/484)

--- a/docs/user_guide_m.md
+++ b/docs/user_guide_m.md
@@ -383,6 +383,7 @@ JVector supports the following distance metrics:
 |------------|-------------|----------|
 | `l2` | Euclidean distance (L2 norm) | General purpose, geometric similarity |
 | `cosinesimil` | Cosine similarity | Text embeddings, normalized vectors |
+| `innerproduct` | Dot product (inner product) | Embeddings where magnitude carries meaning (e.g., biencoder models) |
 
 
 **Example with cosine similarity:**
@@ -413,6 +414,37 @@ curl -X PUT "https://localhost:9200/text-embeddings" -H 'Content-Type: applicati
 }
 '
 ```
+
+**Example with inner product:**
+
+```bash
+curl -X PUT "https://localhost:9200/biencoder-embeddings" -H 'Content-Type: application/json' -d'
+{
+  "settings": {
+    "index.knn": true
+  },
+  "mappings": {
+    "properties": {
+      "embedding": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "method": {
+          "name": "disk_ann",
+          "engine": "jvector",
+          "space_type": "innerproduct",
+          "parameters": {
+            "m": 16,
+            "ef_construction": 100
+          }
+        }
+      }
+    }
+  }
+}
+'
+```
+
+Inner product (dot product) is useful for embeddings where the magnitude carries semantic meaning, such as those from biencoder models. Unlike cosine similarity which normalizes vectors, inner product preserves magnitude information, making it suitable for scenarios where vector length is meaningful.
 
 #### Quantization Options
 

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFloatVectorValues.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFloatVectorValues.java
@@ -11,10 +11,9 @@ import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import java.io.IOException;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.search.VectorScorer;
-
-import java.io.IOException;
 
 public class JVectorFloatVectorValues extends FloatVectorValues {
     public static final int NO_VECTOR = -1;
@@ -22,6 +21,7 @@ public class JVectorFloatVectorValues extends FloatVectorValues {
 
     private final OnDiskGraphIndex.View view;
     private final VectorSimilarityFunction similarityFunction;
+    private final org.apache.lucene.index.VectorSimilarityFunction luceneSimilarityFunction;
     private final int dimension;
     private final int size;
     private final GraphNodeIdToDocMap graphNodeIdToDocMap;
@@ -29,12 +29,14 @@ public class JVectorFloatVectorValues extends FloatVectorValues {
     public JVectorFloatVectorValues(
         OnDiskGraphIndex onDiskGraphIndex,
         VectorSimilarityFunction similarityFunction,
+        org.apache.lucene.index.VectorSimilarityFunction luceneSimilarityFunction,
         GraphNodeIdToDocMap graphNodeIdToDocMap
     ) throws IOException {
         this.view = onDiskGraphIndex.getView();
         this.dimension = view.dimension();
         this.size = view.size();
         this.similarityFunction = similarityFunction;
+        this.luceneSimilarityFunction = luceneSimilarityFunction;
         this.graphNodeIdToDocMap = graphNodeIdToDocMap;
     }
 
@@ -164,7 +166,7 @@ public class JVectorFloatVectorValues extends FloatVectorValues {
 
     @Override
     public VectorScorer scorer(float[] query) throws IOException {
-        return new JVectorVectorScorer(this, VECTOR_TYPE_SUPPORT.createFloatVector(query), similarityFunction);
+        return new JVectorVectorScorer(this, VECTOR_TYPE_SUPPORT.createFloatVector(query), similarityFunction, luceneSimilarityFunction);
     }
 
 }

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
@@ -165,10 +165,7 @@ public class JVectorReader extends KnnVectorsReader {
                 final PQVectors pqVectors = fieldEntryMap.get(field).pqVectors;
                 // SearchScoreProvider that does a first pass with the loaded-in-memory PQVectors,
                 // then reranks with the exact vectors that are stored on disk in the index
-                ScoreFunction.ApproximateScoreFunction asf = pqVectors.precomputedScoreFunctionFor(
-                    q,
-                    vectorSimilarityFunction
-                );
+                ScoreFunction.ApproximateScoreFunction asf = pqVectors.precomputedScoreFunctionFor(q, vectorSimilarityFunction);
                 ScoreFunction.ExactScoreFunction reranker = wrapExactScoreFunction(
                     view.rerankerFor(q, vectorSimilarityFunction),
                     luceneSimilarityFunction,
@@ -176,7 +173,8 @@ public class JVectorReader extends KnnVectorsReader {
                 );
                 ssp = new DefaultSearchScoreProvider(asf, reranker);
             } else { // Not quantized, used typical searcher
-                ScoreFunction.ExactScoreFunction esf = DefaultSearchScoreProvider.exact(q, vectorSimilarityFunction, view).exactScoreFunction();
+                ScoreFunction.ExactScoreFunction esf = DefaultSearchScoreProvider.exact(q, vectorSimilarityFunction, view)
+                    .exactScoreFunction();
                 ssp = new DefaultSearchScoreProvider(wrapExactScoreFunction(esf, luceneSimilarityFunction, vectorSimilarityFunction));
             }
             final GraphNodeIdToDocMap jvectorLuceneDocMap = fieldEntryMap.get(field).graphNodeIdToDocMap;

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
@@ -15,9 +15,16 @@ import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
 import io.github.jbellis.jvector.graph.similarity.SearchScoreProvider;
 import io.github.jbellis.jvector.quantization.PQVectors;
 import io.github.jbellis.jvector.quantization.ProductQuantization;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.KnnVectorsReader;
@@ -27,17 +34,8 @@ import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.store.*;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.IOUtils;
-import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.plugin.stats.KNNCounter;
-
-import java.io.Closeable;
-import java.io.IOException;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 @Log4j2
 public class JVectorReader extends KnnVectorsReader {
@@ -99,7 +97,12 @@ public class JVectorReader extends KnnVectorsReader {
     @Override
     public FloatVectorValues getFloatVectorValues(String field) throws IOException {
         final FieldEntry fieldEntry = fieldEntryMap.get(field);
-        return new JVectorFloatVectorValues(fieldEntry.index, fieldEntry.similarityFunction, fieldEntry.graphNodeIdToDocMap);
+        return new JVectorFloatVectorValues(
+            fieldEntry.index,
+            fieldEntry.similarityFunction,
+            fieldEntry.fieldInfo.getVectorSimilarityFunction(),
+            fieldEntry.graphNodeIdToDocMap
+        );
     }
 
     @Override
@@ -186,8 +189,22 @@ public class JVectorReader extends KnnVectorsReader {
                     jvectorKnnCollector.getRerankFloor(),
                     compatibleBits
                 );
+
+                // Get the Lucene similarity function to check if we need to transform scores
+                final FieldEntry fieldEntry = fieldEntryMap.get(field);
+                final org.apache.lucene.index.VectorSimilarityFunction luceneSimilarityFunction = fieldEntry.fieldInfo
+                    .getVectorSimilarityFunction();
+
                 for (SearchResult.NodeScore ns : searchResults.getNodes()) {
-                    jvectorKnnCollector.collect(jvectorLuceneDocMap.getLuceneDocId(ns.node), ns.score);
+                    float score = ns.score;
+                    // Lucene's MAXIMUM_INNER_PRODUCT formula is: 1 + dotProduct
+                    // jVector's DOT_PRODUCT returns: (1 + dotProduct) / 2
+                    // To convert: score * 2 = (1 + dotProduct) / 2 * 2 = 1 + dotProduct
+                    if (luceneSimilarityFunction == org.apache.lucene.index.VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT
+                        && fieldEntry.similarityFunction == VectorSimilarityFunction.DOT_PRODUCT) {
+                        score = score * 2.0f;
+                    }
+                    jvectorKnnCollector.collect(jvectorLuceneDocMap.getLuceneDocId(ns.node), score);
                 }
                 final long graphSearchEnd = System.currentTimeMillis();
                 final long searchTime = graphSearchEnd - graphSearchStart;
@@ -353,7 +370,8 @@ public class JVectorReader extends KnnVectorsReader {
         public static final List<VectorSimilarityFunction> JVECTOR_SUPPORTED_SIMILARITY_FUNCTIONS = List.of(
             VectorSimilarityFunction.EUCLIDEAN,
             VectorSimilarityFunction.DOT_PRODUCT,
-            VectorSimilarityFunction.COSINE
+            VectorSimilarityFunction.COSINE,
+            VectorSimilarityFunction.DOT_PRODUCT
         );
 
         public static final Map<org.apache.lucene.index.VectorSimilarityFunction, VectorSimilarityFunction> LUCENE_TO_JVECTOR_MAP = Map.of(
@@ -362,7 +380,9 @@ public class JVectorReader extends KnnVectorsReader {
             org.apache.lucene.index.VectorSimilarityFunction.DOT_PRODUCT,
             VectorSimilarityFunction.DOT_PRODUCT,
             org.apache.lucene.index.VectorSimilarityFunction.COSINE,
-            VectorSimilarityFunction.COSINE
+            VectorSimilarityFunction.COSINE,
+            org.apache.lucene.index.VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT,
+            VectorSimilarityFunction.DOT_PRODUCT
         );
 
         public static int distFuncToOrd(org.apache.lucene.index.VectorSimilarityFunction func) {

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
@@ -153,6 +153,12 @@ public class JVectorReader extends KnnVectorsReader {
         VectorFloat<?> q = VECTOR_TYPE_SUPPORT.createFloatVector(target);
         final SearchScoreProvider ssp;
 
+        // Get the Lucene similarity function to check if we need to transform scores
+        final FieldEntry fieldEntry = fieldEntryMap.get(field);
+        final org.apache.lucene.index.VectorSimilarityFunction luceneSimilarityFunction = fieldEntry.fieldInfo
+            .getVectorSimilarityFunction();
+        final VectorSimilarityFunction vectorSimilarityFunction = fieldEntry.similarityFunction;
+
         try (var view = index.getView()) {
             final long graphSearchStart = System.currentTimeMillis();
             if (fieldEntryMap.get(field).pqVectors != null) { // Quantized, use the precomputed score function
@@ -161,12 +167,17 @@ public class JVectorReader extends KnnVectorsReader {
                 // then reranks with the exact vectors that are stored on disk in the index
                 ScoreFunction.ApproximateScoreFunction asf = pqVectors.precomputedScoreFunctionFor(
                     q,
-                    fieldEntryMap.get(field).similarityFunction
+                    vectorSimilarityFunction
                 );
-                ScoreFunction.ExactScoreFunction reranker = view.rerankerFor(q, fieldEntryMap.get(field).similarityFunction);
+                ScoreFunction.ExactScoreFunction reranker = wrapExactScoreFunction(
+                    view.rerankerFor(q, vectorSimilarityFunction),
+                    luceneSimilarityFunction,
+                    vectorSimilarityFunction
+                );
                 ssp = new DefaultSearchScoreProvider(asf, reranker);
             } else { // Not quantized, used typical searcher
-                ssp = DefaultSearchScoreProvider.exact(q, fieldEntryMap.get(field).similarityFunction, view);
+                ScoreFunction.ExactScoreFunction esf = DefaultSearchScoreProvider.exact(q, vectorSimilarityFunction, view).exactScoreFunction();
+                ssp = new DefaultSearchScoreProvider(wrapExactScoreFunction(esf, luceneSimilarityFunction, vectorSimilarityFunction));
             }
             final GraphNodeIdToDocMap jvectorLuceneDocMap = fieldEntryMap.get(field).graphNodeIdToDocMap;
             // Convert the acceptDocs bitmap from Lucene to jVector ordinal bitmap filter
@@ -190,21 +201,8 @@ public class JVectorReader extends KnnVectorsReader {
                     compatibleBits
                 );
 
-                // Get the Lucene similarity function to check if we need to transform scores
-                final FieldEntry fieldEntry = fieldEntryMap.get(field);
-                final org.apache.lucene.index.VectorSimilarityFunction luceneSimilarityFunction = fieldEntry.fieldInfo
-                    .getVectorSimilarityFunction();
-
                 for (SearchResult.NodeScore ns : searchResults.getNodes()) {
-                    float score = ns.score;
-                    // Lucene's MAXIMUM_INNER_PRODUCT formula is: 1 + dotProduct
-                    // jVector's DOT_PRODUCT returns: (1 + dotProduct) / 2
-                    // To convert: score * 2 = (1 + dotProduct) / 2 * 2 = 1 + dotProduct
-                    if (luceneSimilarityFunction == org.apache.lucene.index.VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT
-                        && fieldEntry.similarityFunction == VectorSimilarityFunction.DOT_PRODUCT) {
-                        score = score * 2.0f;
-                    }
-                    jvectorKnnCollector.collect(jvectorLuceneDocMap.getLuceneDocId(ns.node), score);
+                    jvectorKnnCollector.collect(jvectorLuceneDocMap.getLuceneDocId(ns.node), ns.score);
                 }
                 final long graphSearchEnd = System.currentTimeMillis();
                 final long searchTime = graphSearchEnd - graphSearchStart;
@@ -237,6 +235,35 @@ public class JVectorReader extends KnnVectorsReader {
                     jvectorKnnCollector.incVisitedCount(visitedCount);
                 }
             }
+        }
+    }
+
+    /**
+     * Wraps an ExactScoreFunction to handle score transformation between jVector and Lucene similarity functions for innerproduct.
+     *
+     * @param delegate the base ExactScoreFunction to wrap
+     * @param luceneSimilarityFunction the Lucene similarity function
+     * @param jvectorSimilarityFunction the jVector similarity function
+     * @return a wrapped ExactScoreFunction that applies score transformation if needed
+     */
+    private static ScoreFunction.ExactScoreFunction wrapExactScoreFunction(
+        ScoreFunction.ExactScoreFunction delegate,
+        org.apache.lucene.index.VectorSimilarityFunction luceneSimilarityFunction,
+        VectorSimilarityFunction jvectorSimilarityFunction
+    ) {
+        // Lucene's MAXIMUM_INNER_PRODUCT formula is: 1 + dotProduct
+        // jVector's DOT_PRODUCT returns: (1 + dotProduct) / 2
+        // To convert: score * 2 = (1 + dotProduct) / 2 * 2 = 1 + dotProduct
+        if (luceneSimilarityFunction == org.apache.lucene.index.VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT
+            && jvectorSimilarityFunction == VectorSimilarityFunction.DOT_PRODUCT) {
+            return new ScoreFunction.ExactScoreFunction() {
+                @Override
+                public float similarityTo(int node2) {
+                    return delegate.similarityTo(node2) * 2.0f;
+                }
+            };
+        } else {
+            return delegate;
         }
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorVectorScorer.java
@@ -38,7 +38,18 @@ public class JVectorVectorScorer implements VectorScorer {
         if (index == GraphNodeIdToDocMap.NO_VECTOR_OR_DELETED_DOC) {
             return 0.0f;
         }
-        return similarityFunction.compare(target, floatVectorValues.vectorFloatValue(index));
+        float score = similarityFunction.compare(target, floatVectorValues.vectorFloatValue(index));
+
+        // Apply score transformation for MAXIMUM_INNER_PRODUCT
+        // Lucene's MAXIMUM_INNER_PRODUCT formula is: 1 + dotProduct
+        // jVector's DOT_PRODUCT returns: (1 + dotProduct) / 2
+        // To convert: score * 2 = (1 + dotProduct) / 2 * 2 = 1 + dotProduct
+        if (luceneSimilarityFunction == org.apache.lucene.index.VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT
+            && similarityFunction == VectorSimilarityFunction.DOT_PRODUCT) {
+            return score * 2.0f;
+        }
+
+        return score;
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorVectorScorer.java
@@ -7,23 +7,29 @@ package org.opensearch.knn.index.codec.jvector;
 
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
+import java.io.IOException;
 import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.VectorScorer;
-
-import java.io.IOException;
 
 public class JVectorVectorScorer implements VectorScorer {
     private final JVectorFloatVectorValues floatVectorValues;
     private final KnnVectorValues.DocIndexIterator docIndexIterator;
     private final VectorFloat<?> target;
     private final VectorSimilarityFunction similarityFunction;
+    private final org.apache.lucene.index.VectorSimilarityFunction luceneSimilarityFunction;
 
-    public JVectorVectorScorer(JVectorFloatVectorValues vectorValues, VectorFloat<?> target, VectorSimilarityFunction similarityFunction) {
+    public JVectorVectorScorer(
+        JVectorFloatVectorValues vectorValues,
+        VectorFloat<?> target,
+        VectorSimilarityFunction similarityFunction,
+        org.apache.lucene.index.VectorSimilarityFunction luceneSimilarityFunction
+    ) {
         this.floatVectorValues = vectorValues;
         this.docIndexIterator = floatVectorValues.iterator();
         this.target = target;
         this.similarityFunction = similarityFunction;
+        this.luceneSimilarityFunction = luceneSimilarityFunction;
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorVectorScorer.java
@@ -18,12 +18,19 @@ public class JVectorVectorScorer implements VectorScorer {
     private final KnnVectorValues.DocIndexIterator docIndexIterator;
     private final VectorFloat<?> target;
     private final VectorSimilarityFunction similarityFunction;
+    private final org.apache.lucene.index.VectorSimilarityFunction luceneSimilarityFunction;
 
-    public JVectorVectorScorer(JVectorFloatVectorValues vectorValues, VectorFloat<?> target, VectorSimilarityFunction similarityFunction) {
+    public JVectorVectorScorer(
+        JVectorFloatVectorValues vectorValues,
+        VectorFloat<?> target,
+        VectorSimilarityFunction similarityFunction,
+        org.apache.lucene.index.VectorSimilarityFunction luceneSimilarityFunction
+    ) {
         this.floatVectorValues = vectorValues;
         this.docIndexIterator = floatVectorValues.iterator();
         this.target = target;
         this.similarityFunction = similarityFunction;
+        this.luceneSimilarityFunction = luceneSimilarityFunction;
     }
 
     @Override
@@ -32,7 +39,18 @@ public class JVectorVectorScorer implements VectorScorer {
         if (index == GraphNodeIdToDocMap.NO_VECTOR_OR_DELETED_DOC) {
             return 0.0f;
         }
-        return similarityFunction.compare(target, floatVectorValues.vectorFloatValue(index));
+
+        float rawScore = similarityFunction.compare(target, floatVectorValues.vectorFloatValue(index));
+
+        // Lucene's MAXIMUM_INNER_PRODUCT formula is: 1 + dotProduct
+        // jVector's DOT_PRODUCT returns: (1 + dotProduct) / 2
+        // To convert: score * 2 = (1 + dotProduct) / 2 * 2 = 1 + dotProduct
+        if (luceneSimilarityFunction == org.apache.lucene.index.VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT
+            && similarityFunction == VectorSimilarityFunction.DOT_PRODUCT) {
+            rawScore = rawScore * 2.0f;
+        }
+
+        return rawScore;
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -565,7 +565,7 @@ public class JVectorWriter extends KnnVectorsWriter {
         return switch (fieldInfo.getVectorSimilarityFunction()) {
             case EUCLIDEAN -> io.github.jbellis.jvector.vector.VectorSimilarityFunction.EUCLIDEAN;
             case COSINE -> io.github.jbellis.jvector.vector.VectorSimilarityFunction.COSINE;
-            case DOT_PRODUCT -> io.github.jbellis.jvector.vector.VectorSimilarityFunction.DOT_PRODUCT;
+            case DOT_PRODUCT, MAXIMUM_INNER_PRODUCT -> io.github.jbellis.jvector.vector.VectorSimilarityFunction.DOT_PRODUCT;
             default -> throw new IllegalArgumentException("Unsupported similarity function: " + fieldInfo.getVectorSimilarityFunction());
         };
     }

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
@@ -6,6 +6,12 @@
 package org.opensearch.knn.index.codec.jvector;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.document.*;
 import org.apache.lucene.index.*;
@@ -20,19 +26,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.opensearch.knn.TestUtils;
 import org.opensearch.knn.common.KNNConstants;
-import org.opensearch.knn.index.ThreadLeakFiltersForTests;
-import org.opensearch.knn.plugin.stats.KNNCounter;
-
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.*;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import static org.opensearch.knn.common.KNNConstants.DEFAULT_LEADING_SEGMENT_MERGE_DISABLED;
 import static org.opensearch.knn.common.KNNConstants.DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION;
+import org.opensearch.knn.index.ThreadLeakFiltersForTests;
 import static org.opensearch.knn.index.engine.CommonTestUtils.getCodec;
+import org.opensearch.knn.plugin.stats.KNNCounter;
 
 /**
  * Test used specifically for JVector
@@ -189,6 +187,76 @@ public class KNNJVectorTests extends LuceneTestCase {
                 assertEquals(2, topDocs.scoreDocs[2].doc);
                 Assert.assertEquals(
                     VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT.compare(target, new float[] { 1.0f / 3.0f, 0.0f }),
+                    topDocs.scoreDocs[2].score,
+                    0.001f
+                );
+                log.info("successfully completed search tests with MAXIMUM_INNER_PRODUCT");
+            }
+        }
+        log.info("successfully closed directory");
+    }
+
+    /**
+     * Test to verify that the JVector codec is able to successfully search for the nearest neighbours
+     * using Maximum Inner Product (DOT_PRODUCT) similarity function and filtering.
+     * Single field is used to store the vectors.
+     * All the documents are stored in a single segment.
+     * Single commit without refreshing the index.
+     * No merge.
+     */
+    @Test
+    public void testJVectorKnnIndex_filter_maxInnerProduct() throws IOException {
+        int k = 3; // The number of nearest neighbors to gather
+        int totalNumberOfDocs = 10;
+        IndexWriterConfig indexWriterConfig = LuceneTestCase.newIndexWriterConfig();
+        indexWriterConfig.setUseCompoundFile(false);
+        indexWriterConfig.setCodec(getCodec());
+        indexWriterConfig.setMergePolicy(new ForceMergesOnlyMergePolicy());
+        final Path indexPath = createTempDir();
+        log.info("Index path: {}", indexPath);
+        try (FSDirectory dir = FSDirectory.open(indexPath); IndexWriter w = new IndexWriter(dir, indexWriterConfig)) {
+            final float[] target = new float[] { 1.0f, 0.0f };
+            for (int i = 1; i < totalNumberOfDocs + 1; i++) {
+                final float[] source = new float[] { 1.0f / i, 0.0f };
+                final Document doc = new Document();
+                doc.add(new StringField("filter_field", i % 2 == 0 ? "even" : "odd", Field.Store.YES));
+                doc.add(new KnnFloatVectorField("test_field", source, VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT));
+                w.addDocument(doc);
+            }
+            log.info("Flushing docs to make them discoverable on the file system");
+            w.commit();
+
+            try (IndexReader reader = DirectoryReader.open(w)) {
+                log.info("We should now have a single segment with 10 documents");
+                Assert.assertEquals(1, reader.getContext().leaves().size());
+                Assert.assertEquals(totalNumberOfDocs, reader.numDocs());
+
+                final Query filterQuery = new TermQuery(new Term("filter_field", "even"));
+                final IndexSearcher searcher = newSearcher(reader);
+                KnnFloatVectorQuery knnFloatVectorQuery = getJVectorKnnFloatVectorQuery("test_field", target, k, filterQuery);
+                TopDocs topDocs = searcher.search(knnFloatVectorQuery, k);
+                assertEquals(k, topDocs.totalHits.value());
+                // With MAXIMUM_INNER_PRODUCT, higher dot product means more similar
+                // target = [1.0, 0.0], source = [1.0/i, 0.0]
+                // dot product = 1.0 * (1.0/i) + 0.0 * 0.0 = 1.0/i
+                // So doc 0 (i=1) has highest score (1.0), doc 1 (i=2) has 0.5, doc 2 (i=3) has 0.333...
+                // However, in this case we are filtering out odd docs, so we expect doc 1 (i=2) to have the
+                // highest score, followed by doc 3 (i=4), etc.
+                assertEquals(1, topDocs.scoreDocs[0].doc);
+                Assert.assertEquals(
+                    VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT.compare(target, new float[] { 1.0f / 2.0f, 0.0f }),
+                    topDocs.scoreDocs[0].score,
+                    0.001f
+                );
+                assertEquals(3, topDocs.scoreDocs[1].doc);
+                Assert.assertEquals(
+                    VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT.compare(target, new float[] { 1.0f / 4.0f, 0.0f }),
+                    topDocs.scoreDocs[1].score,
+                    0.001f
+                );
+                assertEquals(5, topDocs.scoreDocs[2].doc);
+                Assert.assertEquals(
+                    VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT.compare(target, new float[] { 1.0f / 6.0f, 0.0f }),
                     topDocs.scoreDocs[2].score,
                     0.001f
                 );

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
@@ -132,8 +132,76 @@ public class KNNJVectorTests extends LuceneTestCase {
     }
 
     /**
+     * Test to verify that the JVector codec is able to successfully search for the nearest neighbours
+     * using Maximum Inner Product (DOT_PRODUCT) similarity function.
+     * Single field is used to store the vectors.
+     * All the documents are stored in a single segment.
+     * Single commit without refreshing the index.
+     * No merge.
+     */
+    @Test
+    public void testJVectorKnnIndex_simpleCase_maxInnerProduct() throws IOException {
+        int k = 3; // The number of nearest neighbors to gather
+        int totalNumberOfDocs = 10;
+        IndexWriterConfig indexWriterConfig = LuceneTestCase.newIndexWriterConfig();
+        indexWriterConfig.setUseCompoundFile(false);
+        indexWriterConfig.setCodec(getCodec());
+        indexWriterConfig.setMergePolicy(new ForceMergesOnlyMergePolicy());
+        final Path indexPath = createTempDir();
+        log.info("Index path: {}", indexPath);
+        try (FSDirectory dir = FSDirectory.open(indexPath); IndexWriter w = new IndexWriter(dir, indexWriterConfig)) {
+            final float[] target = new float[] { 1.0f, 0.0f };
+            for (int i = 1; i < totalNumberOfDocs + 1; i++) {
+                final float[] source = new float[] { 1.0f / i, 0.0f };
+                final Document doc = new Document();
+                doc.add(new KnnFloatVectorField("test_field", source, VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT));
+                w.addDocument(doc);
+            }
+            log.info("Flushing docs to make them discoverable on the file system");
+            w.commit();
+
+            try (IndexReader reader = DirectoryReader.open(w)) {
+                log.info("We should now have a single segment with 10 documents");
+                Assert.assertEquals(1, reader.getContext().leaves().size());
+                Assert.assertEquals(totalNumberOfDocs, reader.numDocs());
+
+                final Query filterQuery = new MatchAllDocsQuery();
+                final IndexSearcher searcher = newSearcher(reader);
+                KnnFloatVectorQuery knnFloatVectorQuery = getJVectorKnnFloatVectorQuery("test_field", target, k, filterQuery);
+                TopDocs topDocs = searcher.search(knnFloatVectorQuery, k);
+                assertEquals(k, topDocs.totalHits.value());
+                // With MAXIMUM_INNER_PRODUCT, higher dot product means more similar
+                // target = [1.0, 0.0], source = [1.0/i, 0.0]
+                // dot product = 1.0 * (1.0/i) + 0.0 * 0.0 = 1.0/i
+                // So doc 0 (i=1) has highest score (1.0), doc 1 (i=2) has 0.5, doc 2 (i=3) has 0.333...
+                assertEquals(0, topDocs.scoreDocs[0].doc);
+                Assert.assertEquals(
+                    VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT.compare(target, new float[] { 1.0f, 0.0f }),
+                    topDocs.scoreDocs[0].score,
+                    0.001f
+                );
+                assertEquals(1, topDocs.scoreDocs[1].doc);
+                Assert.assertEquals(
+                    VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT.compare(target, new float[] { 1.0f / 2.0f, 0.0f }),
+                    topDocs.scoreDocs[1].score,
+                    0.001f
+                );
+                assertEquals(2, topDocs.scoreDocs[2].doc);
+                Assert.assertEquals(
+                    VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT.compare(target, new float[] { 1.0f / 3.0f, 0.0f }),
+                    topDocs.scoreDocs[2].score,
+                    0.001f
+                );
+                log.info("successfully completed search tests with MAXIMUM_INNER_PRODUCT");
+            }
+        }
+        log.info("successfully closed directory");
+    }
+
+    /**
      * Test the scenario when not all documents are populated with the vector field
      */
+    @Test
     public void testMissing_fields() throws IOException {
         final int k = 3; // The number of nearest neighbors to gather
         final int totalNumberOfDocs = 10;

--- a/src/test/java/org/opensearch/knn/index/engine/JVectorEngineIT.java
+++ b/src/test/java/org/opensearch/knn/index/engine/JVectorEngineIT.java
@@ -5,35 +5,32 @@
 
 package org.opensearch.knn.index.engine;
 
-import org.opensearch.client.*;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.junit.After;
+import org.opensearch.client.*;
 import org.opensearch.common.settings.Settings;
+import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
 import org.opensearch.core.xcontent.XContentBuilder;
+import static org.opensearch.index.engine.EngineConfig.INDEX_USE_COMPOUND_FILE;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.TestUtils;
 import org.opensearch.knn.common.KNNConstants;
+import static org.opensearch.knn.common.KNNConstants.*;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
-import org.opensearch.knn.index.query.KNNQueryBuilder;
-
-import java.io.IOException;
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.opensearch.index.engine.EngineConfig.INDEX_USE_COMPOUND_FILE;
-import static org.opensearch.knn.common.KNNConstants.*;
 import static org.opensearch.knn.index.engine.CommonTestUtils.*;
+import org.opensearch.knn.index.query.KNNQueryBuilder;
 
 public class JVectorEngineIT extends KNNRestTestCase {
 
@@ -48,6 +45,10 @@ public class JVectorEngineIT extends KNNRestTestCase {
 
     public void testQuery_cosine() throws Exception {
         baseQueryTest(SpaceType.COSINESIMIL);
+    }
+
+    public void testQuery_innerProduct() throws Exception {
+        baseQueryTest(SpaceType.INNER_PRODUCT);
     }
 
     public void testQuery_invalidVectorDimensionInQuery() throws Exception {


### PR DESCRIPTION
This commit adds support for Lucene's MAXIMUM_INNER_PRODUCT similarity function in jVector integration by transforming scores appropriately.

### Description
Adds support for `innerproduct` space type for jvector engine. 
### Related Issues
Resolves #206 
https://github.com/opensearch-project/opensearch-jvector/issues/206

Key thing to point out is we need to transform the dot product score in line for this specific case in order to be consistent with the Lucene implementation, since Lucene doesn't divide by 2, see (https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java#L394), whereas jvector does (https://github.com/datastax/jvector/blob/main/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorSimilarityFunction.java). 

### Check List
- [X] New functionality includes testing.
- N/A New functionality has been documented.
- N/A API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

### Testing
Wrote simple unit test, also did testing for recall by downloading a dataset following the tutorial from the jvector repo (https://github.com/datastax/jvector/blob/main/docs/tutorials/2-disk-tutorial.md), and tested recall on that dataset. 