### PR TITLE
Fix GRPC flaky test by using locale-independent formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 ### Bug Fixes
 - Fix derived nested fields processing [484] (https://github.com/opensearch-project/opensearch-jvector/pull/484)
+- Fix GRPC integration flaky test caused by locale-sensitive String.format [#505](https://github.com/opensearch-project/opensearch-jvector/pull/505)
 ### Infrastructure
 * Upgrade Lucene to 10.4.0 [292] (https://github.com/opensearch-project/opensearch-jvector/pull/292)
 * Upgrade jvector from 4.0.0-rc.6 to 4.0.0-rc.8 [370](https://github.com/opensearch-project/opensearch-jvector/pull/370)

--- a/src/test/java/org/opensearch/knn/grpc/KNNQueryGrpcIT.java
+++ b/src/test/java/org/opensearch/knn/grpc/KNNQueryGrpcIT.java
@@ -76,6 +76,7 @@ public class KNNQueryGrpcIT extends KNNRestTestCase {
 
             // Create index with KNN vector field using JVector engine
             String indexMapping = String.format(
+                java.util.Locale.ROOT,
                 "{\n"
                     + "  \"settings\": {\n"
                     + "    \"index\": {\n"
@@ -88,7 +89,12 @@ public class KNNQueryGrpcIT extends KNNRestTestCase {
                     + "    \"properties\": {\n"
                     + "      \"%s\": {\n"
                     + "        \"type\": \"knn_vector\",\n"
-                    + "        \"dimension\": %d\n"
+                    + "        \"dimension\": %d,\n"
+                    + "        \"method\": {\n"
+                    + "          \"name\": \"disk_ann\",\n"
+                    + "          \"engine\": \"jvector\",\n"
+                    + "          \"space_type\": \"l2\"\n"
+                    + "        }\n"
                     + "      }\n"
                     + "    }\n"
                     + "  }\n"


### PR DESCRIPTION
### Description
[Describe what this change achieves]

### Related Issues
Resolves #504 
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
