### PR TITLE
[Backport] [3.6] Update Spotless to 8.4.0 (#495)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Bug Fixes
 - Fix derived nested fields processing [484] (https://github.com/opensearch-project/opensearch-jvector/pull/484)
 ### Infrastructure
+* Update Spotless to 8.4.0 [495](https://github.com/opensearch-project/opensearch-jvector/pull/495)
 ### Documentation
 ### Maintenance
 * Fix String.format() uses the default system locale [465](https://github.com/opensearch-project/opensearch-jvector/pull/465)

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ plugins {
     id 'java-test-fixtures'
     id 'idea'
     id 'eclipse'
-    id "com.diffplug.spotless" version "6.25.0" apply false
+    id "com.diffplug.spotless" version "8.4.0" apply false
     id 'io.freefair.lombok' version '8.14'
     id "de.undercouch.download" version "5.3.0"
     id "me.champeau.jmh" version "0.7.1"

--- a/src/test/java/org/opensearch/knn/search/processor/mmr/MMRKnnQueryTransformerTests.java
+++ b/src/test/java/org/opensearch/knn/search/processor/mmr/MMRKnnQueryTransformerTests.java
@@ -193,7 +193,11 @@ public class MMRKnnQueryTransformerTests extends MMRTestCase {
 
         transformer.transform(queryBuilder, listener, transformContext);
 
-        verifyException(listener, IllegalArgumentException.class, "Failed to transform the knn query for MMR. Field name of the knn query should not be null.");
+        verifyException(
+            listener,
+            IllegalArgumentException.class,
+            "Failed to transform the knn query for MMR. Field name of the knn query should not be null."
+        );
     }
 
     public void testTransform_ThrowsExceptionWhenFieldNameIsEmpty() {
@@ -326,7 +330,17 @@ public class MMRKnnQueryTransformerTests extends MMRTestCase {
         when(queryBuilder.getMaxDistance()).thenReturn(null);
         when(queryBuilder.getMinScore()).thenReturn(null);
         when(queryBuilder.fieldName()).thenReturn("vector_field");
-        transformContext = new MMRTransformContext(Integer.MAX_VALUE, processingContext, List.of(), List.of(), null, "vector_field", null, client, true);
+        transformContext = new MMRTransformContext(
+            Integer.MAX_VALUE,
+            processingContext,
+            List.of(),
+            List.of(),
+            null,
+            "vector_field",
+            null,
+            client,
+            true
+        );
 
         transformer.transform(queryBuilder, listener, transformContext);
 


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-jvector/pull/495 to `3.6`