### PR TITLE
Add NVQ quantization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 3.7](https://github.com/opensearch-project/opensearch-jvector/compare/3.7...HEAD)
 ### Features
-- Added capability to retrieve float, binary and byte data types vectors using doc_values [#3321](https://github.com/opensearch-project/k-NN/pull/3321)
-- Add NVQ Quantization
+- Add NVQ Quantization [#539](https://github.com/opensearch-project/opensearch-jvector/pull/539) 
+- Added capability to retrieve float, binary and byte data types vectors using doc_values [#538](https://github.com/opensearch-project/opensearch-jvector/pull/538)
+
 ### Enhancements
 ### Bug Fixes
 - Fix dynamic template and mixed cases [538](https://github.com/opensearch-project/opensearch-jvector/pull/538)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 3.7](https://github.com/opensearch-project/opensearch-jvector/compare/3.7...HEAD)
 ### Features
 - Added capability to retrieve float, binary and byte data types vectors using doc_values [#3321](https://github.com/opensearch-project/k-NN/pull/3321)
-
+- Add NVQ Quantization
 ### Enhancements
 ### Bug Fixes
 - Fix dynamic template and mixed cases [538](https://github.com/opensearch-project/opensearch-jvector/pull/538)

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -100,12 +100,10 @@ public class KNNConstants {
     public static final String METHOD_PARAMETER_NUM_PQ_SUBSPACES = "advanced.num_pq_subspaces";
     public static final String METHOD_PARAMETER_QUANTIZATION_TYPE = "advanced.quantization_type";
     public static final String METHOD_PARAMETER_NUM_NVQ_SUBVECTORS = "advanced.num_nvq_subvectors";
-    public static final String METHOD_PARAMETER_NVQ_VECTORS_INLINE = "advanced.nvq_vectors_inline";
     public static final String QUANTIZATION_TYPE_PQ = "pq";
     public static final String QUANTIZATION_TYPE_NVQ = "nvq";
     public static final String DEFAULT_QUANTIZATION_TYPE = QUANTIZATION_TYPE_PQ;
     public static final int DEFAULT_NUM_NVQ_SUBVECTORS = -1; // -1 means use same default as PQ subspaces
-    public static final boolean DEFAULT_NVQ_VECTORS_INLINE = false;
     public static final Double DEFAULT_ALPHA_VALUE = 1.2;
     public static final Double DEFAULT_NEIGHBOR_OVERFLOW_VALUE = 1.2;
     public static final int DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION = 1024; // above this batch size we will trigger quantization by

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -99,11 +99,11 @@ public class KNNConstants {
     public static final String METHOD_PARAMETER_HIERARCHY_ENABLED = "advanced.hierarchy_enabled";
     public static final String METHOD_PARAMETER_NUM_PQ_SUBSPACES = "advanced.num_pq_subspaces";
     public static final String METHOD_PARAMETER_QUANTIZATION_TYPE = "advanced.quantization_type";
-    public static final String METHOD_PARAMETER_NUM_NVQ_SUBVECTORS = "advanced.num_nvq_subvectors";
+    public static final String METHOD_PARAMETER_NUM_NVQ_SUBVECTORS = "advanced.nvq.num_subvectors";
     public static final String QUANTIZATION_TYPE_PQ = "pq";
     public static final String QUANTIZATION_TYPE_NVQ = "nvq";
     public static final String DEFAULT_QUANTIZATION_TYPE = QUANTIZATION_TYPE_PQ;
-    public static final int DEFAULT_NUM_NVQ_SUBVECTORS = -1; // -1 means use same default as PQ subspaces
+    public static final int DEFAULT_NUM_NVQ_SUBVECTORS = 2;
     public static final Double DEFAULT_ALPHA_VALUE = 1.2;
     public static final Double DEFAULT_NEIGHBOR_OVERFLOW_VALUE = 1.2;
     public static final int DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION = 1024; // above this batch size we will trigger quantization by

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -101,7 +101,8 @@ public class KNNConstants {
     public static final String METHOD_PARAMETER_QUANTIZATION_TYPE = "advanced.quantization_type";
     public static final String METHOD_PARAMETER_NUM_NVQ_SUBVECTORS = "advanced.nvq.num_subvectors";
     public static final String QUANTIZATION_TYPE_PQ = "pq";
-    public static final String QUANTIZATION_TYPE_NVQ = "nvq";
+    // When NVQ is enabled, PQ blob is also used. There is no option to use NVQ without PQ presently.
+    public static final String QUANTIZATION_TYPE_NVQ = "nvq+pq";
     public static final String DEFAULT_QUANTIZATION_TYPE = QUANTIZATION_TYPE_PQ;
     public static final int DEFAULT_NUM_NVQ_SUBVECTORS = 2;
     public static final Double DEFAULT_ALPHA_VALUE = 1.2;

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -98,6 +98,12 @@ public class KNNConstants {
     public static final String METHOD_PARAMETER_MIN_BATCH_SIZE_FOR_QUANTIZATION = "advanced.min_batch_size_for_quantization";
     public static final String METHOD_PARAMETER_HIERARCHY_ENABLED = "advanced.hierarchy_enabled";
     public static final String METHOD_PARAMETER_NUM_PQ_SUBSPACES = "advanced.num_pq_subspaces";
+    public static final String METHOD_PARAMETER_QUANTIZATION_TYPE = "advanced.quantization_type";
+    public static final String METHOD_PARAMETER_NUM_NVQ_SUBVECTORS = "advanced.num_nvq_subvectors";
+    public static final String QUANTIZATION_TYPE_PQ = "pq";
+    public static final String QUANTIZATION_TYPE_NVQ = "nvq";
+    public static final String DEFAULT_QUANTIZATION_TYPE = QUANTIZATION_TYPE_PQ;
+    public static final int DEFAULT_NUM_NVQ_SUBVECTORS = -1; // -1 means use same default as PQ subspaces
     public static final Double DEFAULT_ALPHA_VALUE = 1.2;
     public static final Double DEFAULT_NEIGHBOR_OVERFLOW_VALUE = 1.2;
     public static final int DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION = 1024; // above this batch size we will trigger quantization by

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -100,10 +100,12 @@ public class KNNConstants {
     public static final String METHOD_PARAMETER_NUM_PQ_SUBSPACES = "advanced.num_pq_subspaces";
     public static final String METHOD_PARAMETER_QUANTIZATION_TYPE = "advanced.quantization_type";
     public static final String METHOD_PARAMETER_NUM_NVQ_SUBVECTORS = "advanced.num_nvq_subvectors";
+    public static final String METHOD_PARAMETER_NVQ_VECTORS_INLINE = "advanced.nvq_vectors_inline";
     public static final String QUANTIZATION_TYPE_PQ = "pq";
     public static final String QUANTIZATION_TYPE_NVQ = "nvq";
     public static final String DEFAULT_QUANTIZATION_TYPE = QUANTIZATION_TYPE_PQ;
     public static final int DEFAULT_NUM_NVQ_SUBVECTORS = -1; // -1 means use same default as PQ subspaces
+    public static final boolean DEFAULT_NVQ_VECTORS_INLINE = false;
     public static final Double DEFAULT_ALPHA_VALUE = 1.2;
     public static final Double DEFAULT_NEIGHBOR_OVERFLOW_VALUE = 1.2;
     public static final int DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION = 1024; // above this batch size we will trigger quantization by

--- a/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120PerFieldKnnVectorsFormat.java
@@ -73,8 +73,7 @@ public class KNN9120PerFieldKnnVectorsFormat extends BasePerFieldKnnVectorsForma
                             knnVectorsFormatParams.isHierarchyEnabled(),
                             knnVectorsFormatParams.isLeadingSegmentMergeDisabled(),
                             knnVectorsFormatParams.getQuantizationType(),
-                            knnVectorsFormatParams.getNumNvqSubvectors(),
-                            knnVectorsFormatParams.isNvqVectorsInline()
+                            knnVectorsFormatParams.getNumNvqSubvectors()
                         );
                     default:
                         throw new IllegalArgumentException("Unsupported java engine: " + knnEngine);

--- a/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120PerFieldKnnVectorsFormat.java
@@ -73,7 +73,8 @@ public class KNN9120PerFieldKnnVectorsFormat extends BasePerFieldKnnVectorsForma
                             knnVectorsFormatParams.isHierarchyEnabled(),
                             knnVectorsFormatParams.isLeadingSegmentMergeDisabled(),
                             knnVectorsFormatParams.getQuantizationType(),
-                            knnVectorsFormatParams.getNumNvqSubvectors()
+                            knnVectorsFormatParams.getNumNvqSubvectors(),
+                            knnVectorsFormatParams.isNvqVectorsInline()
                         );
                     default:
                         throw new IllegalArgumentException("Unsupported java engine: " + knnEngine);

--- a/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120PerFieldKnnVectorsFormat.java
@@ -71,7 +71,9 @@ public class KNN9120PerFieldKnnVectorsFormat extends BasePerFieldKnnVectorsForma
                             knnVectorsFormatParams.getNumberOfSubspacesPerVectorSupplier(),
                             knnVectorsFormatParams.getMinBatchSizeForQuantization(),
                             knnVectorsFormatParams.isHierarchyEnabled(),
-                            knnVectorsFormatParams.isLeadingSegmentMergeDisabled()
+                            knnVectorsFormatParams.isLeadingSegmentMergeDisabled(),
+                            knnVectorsFormatParams.getQuantizationType(),
+                            knnVectorsFormatParams.getNumNvqSubvectors()
                         );
                     default:
                         throw new IllegalArgumentException("Unsupported java engine: " + knnEngine);

--- a/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120PerFieldKnnVectorsFormat.java
@@ -68,12 +68,10 @@ public class KNN9120PerFieldKnnVectorsFormat extends BasePerFieldKnnVectorsForma
                             knnVectorsFormatParams.getBeamWidth(),
                             knnVectorsFormatParams.getAlpha(),
                             knnVectorsFormatParams.getNeighborOverflow(),
-                            knnVectorsFormatParams.getNumberOfSubspacesPerVectorSupplier(),
+                            knnVectorsFormatParams.getQuantization(),
                             knnVectorsFormatParams.getMinBatchSizeForQuantization(),
                             knnVectorsFormatParams.isHierarchyEnabled(),
-                            knnVectorsFormatParams.isLeadingSegmentMergeDisabled(),
-                            knnVectorsFormatParams.getQuantizationType(),
-                            knnVectorsFormatParams.getNumNvqSubvectors()
+                            knnVectorsFormatParams.isLeadingSegmentMergeDisabled()
                         );
                     default:
                         throw new IllegalArgumentException("Unsupported java engine: " + knnEngine);

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorDiskANNMethod.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorDiskANNMethod.java
@@ -101,14 +101,6 @@ public class JVectorDiskANNMethod extends AbstractKNNMethod {
                     (v, context) -> QUANTIZATION_TYPE_PQ.equals(v) || QUANTIZATION_TYPE_NVQ.equals(v)
                 )
             )
-            .addParameter(
-                METHOD_PARAMETER_NVQ_VECTORS_INLINE,
-                new Parameter.BooleanParameter(
-                    METHOD_PARAMETER_NVQ_VECTORS_INLINE,
-                    KNNConstants.DEFAULT_NVQ_VECTORS_INLINE,
-                    (v, context) -> true
-                )
-            )
             .build();
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorDiskANNMethod.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorDiskANNMethod.java
@@ -93,6 +93,22 @@ public class JVectorDiskANNMethod extends AbstractKNNMethod {
                     (v, context) -> true
                 )
             )
+            .addParameter(
+                METHOD_PARAMETER_QUANTIZATION_TYPE,
+                new Parameter.StringParameter(
+                    METHOD_PARAMETER_QUANTIZATION_TYPE,
+                    KNNConstants.DEFAULT_QUANTIZATION_TYPE,
+                    (v, context) -> QUANTIZATION_TYPE_PQ.equals(v) || QUANTIZATION_TYPE_NVQ.equals(v)
+                )
+            )
+            .addParameter(
+                METHOD_PARAMETER_NVQ_VECTORS_INLINE,
+                new Parameter.BooleanParameter(
+                    METHOD_PARAMETER_NVQ_VECTORS_INLINE,
+                    KNNConstants.DEFAULT_NVQ_VECTORS_INLINE,
+                    (v, context) -> true
+                )
+            )
             .build();
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorDiskANNMethod.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorDiskANNMethod.java
@@ -101,6 +101,14 @@ public class JVectorDiskANNMethod extends AbstractKNNMethod {
                     (v, context) -> QUANTIZATION_TYPE_PQ.equals(v) || QUANTIZATION_TYPE_NVQ.equals(v)
                 )
             )
+            .addParameter(
+                METHOD_PARAMETER_NUM_NVQ_SUBVECTORS,
+                new Parameter.IntegerParameter(
+                    METHOD_PARAMETER_NUM_NVQ_SUBVECTORS,
+                    KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS,
+                    (v, context) -> v != null && v > 0 && v <= context.getDimension()
+                )
+            )
             .build();
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFloatVectorValues.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFloatVectorValues.java
@@ -25,6 +25,7 @@ public class JVectorFloatVectorValues extends FloatVectorValues {
     private final int dimension;
     private final int size;
     private final GraphNodeIdToDocMap graphNodeIdToDocMap;
+    private final JVectorIndexQuantization quantization;
 
     public JVectorFloatVectorValues(
         OnDiskGraphIndex onDiskGraphIndex,
@@ -32,17 +33,23 @@ public class JVectorFloatVectorValues extends FloatVectorValues {
         org.apache.lucene.index.VectorSimilarityFunction luceneSimilarityFunction,
         GraphNodeIdToDocMap graphNodeIdToDocMap
     ) throws IOException {
+        this(onDiskGraphIndex, similarityFunction, luceneSimilarityFunction, graphNodeIdToDocMap, new JVectorIndexQuantization.PQ());
+    }
+
+    protected JVectorFloatVectorValues(
+        OnDiskGraphIndex onDiskGraphIndex,
+        VectorSimilarityFunction similarityFunction,
+        org.apache.lucene.index.VectorSimilarityFunction luceneSimilarityFunction,
+        GraphNodeIdToDocMap graphNodeIdToDocMap,
+        JVectorIndexQuantization quantization
+    ) throws IOException {
         this.view = onDiskGraphIndex.getView();
         this.dimension = view.dimension();
         this.size = view.size();
         this.similarityFunction = similarityFunction;
         this.luceneSimilarityFunction = luceneSimilarityFunction;
         this.graphNodeIdToDocMap = graphNodeIdToDocMap;
-    }
-
-    /** Exposes the underlying view to subclasses (e.g. for NVQ dequantization). */
-    protected OnDiskGraphIndex.View getView() {
-        return view;
+        this.quantization = quantization;
     }
 
     @Override
@@ -56,7 +63,7 @@ public class JVectorFloatVectorValues extends FloatVectorValues {
     }
 
     public VectorFloat<?> vectorFloatValue(int ord) {
-        return view.getVector(ord);
+        return quantization.vectorFloatValue(view, ord);
     }
 
     public DocIndexIterator iterator() {

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFloatVectorValues.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFloatVectorValues.java
@@ -6,6 +6,8 @@
 package org.opensearch.knn.index.codec.jvector;
 
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
+import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
+import io.github.jbellis.jvector.quantization.NVQuantization;
 import io.github.jbellis.jvector.util.Bits;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
@@ -25,6 +27,10 @@ public class JVectorFloatVectorValues extends FloatVectorValues {
     private final int dimension;
     private final int size;
     private final GraphNodeIdToDocMap graphNodeIdToDocMap;
+    // Non-null only when the underlying graph stores NVQ vectors inline (no full-resolution vectors available).
+    private final NVQuantization nvqInline;
+    // Reusable scratch buffer for inline NVQ dequantization (safe: access is serialised by the caller).
+    private final NVQuantization.QuantizedVector nvqScratch;
 
     public JVectorFloatVectorValues(
         OnDiskGraphIndex onDiskGraphIndex,
@@ -32,12 +38,25 @@ public class JVectorFloatVectorValues extends FloatVectorValues {
         org.apache.lucene.index.VectorSimilarityFunction luceneSimilarityFunction,
         GraphNodeIdToDocMap graphNodeIdToDocMap
     ) throws IOException {
+        this(onDiskGraphIndex, similarityFunction, graphNodeIdToDocMap, null);
+    }
+
+    public JVectorFloatVectorValues(
+        OnDiskGraphIndex onDiskGraphIndex,
+        VectorSimilarityFunction similarityFunction,
+        GraphNodeIdToDocMap graphNodeIdToDocMap,
+        NVQuantization nvqInline
+    ) throws IOException {
         this.view = onDiskGraphIndex.getView();
         this.dimension = view.dimension();
         this.size = view.size();
         this.similarityFunction = similarityFunction;
         this.luceneSimilarityFunction = luceneSimilarityFunction;
         this.graphNodeIdToDocMap = graphNodeIdToDocMap;
+        this.nvqInline = nvqInline;
+        this.nvqScratch = nvqInline != null
+            ? NVQuantization.QuantizedVector.createEmpty(nvqInline.subvectorSizesAndOffsets, nvqInline.bitsPerDimension)
+            : null;
     }
 
     @Override
@@ -50,10 +69,90 @@ public class JVectorFloatVectorValues extends FloatVectorValues {
         return size;
     }
 
-    // This allows us to access the vector without copying it to float[]
+    /**
+     * Returns the float vector for the given graph-node ordinal.
+     *
+     * For normal (non-NVQ-inline) graphs the full-resolution vector is read directly.
+     * For NVQ-inline graphs the quantized bytes stored in the graph node are
+     * dequantized back to approximate float values so that callers (e.g. the merge
+     * path) can treat all segments uniformly.
+     */
     public VectorFloat<?> vectorFloatValue(int ord) {
+        if (nvqInline != null) {
+            return dequantizeNVQInline(ord);
+        }
         return view.getVector(ord);
     }
+
+    // -------------------------------------------------------------------------
+    // NVQ inline dequantization helpers
+    // -------------------------------------------------------------------------
+
+    private VectorFloat<?> dequantizeNVQInline(int ord) {
+        try {
+            var reader = view.featureReaderForNode(ord, FeatureId.NVQ_VECTORS);
+            NVQuantization.QuantizedVector.loadInto(reader, nvqScratch);
+            return nvqDequantize(nvqScratch, nvqInline);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to dequantize NVQ inline vector for ordinal " + ord, e);
+        }
+    }
+
+    /**
+     * Reconstructs an approximate float vector from a {@link NVQuantization.QuantizedVector}.
+     *
+     * The inverse of the NVQ encoding is:
+     * <pre>
+     *   scaledValue   = b * logisticScale + logisticBias      (map byte → sigmoid domain)
+     *   reconstructed = logit(scaledValue) / scaledGrowthRate + scaledMidpoint
+     * </pre>
+     * followed by adding back the {@code globalMean} that was subtracted during encoding.
+     */
+    private static VectorFloat<?> nvqDequantize(NVQuantization.QuantizedVector qv, NVQuantization nvq) {
+        VectorFloat<?> result = VECTOR_TYPE_SUPPORT.createFloatVector(nvq.originalDimension);
+        int offset = 0;
+        for (NVQuantization.QuantizedSubVector sv : qv.subVectors) {
+            float delta = sv.maxValue - sv.minValue;
+            float scaledGrowthRate = sv.growthRate / delta;
+            float scaledMidpoint = sv.midpoint * delta;
+            float logisticBias = logisticNQT(sv.minValue, scaledGrowthRate, scaledMidpoint);
+            float logisticScale = (logisticNQT(sv.maxValue, scaledGrowthRate, scaledMidpoint) - logisticBias) / 255.0f;
+            float inverseScaledGrowthRate = 1.0f / scaledGrowthRate;
+
+            for (int d = 0; d < sv.originalDimensions; d++) {
+                int b = Byte.toUnsignedInt(sv.bytes.get(d));
+                float scaledValue = Math.fma(b, logisticScale, logisticBias);
+                result.set(offset + d, logitNQT(scaledValue, inverseScaledGrowthRate, scaledMidpoint));
+            }
+            offset += sv.originalDimensions;
+        }
+        // Add back global mean (subtracted during encoding)
+        for (int i = 0; i < nvq.originalDimension; i++) {
+            result.set(i, result.get(i) + nvq.globalMean.get(i));
+        }
+        return result;
+    }
+
+    /** Fast logistic function used by NVQ (mirrors DefaultVectorUtilSupport.logisticFunctionNQT). */
+    private static float logisticNQT(float value, float alpha, float x0) {
+        float temp = Math.fma(value, alpha, -alpha * x0);
+        int p = Math.round(temp + 0.5f);
+        int m = Float.floatToIntBits(Math.fma(temp - p, 0.5f, 1));
+        temp = Float.intBitsToFloat(m + (p << 23));
+        return temp / (temp + 1);
+    }
+
+    /** Fast logit (inverse logistic) used by NVQ (mirrors DefaultVectorUtilSupport.logitNQT). */
+    private static float logitNQT(float scaledValue, float inverseAlpha, float x0) {
+        float z = scaledValue / (1 - scaledValue);
+        int temp = Float.floatToIntBits(z);
+        int e = temp & 0x7f800000;
+        float p = (float) ((e >> 23) - 128);
+        float m = Float.intBitsToFloat((temp & 0x007fffff) + 0x3f800000);
+        return (m + p) * inverseAlpha + x0;
+    }
+
+    // -------------------------------------------------------------------------
 
     public DocIndexIterator iterator() {
         return new DocIndexIterator() {

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFloatVectorValues.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFloatVectorValues.java
@@ -6,8 +6,6 @@
 package org.opensearch.knn.index.codec.jvector;
 
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
-import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
-import io.github.jbellis.jvector.quantization.NVQuantization;
 import io.github.jbellis.jvector.util.Bits;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
@@ -19,7 +17,7 @@ import org.apache.lucene.search.VectorScorer;
 
 public class JVectorFloatVectorValues extends FloatVectorValues {
     public static final int NO_VECTOR = -1;
-    private static final VectorTypeSupport VECTOR_TYPE_SUPPORT = VectorizationProvider.getInstance().getVectorTypeSupport();
+    static final VectorTypeSupport VECTOR_TYPE_SUPPORT = VectorizationProvider.getInstance().getVectorTypeSupport();
 
     private final OnDiskGraphIndex.View view;
     private final VectorSimilarityFunction similarityFunction;
@@ -27,37 +25,12 @@ public class JVectorFloatVectorValues extends FloatVectorValues {
     private final int dimension;
     private final int size;
     private final GraphNodeIdToDocMap graphNodeIdToDocMap;
-    // Non-null only when the underlying graph stores NVQ vectors inline (no full-resolution vectors available).
-    private final NVQuantization nvqInline;
-    // Reusable scratch buffer for inline NVQ dequantization (safe: access is serialised by the caller).
-    private final NVQuantization.QuantizedVector nvqScratch;
 
-    /** Full-precision (non-NVQ) constructor — Lucene similarity available for vectorScorer(). */
     public JVectorFloatVectorValues(
         OnDiskGraphIndex onDiskGraphIndex,
         VectorSimilarityFunction similarityFunction,
         org.apache.lucene.index.VectorSimilarityFunction luceneSimilarityFunction,
         GraphNodeIdToDocMap graphNodeIdToDocMap
-    ) throws IOException {
-        this(onDiskGraphIndex, similarityFunction, luceneSimilarityFunction, graphNodeIdToDocMap, null);
-    }
-
-    /** NVQ-inline constructor — luceneSimilarityFunction not available; vectorScorer() unsupported. */
-    public JVectorFloatVectorValues(
-        OnDiskGraphIndex onDiskGraphIndex,
-        VectorSimilarityFunction similarityFunction,
-        GraphNodeIdToDocMap graphNodeIdToDocMap,
-        NVQuantization nvqInline
-    ) throws IOException {
-        this(onDiskGraphIndex, similarityFunction, null, graphNodeIdToDocMap, nvqInline);
-    }
-
-    private JVectorFloatVectorValues(
-        OnDiskGraphIndex onDiskGraphIndex,
-        VectorSimilarityFunction similarityFunction,
-        org.apache.lucene.index.VectorSimilarityFunction luceneSimilarityFunction,
-        GraphNodeIdToDocMap graphNodeIdToDocMap,
-        NVQuantization nvqInline
     ) throws IOException {
         this.view = onDiskGraphIndex.getView();
         this.dimension = view.dimension();
@@ -65,10 +38,11 @@ public class JVectorFloatVectorValues extends FloatVectorValues {
         this.similarityFunction = similarityFunction;
         this.luceneSimilarityFunction = luceneSimilarityFunction;
         this.graphNodeIdToDocMap = graphNodeIdToDocMap;
-        this.nvqInline = nvqInline;
-        this.nvqScratch = nvqInline != null
-            ? NVQuantization.QuantizedVector.createEmpty(nvqInline.subvectorSizesAndOffsets, nvqInline.bitsPerDimension)
-            : null;
+    }
+
+    /** Exposes the underlying view to subclasses (e.g. for NVQ dequantization). */
+    protected OnDiskGraphIndex.View getView() {
+        return view;
     }
 
     @Override
@@ -81,90 +55,9 @@ public class JVectorFloatVectorValues extends FloatVectorValues {
         return size;
     }
 
-    /**
-     * Returns the float vector for the given graph-node ordinal.
-     *
-     * For normal (non-NVQ-inline) graphs the full-resolution vector is read directly.
-     * For NVQ-inline graphs the quantized bytes stored in the graph node are
-     * dequantized back to approximate float values so that callers (e.g. the merge
-     * path) can treat all segments uniformly.
-     */
     public VectorFloat<?> vectorFloatValue(int ord) {
-        if (nvqInline != null) {
-            return dequantizeNVQInline(ord);
-        }
         return view.getVector(ord);
     }
-
-    // -------------------------------------------------------------------------
-    // NVQ inline dequantization helpers
-    // -------------------------------------------------------------------------
-
-    private VectorFloat<?> dequantizeNVQInline(int ord) {
-        try {
-            var reader = view.featureReaderForNode(ord, FeatureId.NVQ_VECTORS);
-            NVQuantization.QuantizedVector.loadInto(reader, nvqScratch);
-            return nvqDequantize(nvqScratch, nvqInline);
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to dequantize NVQ inline vector for ordinal " + ord, e);
-        }
-    }
-
-    /**
-     * Reconstructs an approximate float vector from a {@link NVQuantization.QuantizedVector}.
-     *
-     * The inverse of the NVQ encoding is:
-     * <pre>
-     *   scaledValue   = b * logisticScale + logisticBias      (map byte → sigmoid domain)
-     *   reconstructed = logit(scaledValue) / scaledGrowthRate + scaledMidpoint
-     * </pre>
-     * followed by adding back the {@code globalMean} that was subtracted during encoding.
-     */
-    private static VectorFloat<?> nvqDequantize(NVQuantization.QuantizedVector qv, NVQuantization nvq) {
-        VectorFloat<?> result = VECTOR_TYPE_SUPPORT.createFloatVector(nvq.originalDimension);
-        int offset = 0;
-        for (NVQuantization.QuantizedSubVector sv : qv.subVectors) {
-            float delta = sv.maxValue - sv.minValue;
-            float scaledGrowthRate = sv.growthRate / delta;
-            float scaledMidpoint = sv.midpoint * delta;
-            float logisticBias = logisticNQT(sv.minValue, scaledGrowthRate, scaledMidpoint);
-            float logisticScale = (logisticNQT(sv.maxValue, scaledGrowthRate, scaledMidpoint) - logisticBias) / 255.0f;
-            float inverseScaledGrowthRate = 1.0f / scaledGrowthRate;
-
-            for (int d = 0; d < sv.originalDimensions; d++) {
-                int b = Byte.toUnsignedInt(sv.bytes.get(d));
-                float scaledValue = Math.fma(b, logisticScale, logisticBias);
-                result.set(offset + d, logitNQT(scaledValue, inverseScaledGrowthRate, scaledMidpoint));
-            }
-            offset += sv.originalDimensions;
-        }
-        // Add back global mean (subtracted during encoding)
-        for (int i = 0; i < nvq.originalDimension; i++) {
-            result.set(i, result.get(i) + nvq.globalMean.get(i));
-        }
-        return result;
-    }
-
-    /** Fast logistic function used by NVQ (mirrors DefaultVectorUtilSupport.logisticFunctionNQT). */
-    private static float logisticNQT(float value, float alpha, float x0) {
-        float temp = Math.fma(value, alpha, -alpha * x0);
-        int p = Math.round(temp + 0.5f);
-        int m = Float.floatToIntBits(Math.fma(temp - p, 0.5f, 1));
-        temp = Float.intBitsToFloat(m + (p << 23));
-        return temp / (temp + 1);
-    }
-
-    /** Fast logit (inverse logistic) used by NVQ (mirrors DefaultVectorUtilSupport.logitNQT). */
-    private static float logitNQT(float scaledValue, float inverseAlpha, float x0) {
-        float z = scaledValue / (1 - scaledValue);
-        int temp = Float.floatToIntBits(z);
-        int e = temp & 0x7f800000;
-        float p = (float) ((e >> 23) - 128);
-        float m = Float.intBitsToFloat((temp & 0x007fffff) + 0x3f800000);
-        return (m + p) * inverseAlpha + x0;
-    }
-
-    // -------------------------------------------------------------------------
 
     public DocIndexIterator iterator() {
         return new DocIndexIterator() {

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFloatVectorValues.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFloatVectorValues.java
@@ -32,18 +32,30 @@ public class JVectorFloatVectorValues extends FloatVectorValues {
     // Reusable scratch buffer for inline NVQ dequantization (safe: access is serialised by the caller).
     private final NVQuantization.QuantizedVector nvqScratch;
 
+    /** Full-precision (non-NVQ) constructor — Lucene similarity available for vectorScorer(). */
     public JVectorFloatVectorValues(
         OnDiskGraphIndex onDiskGraphIndex,
         VectorSimilarityFunction similarityFunction,
         org.apache.lucene.index.VectorSimilarityFunction luceneSimilarityFunction,
         GraphNodeIdToDocMap graphNodeIdToDocMap
     ) throws IOException {
-        this(onDiskGraphIndex, similarityFunction, graphNodeIdToDocMap, null);
+        this(onDiskGraphIndex, similarityFunction, luceneSimilarityFunction, graphNodeIdToDocMap, null);
     }
 
+    /** NVQ-inline constructor — luceneSimilarityFunction not available; vectorScorer() unsupported. */
     public JVectorFloatVectorValues(
         OnDiskGraphIndex onDiskGraphIndex,
         VectorSimilarityFunction similarityFunction,
+        GraphNodeIdToDocMap graphNodeIdToDocMap,
+        NVQuantization nvqInline
+    ) throws IOException {
+        this(onDiskGraphIndex, similarityFunction, null, graphNodeIdToDocMap, nvqInline);
+    }
+
+    private JVectorFloatVectorValues(
+        OnDiskGraphIndex onDiskGraphIndex,
+        VectorSimilarityFunction similarityFunction,
+        org.apache.lucene.index.VectorSimilarityFunction luceneSimilarityFunction,
         GraphNodeIdToDocMap graphNodeIdToDocMap,
         NVQuantization nvqInline
     ) throws IOException {

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFormat.java
@@ -30,7 +30,8 @@ public class JVectorFormat extends KnnVectorsFormat {
     public static final String NEIGHBORS_SCORE_CACHE_EXTENSION = "neighbors-score-cache-" + JVECTOR_FILES_SUFFIX;
 
     public static final int VERSION_START = 0;
-    public static final int VERSION_CURRENT = VERSION_START;
+    public static final int VERSION_WITH_QUANTIZATION_TYPE = 1;
+    public static final int VERSION_CURRENT = VERSION_WITH_QUANTIZATION_TYPE;
     public static final int DEFAULT_MAX_CONN = 32;
     public static final int DEFAULT_BEAM_WIDTH = 100;
     // Unfortunately, this can't be managed yet by the OpenSearch ThreadPool because it's not supporting {@link ForkJoinPool} types
@@ -46,6 +47,8 @@ public class JVectorFormat extends KnnVectorsFormat {
     private final float neighborOverflow;
     private final boolean hierarchyEnabled;
     private final boolean leadingSegmentMergeDisabled;
+    private final String quantizationType;
+    private final int numNvqSubvectors;
     private final ForkJoinPool simdPoolMerge;
     private final ForkJoinPool simdPoolFlush;
     private final ForkJoinPool parallelismPool;
@@ -61,6 +64,8 @@ public class JVectorFormat extends KnnVectorsFormat {
             KNNConstants.DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION,
             KNNConstants.DEFAULT_HIERARCHY_ENABLED,
             KNNConstants.DEFAULT_LEADING_SEGMENT_MERGE_DISABLED,
+            KNNConstants.DEFAULT_QUANTIZATION_TYPE,
+            KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS,
             SIMD_POOL_MERGE,
             SIMD_POOL_FLUSH,
             PARALLELISM_POOL
@@ -82,6 +87,8 @@ public class JVectorFormat extends KnnVectorsFormat {
             minBatchSizeForQuantization,
             KNNConstants.DEFAULT_HIERARCHY_ENABLED,
             leadingSegmentMergeDisabled,
+            KNNConstants.DEFAULT_QUANTIZATION_TYPE,
+            KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS,
             SIMD_POOL_MERGE,
             SIMD_POOL_FLUSH,
             PARALLELISM_POOL
@@ -105,6 +112,8 @@ public class JVectorFormat extends KnnVectorsFormat {
             minBatchSizeForQuantization,
             KNNConstants.DEFAULT_HIERARCHY_ENABLED,
             leadingSegmentMergeDisabled,
+            KNNConstants.DEFAULT_QUANTIZATION_TYPE,
+            KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS,
             simdPoolMerge,
             simdPoolFlush,
             parallelismPool
@@ -131,6 +140,38 @@ public class JVectorFormat extends KnnVectorsFormat {
             minBatchSizeForQuantization,
             hierarchyEnabled,
             leadingSegmentMergeDisabled,
+            KNNConstants.DEFAULT_QUANTIZATION_TYPE,
+            KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS,
+            SIMD_POOL_MERGE,
+            SIMD_POOL_FLUSH,
+            PARALLELISM_POOL
+        );
+    }
+
+    public JVectorFormat(
+        int maxConn,
+        int beamWidth,
+        float neighborOverflow,
+        float alpha,
+        Function<Integer, Integer> numberOfSubspacesPerVectorSupplier,
+        int minBatchSizeForQuantization,
+        boolean hierarchyEnabled,
+        boolean leadingSegmentMergeDisabled,
+        String quantizationType,
+        int numNvqSubvectors
+    ) {
+        this(
+            NAME,
+            maxConn,
+            beamWidth,
+            neighborOverflow,
+            alpha,
+            numberOfSubspacesPerVectorSupplier,
+            minBatchSizeForQuantization,
+            hierarchyEnabled,
+            leadingSegmentMergeDisabled,
+            quantizationType,
+            numNvqSubvectors,
             SIMD_POOL_MERGE,
             SIMD_POOL_FLUSH,
             PARALLELISM_POOL
@@ -147,6 +188,8 @@ public class JVectorFormat extends KnnVectorsFormat {
         int minBatchSizeForQuantization,
         boolean hierarchyEnabled,
         boolean leadingSegmentMergeDisabled,
+        String quantizationType,
+        int numNvqSubvectors,
         final ForkJoinPool simdPoolMerge,
         final ForkJoinPool simdPoolFlush,
         final ForkJoinPool parallelismPool
@@ -160,6 +203,8 @@ public class JVectorFormat extends KnnVectorsFormat {
         this.neighborOverflow = neighborOverflow;
         this.hierarchyEnabled = hierarchyEnabled;
         this.leadingSegmentMergeDisabled = leadingSegmentMergeDisabled;
+        this.quantizationType = quantizationType;
+        this.numNvqSubvectors = numNvqSubvectors;
         this.simdPoolMerge = simdPoolMerge;
         this.simdPoolFlush = simdPoolFlush;
         this.parallelismPool = parallelismPool;
@@ -177,6 +222,8 @@ public class JVectorFormat extends KnnVectorsFormat {
             minBatchSizeForQuantization,
             hierarchyEnabled,
             leadingSegmentMergeDisabled,
+            quantizationType,
+            numNvqSubvectors,
             simdPoolMerge,
             simdPoolFlush,
             parallelismPool

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFormat.java
@@ -49,7 +49,6 @@ public class JVectorFormat extends KnnVectorsFormat {
     private final boolean leadingSegmentMergeDisabled;
     private final String quantizationType;
     private final int numNvqSubvectors;
-    private final boolean nvqVectorsInline;
     private final ForkJoinPool simdPoolMerge;
     private final ForkJoinPool simdPoolFlush;
     private final ForkJoinPool parallelismPool;
@@ -162,34 +161,6 @@ public class JVectorFormat extends KnnVectorsFormat {
         int numNvqSubvectors
     ) {
         this(
-            maxConn,
-            beamWidth,
-            neighborOverflow,
-            alpha,
-            numberOfSubspacesPerVectorSupplier,
-            minBatchSizeForQuantization,
-            hierarchyEnabled,
-            leadingSegmentMergeDisabled,
-            quantizationType,
-            numNvqSubvectors,
-            KNNConstants.DEFAULT_NVQ_VECTORS_INLINE
-        );
-    }
-
-    public JVectorFormat(
-        int maxConn,
-        int beamWidth,
-        float neighborOverflow,
-        float alpha,
-        Function<Integer, Integer> numberOfSubspacesPerVectorSupplier,
-        int minBatchSizeForQuantization,
-        boolean hierarchyEnabled,
-        boolean leadingSegmentMergeDisabled,
-        String quantizationType,
-        int numNvqSubvectors,
-        boolean nvqVectorsInline
-    ) {
-        this(
             NAME,
             maxConn,
             beamWidth,
@@ -201,7 +172,6 @@ public class JVectorFormat extends KnnVectorsFormat {
             leadingSegmentMergeDisabled,
             quantizationType,
             numNvqSubvectors,
-            nvqVectorsInline,
             SIMD_POOL_MERGE,
             SIMD_POOL_FLUSH,
             PARALLELISM_POOL
@@ -224,42 +194,6 @@ public class JVectorFormat extends KnnVectorsFormat {
         final ForkJoinPool simdPoolFlush,
         final ForkJoinPool parallelismPool
     ) {
-        this(
-            name,
-            maxConn,
-            beamWidth,
-            neighborOverflow,
-            alpha,
-            numberOfSubspacesPerVectorSupplier,
-            minBatchSizeForQuantization,
-            hierarchyEnabled,
-            leadingSegmentMergeDisabled,
-            quantizationType,
-            numNvqSubvectors,
-            KNNConstants.DEFAULT_NVQ_VECTORS_INLINE,
-            simdPoolMerge,
-            simdPoolFlush,
-            parallelismPool
-        );
-    }
-
-    public JVectorFormat(
-        String name,
-        int maxConn,
-        int beamWidth,
-        float neighborOverflow,
-        float alpha,
-        Function<Integer, Integer> numberOfSubspacesPerVectorSupplier,
-        int minBatchSizeForQuantization,
-        boolean hierarchyEnabled,
-        boolean leadingSegmentMergeDisabled,
-        String quantizationType,
-        int numNvqSubvectors,
-        boolean nvqVectorsInline,
-        final ForkJoinPool simdPoolMerge,
-        final ForkJoinPool simdPoolFlush,
-        final ForkJoinPool parallelismPool
-    ) {
         super(name);
         this.maxConn = maxConn;
         this.beamWidth = beamWidth;
@@ -271,7 +205,6 @@ public class JVectorFormat extends KnnVectorsFormat {
         this.leadingSegmentMergeDisabled = leadingSegmentMergeDisabled;
         this.quantizationType = quantizationType;
         this.numNvqSubvectors = numNvqSubvectors;
-        this.nvqVectorsInline = nvqVectorsInline;
         this.simdPoolMerge = simdPoolMerge;
         this.simdPoolFlush = simdPoolFlush;
         this.parallelismPool = parallelismPool;
@@ -291,7 +224,6 @@ public class JVectorFormat extends KnnVectorsFormat {
             leadingSegmentMergeDisabled,
             quantizationType,
             numNvqSubvectors,
-            nvqVectorsInline,
             simdPoolMerge,
             simdPoolFlush,
             parallelismPool

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFormat.java
@@ -16,7 +16,6 @@ import org.opensearch.knn.common.KNNConstants;
 import java.io.IOException;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinWorkerThread;
-import java.util.function.Function;
 
 @Log4j2
 public class JVectorFormat extends KnnVectorsFormat {
@@ -41,14 +40,12 @@ public class JVectorFormat extends KnnVectorsFormat {
 
     private final int maxConn;
     private final int beamWidth;
-    private final Function<Integer, Integer> numberOfSubspacesPerVectorSupplier; // as a function of the original dimension
+    private final JVectorIndexQuantization quantization;
     private final int minBatchSizeForQuantization;
     private final float alpha;
     private final float neighborOverflow;
     private final boolean hierarchyEnabled;
     private final boolean leadingSegmentMergeDisabled;
-    private final String quantizationType;
-    private final int numNvqSubvectors;
     private final ForkJoinPool simdPoolMerge;
     private final ForkJoinPool simdPoolFlush;
     private final ForkJoinPool parallelismPool;
@@ -60,12 +57,10 @@ public class JVectorFormat extends KnnVectorsFormat {
             DEFAULT_BEAM_WIDTH,
             KNNConstants.DEFAULT_NEIGHBOR_OVERFLOW_VALUE.floatValue(),
             KNNConstants.DEFAULT_ALPHA_VALUE.floatValue(),
-            JVectorFormat::getDefaultNumberOfSubspacesPerVector,
+            new JVectorIndexQuantization.PQ(),
             KNNConstants.DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION,
             KNNConstants.DEFAULT_HIERARCHY_ENABLED,
             KNNConstants.DEFAULT_LEADING_SEGMENT_MERGE_DISABLED,
-            KNNConstants.DEFAULT_QUANTIZATION_TYPE,
-            KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS,
             SIMD_POOL_MERGE,
             SIMD_POOL_FLUSH,
             PARALLELISM_POOL
@@ -83,12 +78,10 @@ public class JVectorFormat extends KnnVectorsFormat {
             DEFAULT_BEAM_WIDTH,
             KNNConstants.DEFAULT_NEIGHBOR_OVERFLOW_VALUE.floatValue(),
             KNNConstants.DEFAULT_ALPHA_VALUE.floatValue(),
-            JVectorFormat::getDefaultNumberOfSubspacesPerVector,
+            new JVectorIndexQuantization.PQ(),
             minBatchSizeForQuantization,
             KNNConstants.DEFAULT_HIERARCHY_ENABLED,
             leadingSegmentMergeDisabled,
-            KNNConstants.DEFAULT_QUANTIZATION_TYPE,
-            KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS,
             SIMD_POOL_MERGE,
             SIMD_POOL_FLUSH,
             PARALLELISM_POOL
@@ -108,12 +101,10 @@ public class JVectorFormat extends KnnVectorsFormat {
             DEFAULT_BEAM_WIDTH,
             KNNConstants.DEFAULT_NEIGHBOR_OVERFLOW_VALUE.floatValue(),
             KNNConstants.DEFAULT_ALPHA_VALUE.floatValue(),
-            JVectorFormat::getDefaultNumberOfSubspacesPerVector,
+            new JVectorIndexQuantization.PQ(),
             minBatchSizeForQuantization,
             KNNConstants.DEFAULT_HIERARCHY_ENABLED,
             leadingSegmentMergeDisabled,
-            KNNConstants.DEFAULT_QUANTIZATION_TYPE,
-            KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS,
             simdPoolMerge,
             simdPoolFlush,
             parallelismPool
@@ -125,7 +116,7 @@ public class JVectorFormat extends KnnVectorsFormat {
         int beamWidth,
         float neighborOverflow,
         float alpha,
-        Function<Integer, Integer> numberOfSubspacesPerVectorSupplier,
+        JVectorIndexQuantization quantization,
         int minBatchSizeForQuantization,
         boolean hierarchyEnabled,
         boolean leadingSegmentMergeDisabled
@@ -136,42 +127,10 @@ public class JVectorFormat extends KnnVectorsFormat {
             beamWidth,
             neighborOverflow,
             alpha,
-            numberOfSubspacesPerVectorSupplier,
+            quantization,
             minBatchSizeForQuantization,
             hierarchyEnabled,
             leadingSegmentMergeDisabled,
-            KNNConstants.DEFAULT_QUANTIZATION_TYPE,
-            KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS,
-            SIMD_POOL_MERGE,
-            SIMD_POOL_FLUSH,
-            PARALLELISM_POOL
-        );
-    }
-
-    public JVectorFormat(
-        int maxConn,
-        int beamWidth,
-        float neighborOverflow,
-        float alpha,
-        Function<Integer, Integer> numberOfSubspacesPerVectorSupplier,
-        int minBatchSizeForQuantization,
-        boolean hierarchyEnabled,
-        boolean leadingSegmentMergeDisabled,
-        String quantizationType,
-        int numNvqSubvectors
-    ) {
-        this(
-            NAME,
-            maxConn,
-            beamWidth,
-            neighborOverflow,
-            alpha,
-            numberOfSubspacesPerVectorSupplier,
-            minBatchSizeForQuantization,
-            hierarchyEnabled,
-            leadingSegmentMergeDisabled,
-            quantizationType,
-            numNvqSubvectors,
             SIMD_POOL_MERGE,
             SIMD_POOL_FLUSH,
             PARALLELISM_POOL
@@ -184,12 +143,10 @@ public class JVectorFormat extends KnnVectorsFormat {
         int beamWidth,
         float neighborOverflow,
         float alpha,
-        Function<Integer, Integer> numberOfSubspacesPerVectorSupplier,
+        JVectorIndexQuantization quantization,
         int minBatchSizeForQuantization,
         boolean hierarchyEnabled,
         boolean leadingSegmentMergeDisabled,
-        String quantizationType,
-        int numNvqSubvectors,
         final ForkJoinPool simdPoolMerge,
         final ForkJoinPool simdPoolFlush,
         final ForkJoinPool parallelismPool
@@ -197,14 +154,12 @@ public class JVectorFormat extends KnnVectorsFormat {
         super(name);
         this.maxConn = maxConn;
         this.beamWidth = beamWidth;
-        this.numberOfSubspacesPerVectorSupplier = numberOfSubspacesPerVectorSupplier;
+        this.quantization = quantization;
         this.minBatchSizeForQuantization = minBatchSizeForQuantization;
         this.alpha = alpha;
         this.neighborOverflow = neighborOverflow;
         this.hierarchyEnabled = hierarchyEnabled;
         this.leadingSegmentMergeDisabled = leadingSegmentMergeDisabled;
-        this.quantizationType = quantizationType;
-        this.numNvqSubvectors = numNvqSubvectors;
         this.simdPoolMerge = simdPoolMerge;
         this.simdPoolFlush = simdPoolFlush;
         this.parallelismPool = parallelismPool;
@@ -218,12 +173,10 @@ public class JVectorFormat extends KnnVectorsFormat {
             beamWidth,
             neighborOverflow,
             alpha,
-            numberOfSubspacesPerVectorSupplier,
+            quantization,
             minBatchSizeForQuantization,
             hierarchyEnabled,
             leadingSegmentMergeDisabled,
-            quantizationType,
-            numNvqSubvectors,
             simdPoolMerge,
             simdPoolFlush,
             parallelismPool
@@ -239,68 +192,6 @@ public class JVectorFormat extends KnnVectorsFormat {
     public int getMaxDimensions(String s) {
         // Not a hard limit, but a reasonable default
         return 8192;
-    }
-
-    /**
-     * This method returns the default number of subspaces per vector for a given original dimension.
-     * Should be used as a default value for the number of subspaces per vector in case no value is provided.
-     *
-     * @param originalDimension original vector dimension
-     * @return default number of subspaces per vector
-     */
-    public static int getDefaultNumberOfSubspacesPerVector(int originalDimension) {
-        // the idea here is that higher dimensions compress well, but not so well that we should use fewer bits
-        // than a lower-dimension vector, which is what you could get with cutoff points to switch between (e.g.)
-        // D*0.5 and D*0.25. Thus, the following ensures that bytes per vector is strictly increasing with D.
-        int compressedBytes;
-        if (originalDimension <= 32) {
-            // We are compressing from 4-byte floats to single-byte codebook indexes,
-            // so this represents compression of 4x
-            // * GloVe-25 needs 25 BPV to achieve good recall
-            compressedBytes = originalDimension;
-        } else if (originalDimension <= 64) {
-            // * GloVe-50 performs fine at 25
-            compressedBytes = 32;
-        } else if (originalDimension <= 200) {
-            // * GloVe-100 and -200 perform well at 50 and 100 BPV, respectively
-            compressedBytes = (int) (originalDimension * 0.5);
-        } else if (originalDimension <= 400) {
-            // * NYTimes-256 actually performs fine at 64 BPV but we'll be conservative
-            // since we don't want BPV to decrease
-            compressedBytes = 100;
-        } else if (originalDimension <= 768) {
-            // allow BPV to increase linearly up to 192
-            compressedBytes = (int) (originalDimension * 0.25);
-        } else if (originalDimension <= 1536) {
-            // * ada002 vectors have good recall even at 192 BPV = compression of 32x
-            compressedBytes = 192;
-        } else {
-            // We have not tested recall with larger vectors than this, let's let it increase linearly
-            compressedBytes = (int) (originalDimension * 0.125);
-        }
-        return compressedBytes;
-    }
-
-    /**
-     * Returns the default number of NVQ subvectors for a given vector dimension.
-     *
-     * <p>Unlike PQ (which stores only 1 byte per subvector as a centroid index), each NVQ
-     * subvector carries 28 bytes of fixed overhead: four floats (growthRate, midpoint, minValue,
-     * maxValue) and three ints for the sigmoid parameterization. To keep the NVQ inline graph
-     * smaller than full-precision storage ({@code dim × 4} bytes), M must satisfy:
-     *
-     * <pre>  4 + dim + 28 × M  &lt;  4 × dim   →   M  &lt;  3 × dim / 28</pre>
-     *
-     * This method targets roughly 32-dimensional subvectors, which amortizes the per-subvector
-     * overhead reasonably (28-byte overhead vs 32 bytes of data) while giving the NVQ sigmoid
-     * enough dimensions to model local non-linearity. The resulting compressed size is
-     * approximately {@code 2 × dim} bytes per vector — about 2× smaller than full precision.
-     *
-     * @param dim the original vector dimension
-     * @return the number of NVQ subvectors (at least 1)
-     */
-    public static int getDefaultNvqSubvectorsForDimension(int dim) {
-        return Math.max(1, dim / 32);
     }
 
     public static ForkJoinPool getPhysicalCoreExecutor() {

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFormat.java
@@ -49,6 +49,7 @@ public class JVectorFormat extends KnnVectorsFormat {
     private final boolean leadingSegmentMergeDisabled;
     private final String quantizationType;
     private final int numNvqSubvectors;
+    private final boolean nvqVectorsInline;
     private final ForkJoinPool simdPoolMerge;
     private final ForkJoinPool simdPoolFlush;
     private final ForkJoinPool parallelismPool;
@@ -161,6 +162,34 @@ public class JVectorFormat extends KnnVectorsFormat {
         int numNvqSubvectors
     ) {
         this(
+            maxConn,
+            beamWidth,
+            neighborOverflow,
+            alpha,
+            numberOfSubspacesPerVectorSupplier,
+            minBatchSizeForQuantization,
+            hierarchyEnabled,
+            leadingSegmentMergeDisabled,
+            quantizationType,
+            numNvqSubvectors,
+            KNNConstants.DEFAULT_NVQ_VECTORS_INLINE
+        );
+    }
+
+    public JVectorFormat(
+        int maxConn,
+        int beamWidth,
+        float neighborOverflow,
+        float alpha,
+        Function<Integer, Integer> numberOfSubspacesPerVectorSupplier,
+        int minBatchSizeForQuantization,
+        boolean hierarchyEnabled,
+        boolean leadingSegmentMergeDisabled,
+        String quantizationType,
+        int numNvqSubvectors,
+        boolean nvqVectorsInline
+    ) {
+        this(
             NAME,
             maxConn,
             beamWidth,
@@ -172,6 +201,7 @@ public class JVectorFormat extends KnnVectorsFormat {
             leadingSegmentMergeDisabled,
             quantizationType,
             numNvqSubvectors,
+            nvqVectorsInline,
             SIMD_POOL_MERGE,
             SIMD_POOL_FLUSH,
             PARALLELISM_POOL
@@ -194,6 +224,42 @@ public class JVectorFormat extends KnnVectorsFormat {
         final ForkJoinPool simdPoolFlush,
         final ForkJoinPool parallelismPool
     ) {
+        this(
+            name,
+            maxConn,
+            beamWidth,
+            neighborOverflow,
+            alpha,
+            numberOfSubspacesPerVectorSupplier,
+            minBatchSizeForQuantization,
+            hierarchyEnabled,
+            leadingSegmentMergeDisabled,
+            quantizationType,
+            numNvqSubvectors,
+            KNNConstants.DEFAULT_NVQ_VECTORS_INLINE,
+            simdPoolMerge,
+            simdPoolFlush,
+            parallelismPool
+        );
+    }
+
+    public JVectorFormat(
+        String name,
+        int maxConn,
+        int beamWidth,
+        float neighborOverflow,
+        float alpha,
+        Function<Integer, Integer> numberOfSubspacesPerVectorSupplier,
+        int minBatchSizeForQuantization,
+        boolean hierarchyEnabled,
+        boolean leadingSegmentMergeDisabled,
+        String quantizationType,
+        int numNvqSubvectors,
+        boolean nvqVectorsInline,
+        final ForkJoinPool simdPoolMerge,
+        final ForkJoinPool simdPoolFlush,
+        final ForkJoinPool parallelismPool
+    ) {
         super(name);
         this.maxConn = maxConn;
         this.beamWidth = beamWidth;
@@ -205,6 +271,7 @@ public class JVectorFormat extends KnnVectorsFormat {
         this.leadingSegmentMergeDisabled = leadingSegmentMergeDisabled;
         this.quantizationType = quantizationType;
         this.numNvqSubvectors = numNvqSubvectors;
+        this.nvqVectorsInline = nvqVectorsInline;
         this.simdPoolMerge = simdPoolMerge;
         this.simdPoolFlush = simdPoolFlush;
         this.parallelismPool = parallelismPool;
@@ -224,6 +291,7 @@ public class JVectorFormat extends KnnVectorsFormat {
             leadingSegmentMergeDisabled,
             quantizationType,
             numNvqSubvectors,
+            nvqVectorsInline,
             simdPoolMerge,
             simdPoolFlush,
             parallelismPool

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFormat.java
@@ -281,6 +281,28 @@ public class JVectorFormat extends KnnVectorsFormat {
         return compressedBytes;
     }
 
+    /**
+     * Returns the default number of NVQ subvectors for a given vector dimension.
+     *
+     * <p>Unlike PQ (which stores only 1 byte per subvector as a centroid index), each NVQ
+     * subvector carries 28 bytes of fixed overhead: four floats (growthRate, midpoint, minValue,
+     * maxValue) and three ints for the sigmoid parameterization. To keep the NVQ inline graph
+     * smaller than full-precision storage ({@code dim × 4} bytes), M must satisfy:
+     *
+     * <pre>  4 + dim + 28 × M  &lt;  4 × dim   →   M  &lt;  3 × dim / 28</pre>
+     *
+     * This method targets roughly 32-dimensional subvectors, which amortizes the per-subvector
+     * overhead reasonably (28-byte overhead vs 32 bytes of data) while giving the NVQ sigmoid
+     * enough dimensions to model local non-linearity. The resulting compressed size is
+     * approximately {@code 2 × dim} bytes per vector — about 2× smaller than full precision.
+     *
+     * @param dim the original vector dimension
+     * @return the number of NVQ subvectors (at least 1)
+     */
+    public static int getDefaultNvqSubvectorsForDimension(int dim) {
+        return Math.max(1, dim / 32);
+    }
+
     public static ForkJoinPool getPhysicalCoreExecutor() {
         final int estimatedPhysicalCoreCount = Integer.getInteger(
             "jvector.physical_core_count",

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorIndexQuantization.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorIndexQuantization.java
@@ -5,14 +5,19 @@
 
 package org.opensearch.knn.index.codec.jvector;
 
+import io.github.jbellis.jvector.disk.ReaderSupplier;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
 import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
 import io.github.jbellis.jvector.quantization.NVQuantization;
+import io.github.jbellis.jvector.quantization.PQVectors;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import io.github.jbellis.jvector.graph.disk.feature.NVQ;
 import java.io.IOException;
 import java.util.function.Function;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
 import org.opensearch.knn.common.KNNConstants;
 
 /**
@@ -29,8 +34,110 @@ public sealed interface JVectorIndexQuantization {
 
     static final VectorTypeSupport VECTOR_TYPE_SUPPORT = VectorizationProvider.getInstance().getVectorTypeSupport();
 
+    // On-disk quantization type bytes written into VectorIndexFieldMetadata
+    byte QUANTIZATION_TYPE_NONE = 0;
+    byte QUANTIZATION_TYPE_PQ = 1;
+    byte QUANTIZATION_TYPE_NVQ = 2;
+
+    /** Holds the quantization objects loaded from disk for a single field. */
+    record LoadedState(NVQuantization nvqInlineQuantization, PQVectors pqVectors, ReaderSupplier compressedVectorsReaderSupplier) {
+    }
+
+    /**
+     * Loads the quantization state for a field from disk, dispatching on the on-disk {@code qType} byte.
+     * For NVQ, the {@link NVQuantization} is extracted from the graph and an optional auxiliary PQ blob is loaded.
+     * For PQ-only, the PQ blob is loaded from the field data file.
+     */
+    static LoadedState loadQuantizationState(
+        byte qType,
+        OnDiskGraphIndex index,
+        Directory directory,
+        String fieldDataFileName,
+        long compressedVectorsOffset,
+        long compressedVectorsLength,
+        long vectorIndexOffset
+    ) throws IOException {
+        return switch (qType) {
+            case QUANTIZATION_TYPE_NVQ -> loadNVQState(
+                index,
+                directory,
+                fieldDataFileName,
+                compressedVectorsOffset,
+                compressedVectorsLength
+            );
+            default -> compressedVectorsLength > 0
+                ? loadPQState(directory, fieldDataFileName, compressedVectorsOffset, compressedVectorsLength, vectorIndexOffset)
+                : new LoadedState(null, null, null);
+        };
+    }
+
+    private static LoadedState loadNVQState(
+        OnDiskGraphIndex index,
+        Directory directory,
+        String fieldDataFileName,
+        long compressedVectorsOffset,
+        long compressedVectorsLength
+    ) throws IOException {
+        NVQuantization nvq = nvqFromGraph(index);
+        if (compressedVectorsLength == 0) {
+            return new LoadedState(nvq, null, null);
+        }
+        assert compressedVectorsOffset > 0;
+        ReaderSupplier supplier = new JVectorRandomAccessReader.Supplier(
+            directory.openInput(fieldDataFileName, IOContext.READONCE),
+            compressedVectorsOffset,
+            compressedVectorsLength
+        );
+        PQVectors pqVectors;
+        try (var reader = supplier.get()) {
+            pqVectors = PQVectors.load(reader);
+        }
+        return new LoadedState(nvq, pqVectors, supplier);
+    }
+
+    private static LoadedState loadPQState(
+        Directory directory,
+        String fieldDataFileName,
+        long compressedVectorsOffset,
+        long compressedVectorsLength,
+        long vectorIndexOffset
+    ) throws IOException {
+        if (compressedVectorsOffset < vectorIndexOffset) {
+            throw new IllegalArgumentException("compressedVectorsOffset must be greater than vectorIndexOffset");
+        }
+        ReaderSupplier supplier = new JVectorRandomAccessReader.Supplier(
+            directory.openInput(fieldDataFileName, IOContext.READONCE),
+            compressedVectorsOffset,
+            compressedVectorsLength
+        );
+        PQVectors pqVectors;
+        try (var reader = supplier.get()) {
+            pqVectors = PQVectors.load(reader);
+        }
+        return new LoadedState(null, pqVectors, supplier);
+    }
+
+    // TODO: replace reflection with nvqFeature.getNVQuantization() once jvector exposes it publicly in the released jar
+    private static NVQuantization nvqFromGraph(OnDiskGraphIndex index) throws IOException {
+        io.github.jbellis.jvector.graph.disk.feature.NVQ nvqFeature = (io.github.jbellis.jvector.graph.disk.feature.NVQ) index.getFeatures()
+            .get(FeatureId.NVQ_VECTORS);
+        if (nvqFeature == null) {
+            return null;
+        }
+        try {
+            java.lang.reflect.Field nvqField = io.github.jbellis.jvector.graph.disk.feature.NVQ.class.getDeclaredField("nvq");
+            nvqField.setAccessible(true);
+            return (NVQuantization) nvqField.get(nvqFeature);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new IOException("Unable to extract NVQuantization from NVQ feature via reflection", e);
+        }
+    }
+
     /** String identifier used in REST params and on-disk serialization. */
     public abstract String getType();
+
+    /** Returns the byte value written to the segment metadata to identify this quantization type. */
+    public abstract byte quantizationType();
 
     /** Returns the number of subspaces/subvectors to use for a vector of the given dimension. */
     public abstract int numSubspaces(int dimension);
@@ -71,6 +178,11 @@ public sealed interface JVectorIndexQuantization {
         @Override
         public String getType() {
             return KNNConstants.QUANTIZATION_TYPE_NVQ;
+        }
+
+        @Override
+        public byte quantizationType() {
+            return QUANTIZATION_TYPE_NVQ;
         }
 
         @Override
@@ -201,6 +313,11 @@ public sealed interface JVectorIndexQuantization {
         @Override
         public String getType() {
             return KNNConstants.QUANTIZATION_TYPE_PQ;
+        }
+
+        @Override
+        public byte quantizationType() {
+            return QUANTIZATION_TYPE_PQ;
         }
 
         @Override

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorIndexQuantization.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorIndexQuantization.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.jvector;
+
+import java.util.function.Function;
+import org.opensearch.knn.common.KNNConstants;
+
+/**
+ * Encapsulates the quantization strategy used when writing a jVector segment.
+ * <p>
+ * Concrete subclasses are {@link NVQ} for Non-uniform Vector Quantization (stored inline
+ * in the graph) and {@link PQ} for Product Quantization (stored as a separate blob).
+ * PQ and NVQ quantize different portions of the graph. As a result,
+ * the following combinations for quantization are possible today in the disk-ann graph:
+ * 1. PQ + full-precision vectors
+ * 2. PQ + NVQ
+ */
+public abstract class JVectorIndexQuantization {
+
+    /** String identifier used in REST params and on-disk serialization. */
+    public abstract String getType();
+
+    /** Returns the number of subspaces/subvectors to use for a vector of the given dimension. */
+    public abstract int numSubspaces(int dimension);
+
+    // -----------------------------------------------------------------------
+    // NVQ implementation
+    // -----------------------------------------------------------------------
+
+    public static final class NVQ extends JVectorIndexQuantization {
+        private final int numSubvectors;
+
+        public NVQ(int numSubvectors) {
+            this.numSubvectors = numSubvectors;
+        }
+
+        public int getNumSubvectors() {
+            return numSubvectors;
+        }
+
+        @Override
+        public String getType() {
+            return KNNConstants.QUANTIZATION_TYPE_NVQ;
+        }
+
+        @Override
+        public int numSubspaces(int dimension) {
+            return numSubvectors;
+        }
+
+        /**
+         * Returns the recommended number of NVQ subvectors for a given vector dimension.
+         *
+         * <p>Unlike PQ (which stores only 1 byte per subvector as a centroid index), each NVQ
+         * subvector carries 28 bytes of fixed overhead: four floats (growthRate, midpoint, minValue,
+         * maxValue) and three ints for the sigmoid parameterization. To keep the NVQ inline graph
+         * smaller than full-precision storage ({@code dim × 4} bytes), M must satisfy:
+         *
+         * <pre>  4 + dim + 28 × M  &lt;  4 × dim   →   M  &lt;  3 × dim / 28</pre>
+         *
+         * The default value of 2 subvectors is set based on a recommendation by the jvector
+         * library presently.
+         *
+         * @return the number of NVQ subvectors (at least 1)
+         */
+        public static int defaultNumSubvectors() {
+            return 2;
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // PQ implementation
+    // -----------------------------------------------------------------------
+
+    public static final class PQ extends JVectorIndexQuantization {
+        private final Function<Integer, Integer> numSubspacesSupplier;
+
+        public PQ(Function<Integer, Integer> numSubspacesSupplier) {
+            this.numSubspacesSupplier = numSubspacesSupplier;
+        }
+
+        /** PQ with a fixed (dimension-independent) subspace count. */
+        public PQ(int fixedNumSubspaces) {
+            this(ignored -> fixedNumSubspaces);
+        }
+
+        /** PQ using the default dimension-adaptive subspace count. */
+        public PQ() {
+            this(PQ::defaultNumSubspaces);
+        }
+
+        public Function<Integer, Integer> getNumSubspacesSupplier() {
+            return numSubspacesSupplier;
+        }
+
+        @Override
+        public String getType() {
+            return KNNConstants.QUANTIZATION_TYPE_PQ;
+        }
+
+        @Override
+        public int numSubspaces(int dimension) {
+            return numSubspacesSupplier.apply(dimension);
+        }
+
+        /**
+         * Returns the default number of PQ subspaces for a given vector dimension.
+         *
+         * <p>The idea is that higher dimensions compress well, but not so well that we should use
+         * fewer bits than a lower-dimension vector, which is what you could get with cutoff points
+         * to switch between (e.g.) D*0.5 and D*0.25. Thus, the following ensures that bytes per
+         * vector is strictly increasing with D.
+         *
+         * @param originalDimension original vector dimension
+         * @return default number of subspaces per vector
+         */
+        public static int defaultNumSubspaces(int originalDimension) {
+            int compressedBytes;
+            if (originalDimension <= 32) {
+                compressedBytes = originalDimension;
+            } else if (originalDimension <= 64) {
+                compressedBytes = 32;
+            } else if (originalDimension <= 200) {
+                compressedBytes = (int) (originalDimension * 0.5);
+            } else if (originalDimension <= 400) {
+                compressedBytes = 100;
+            } else if (originalDimension <= 768) {
+                compressedBytes = (int) (originalDimension * 0.25);
+            } else if (originalDimension <= 1536) {
+                compressedBytes = 192;
+            } else {
+                compressedBytes = (int) (originalDimension * 0.125);
+            }
+            return compressedBytes;
+        }
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorIndexQuantization.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorIndexQuantization.java
@@ -6,19 +6,32 @@
 package org.opensearch.knn.index.codec.jvector;
 
 import io.github.jbellis.jvector.disk.ReaderSupplier;
+import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
 import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
+import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
+import io.github.jbellis.jvector.quantization.CompressedVectors;
+import io.github.jbellis.jvector.quantization.NVQVectors;
 import io.github.jbellis.jvector.quantization.NVQuantization;
 import io.github.jbellis.jvector.quantization.PQVectors;
+import io.github.jbellis.jvector.quantization.ProductQuantization;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 import io.github.jbellis.jvector.graph.disk.feature.NVQ;
 import java.io.IOException;
+import java.time.Clock;
+import java.util.concurrent.ForkJoinPool;
 import java.util.function.Function;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.plugin.stats.KNNCounter;
+
+import static io.github.jbellis.jvector.quantization.KMeansPlusPlusClusterer.UNWEIGHTED;
 
 /**
  * Encapsulates the quantization strategy used when writing a jVector segment.
@@ -32,15 +45,20 @@ import org.opensearch.knn.common.KNNConstants;
  */
 public sealed interface JVectorIndexQuantization {
 
+    Logger log = LogManager.getLogger(JVectorIndexQuantization.class);
     static final VectorTypeSupport VECTOR_TYPE_SUPPORT = VectorizationProvider.getInstance().getVectorTypeSupport();
 
     // On-disk quantization type bytes written into VectorIndexFieldMetadata
     byte QUANTIZATION_TYPE_NONE = 0;
     byte QUANTIZATION_TYPE_PQ = 1;
-    byte QUANTIZATION_TYPE_NVQ = 2;
+    byte QUANTIZATION_TYPE_NVQ_INLINE = 2;
 
     /** Holds the quantization objects loaded from disk for a single field. */
     record LoadedState(NVQuantization nvqInlineQuantization, PQVectors pqVectors, ReaderSupplier compressedVectorsReaderSupplier) {
+    }
+
+    /** Result of quantizing a set of vectors ahead of graph construction. */
+    record QuantizationResult(CompressedVectors compressedVectors, PQVectors auxiliaryPqVectors, BuildScoreProvider buildScoreProvider) {
     }
 
     /**
@@ -58,7 +76,7 @@ public sealed interface JVectorIndexQuantization {
         long vectorIndexOffset
     ) throws IOException {
         return switch (qType) {
-            case QUANTIZATION_TYPE_NVQ -> loadNVQState(
+            case QUANTIZATION_TYPE_NVQ_INLINE -> loadNVQState(
                 index,
                 directory,
                 fieldDataFileName,
@@ -69,6 +87,57 @@ public sealed interface JVectorIndexQuantization {
                 ? loadPQState(directory, fieldDataFileName, compressedVectorsOffset, compressedVectorsLength, vectorIndexOffset)
                 : new LoadedState(null, null, null);
         };
+    }
+
+    /**
+     * Compute NVQ vectors from raw float vectors.
+     * Called by {@link JVectorIndexQuantization.NVQ#quantize} and directly from the merge path.
+     */
+    static NVQVectors computeNvqVectors(int numSubvectors, RandomAccessVectorValues ravv, ForkJoinPool computePool) throws IOException {
+        log.info("Computing NVQ parameters for {} vectors", ravv.size());
+        final long start = Clock.systemDefaultZone().millis();
+        NVQuantization nvq = NVQuantization.compute(ravv, numSubvectors);
+        KNNCounter.KNN_QUANTIZATION_TRAINING_TIME.add(Clock.systemDefaultZone().millis() - start);
+        log.info("Encoding NVQ vectors for {} vectors", ravv.size());
+        NVQVectors nvqVectors = nvq.encodeAll(ravv, computePool);
+        log.info(
+            "Encoded NVQ vectors, original size: {} bytes, compressed size: {} bytes",
+            nvqVectors.getOriginalSize(),
+            nvqVectors.getCompressedSize()
+        );
+        return nvqVectors;
+    }
+
+    /**
+     * Compute PQ vectors from raw float vectors with the given subspace count.
+     * Called by {@link #quantize} implementations and directly from the merge path.
+     */
+    static PQVectors computePqVectors(
+        RandomAccessVectorValues ravv,
+        VectorSimilarityFunction vsf,
+        int numSubspaces,
+        ForkJoinPool computePool
+    ) throws IOException {
+        log.info("Computing PQ codebooks for {} vectors", ravv.size());
+        final long start = Clock.systemDefaultZone().millis();
+        final int clusters = Math.min(256, ravv.size());
+        ProductQuantization pq = ProductQuantization.compute(
+            ravv,
+            numSubspaces,
+            clusters,
+            vsf == VectorSimilarityFunction.EUCLIDEAN,
+            UNWEIGHTED,
+            computePool,
+            ForkJoinPool.commonPool()
+        );
+        KNNCounter.KNN_QUANTIZATION_TRAINING_TIME.add(Clock.systemDefaultZone().millis() - start);
+        PQVectors pqVectors = PQVectors.encodeAndBuild(pq, ravv.size(), ravv, computePool);
+        log.info(
+            "Encoded PQ vectors, original size: {} bytes, compressed size: {} bytes",
+            pqVectors.getOriginalSize(),
+            pqVectors.getCompressedSize()
+        );
+        return pqVectors;
     }
 
     private static LoadedState loadNVQState(
@@ -145,6 +214,13 @@ public sealed interface JVectorIndexQuantization {
     /** Reads back (and, for lossy schemes, dequantizes) the float vector stored for {@code ord} in {@code view}. */
     public abstract VectorFloat<?> vectorFloatValue(OnDiskGraphIndex.View view, int ord);
 
+    /**
+     * Compute compressed vectors and a build score provider from raw float vectors.
+     * Dispatches to the NVQ or PQ implementation based on the concrete type.
+     */
+    public abstract QuantizationResult quantize(RandomAccessVectorValues ravv, VectorSimilarityFunction vsf, ForkJoinPool computePool)
+        throws IOException;
+
     // -----------------------------------------------------------------------
     // NVQ implementation
     // -----------------------------------------------------------------------
@@ -182,12 +258,20 @@ public sealed interface JVectorIndexQuantization {
 
         @Override
         public byte quantizationType() {
-            return QUANTIZATION_TYPE_NVQ;
+            return QUANTIZATION_TYPE_NVQ_INLINE;
         }
 
         @Override
         public int numSubspaces(int dimension) {
             return numSubvectors;
+        }
+
+        @Override
+        public QuantizationResult quantize(RandomAccessVectorValues ravv, VectorSimilarityFunction vsf, ForkJoinPool computePool)
+            throws IOException {
+            NVQVectors nvqVectors = computeNvqVectors(numSubvectors, ravv, computePool);
+            PQVectors auxPqVectors = computePqVectors(ravv, vsf, PQ.defaultNumSubspaces(ravv.dimension()), computePool);
+            return new QuantizationResult(nvqVectors, auxPqVectors, BuildScoreProvider.pqBuildScoreProvider(vsf, auxPqVectors));
         }
 
         /**
@@ -323,6 +407,13 @@ public sealed interface JVectorIndexQuantization {
         @Override
         public int numSubspaces(int dimension) {
             return numSubspacesSupplier.apply(dimension);
+        }
+
+        @Override
+        public QuantizationResult quantize(RandomAccessVectorValues ravv, VectorSimilarityFunction vsf, ForkJoinPool computePool)
+            throws IOException {
+            PQVectors pqVectors = computePqVectors(ravv, vsf, numSubspaces(ravv.dimension()), computePool);
+            return new QuantizationResult(pqVectors, null, BuildScoreProvider.pqBuildScoreProvider(vsf, pqVectors));
         }
 
         /** PQ does not quantize the inline graph vectors; they are read back at full precision. */

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorIndexQuantization.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorIndexQuantization.java
@@ -5,6 +5,13 @@
 
 package org.opensearch.knn.index.codec.jvector;
 
+import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
+import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
+import io.github.jbellis.jvector.quantization.NVQuantization;
+import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import java.io.IOException;
 import java.util.function.Function;
 import org.opensearch.knn.common.KNNConstants;
 
@@ -18,7 +25,9 @@ import org.opensearch.knn.common.KNNConstants;
  * 1. PQ + full-precision vectors
  * 2. PQ + NVQ
  */
-public abstract class JVectorIndexQuantization {
+public sealed abstract class JVectorIndexQuantization {
+
+    static final VectorTypeSupport VECTOR_TYPE_SUPPORT = VectorizationProvider.getInstance().getVectorTypeSupport();
 
     /** String identifier used in REST params and on-disk serialization. */
     public abstract String getType();
@@ -26,15 +35,33 @@ public abstract class JVectorIndexQuantization {
     /** Returns the number of subspaces/subvectors to use for a vector of the given dimension. */
     public abstract int numSubspaces(int dimension);
 
+    /** Reads back (and, for lossy schemes, dequantizes) the float vector stored for {@code ord} in {@code view}. */
+    public abstract VectorFloat<?> vectorFloatValue(OnDiskGraphIndex.View view, int ord);
+
     // -----------------------------------------------------------------------
     // NVQ implementation
     // -----------------------------------------------------------------------
 
     public static final class NVQ extends JVectorIndexQuantization {
         private final int numSubvectors;
+        // Bound only when this instance is used to read back (dequantize) stored vectors; null at write/config time.
+        private final NVQuantization trainedQuantizer;
+        private final NVQuantization.QuantizedVector scratch;
 
         public NVQ(int numSubvectors) {
             this.numSubvectors = numSubvectors;
+            this.trainedQuantizer = null;
+            this.scratch = null;
+        }
+
+        /** Binds a trained {@link NVQuantization} so this instance can dequantize stored vectors. */
+        public NVQ(NVQuantization trainedQuantizer) {
+            this.numSubvectors = trainedQuantizer.subvectorSizesAndOffsets.length;
+            this.trainedQuantizer = trainedQuantizer;
+            this.scratch = NVQuantization.QuantizedVector.createEmpty(
+                trainedQuantizer.subvectorSizesAndOffsets,
+                trainedQuantizer.bitsPerDimension
+            );
         }
 
         public int getNumSubvectors() {
@@ -49,6 +76,23 @@ public abstract class JVectorIndexQuantization {
         @Override
         public int numSubspaces(int dimension) {
             return numSubvectors;
+        }
+
+        /**
+         * Dequantizes the NVQ-encoded bytes for {@code ord} back to approximate float values.
+         */
+        @Override
+        public VectorFloat<?> vectorFloatValue(OnDiskGraphIndex.View view, int ord) {
+            if (trainedQuantizer == null) {
+                throw new IllegalStateException("NVQ quantization is not bound to a trained quantizer; cannot dequantize");
+            }
+            try {
+                var reader = view.featureReaderForNode(ord, FeatureId.NVQ_VECTORS);
+                NVQuantization.QuantizedVector.loadInto(reader, scratch);
+                return nvqDequantize(scratch, trainedQuantizer);
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to dequantize NVQ inline vector for ordinal " + ord, e);
+            }
         }
 
         /**
@@ -68,6 +112,64 @@ public abstract class JVectorIndexQuantization {
          */
         public static int defaultNumSubvectors() {
             return 2;
+        }
+
+        // -------------------------------------------------------------------------
+        // NVQ dequantization helpers
+        // -------------------------------------------------------------------------
+
+        /**
+         * Reconstructs an approximate float vector from a {@link NVQuantization.QuantizedVector}.
+         *
+         * The inverse of the NVQ encoding is:
+         * <pre>
+         *   scaledValue   = b * logisticScale + logisticBias      (map byte → sigmoid domain)
+         *   reconstructed = logit(scaledValue) / scaledGrowthRate + scaledMidpoint
+         * </pre>
+         * followed by adding back the {@code globalMean} that was subtracted during encoding.
+         */
+        private static VectorFloat<?> nvqDequantize(NVQuantization.QuantizedVector qv, NVQuantization nvq) {
+            VectorFloat<?> result = VECTOR_TYPE_SUPPORT.createFloatVector(nvq.originalDimension);
+            int offset = 0;
+            for (NVQuantization.QuantizedSubVector sv : qv.subVectors) {
+                float delta = sv.maxValue - sv.minValue;
+                float scaledGrowthRate = sv.growthRate / delta;
+                float scaledMidpoint = sv.midpoint * delta;
+                float logisticBias = logisticNQT(sv.minValue, scaledGrowthRate, scaledMidpoint);
+                float logisticScale = (logisticNQT(sv.maxValue, scaledGrowthRate, scaledMidpoint) - logisticBias) / 255.0f;
+                float inverseScaledGrowthRate = 1.0f / scaledGrowthRate;
+
+                for (int d = 0; d < sv.originalDimensions; d++) {
+                    int b = Byte.toUnsignedInt(sv.bytes.get(d));
+                    float scaledValue = Math.fma(b, logisticScale, logisticBias);
+                    result.set(offset + d, logitNQT(scaledValue, inverseScaledGrowthRate, scaledMidpoint));
+                }
+                offset += sv.originalDimensions;
+            }
+            // Add back global mean (subtracted during encoding)
+            for (int i = 0; i < nvq.originalDimension; i++) {
+                result.set(i, result.get(i) + nvq.globalMean.get(i));
+            }
+            return result;
+        }
+
+        /** Fast logistic function used by NVQ (mirrors DefaultVectorUtilSupport.logisticFunctionNQT). */
+        private static float logisticNQT(float value, float alpha, float x0) {
+            float temp = Math.fma(value, alpha, -alpha * x0);
+            int p = Math.round(temp + 0.5f);
+            int m = Float.floatToIntBits(Math.fma(temp - p, 0.5f, 1));
+            temp = Float.intBitsToFloat(m + (p << 23));
+            return temp / (temp + 1);
+        }
+
+        /** Fast logit (inverse logistic) used by NVQ (mirrors DefaultVectorUtilSupport.logitNQT). */
+        private static float logitNQT(float scaledValue, float inverseAlpha, float x0) {
+            float z = scaledValue / (1 - scaledValue);
+            int temp = Float.floatToIntBits(z);
+            int e = temp & 0x7f800000;
+            float p = (float) ((e >> 23) - 128);
+            float m = Float.intBitsToFloat((temp & 0x007fffff) + 0x3f800000);
+            return (m + p) * inverseAlpha + x0;
         }
     }
 
@@ -104,6 +206,12 @@ public abstract class JVectorIndexQuantization {
         @Override
         public int numSubspaces(int dimension) {
             return numSubspacesSupplier.apply(dimension);
+        }
+
+        /** PQ does not quantize the inline graph vectors; they are read back at full precision. */
+        @Override
+        public VectorFloat<?> vectorFloatValue(OnDiskGraphIndex.View view, int ord) {
+            return view.getVector(ord);
         }
 
         /**

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorIndexQuantization.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorIndexQuantization.java
@@ -25,7 +25,7 @@ import org.opensearch.knn.common.KNNConstants;
  * 1. PQ + full-precision vectors
  * 2. PQ + NVQ
  */
-public sealed abstract class JVectorIndexQuantization {
+public sealed interface JVectorIndexQuantization {
 
     static final VectorTypeSupport VECTOR_TYPE_SUPPORT = VectorizationProvider.getInstance().getVectorTypeSupport();
 
@@ -42,7 +42,7 @@ public sealed abstract class JVectorIndexQuantization {
     // NVQ implementation
     // -----------------------------------------------------------------------
 
-    public static final class NVQ extends JVectorIndexQuantization {
+    public static final class NVQ implements JVectorIndexQuantization {
         private final int numSubvectors;
         // Bound only when this instance is used to read back (dequantize) stored vectors; null at write/config time.
         private final NVQuantization trainedQuantizer;
@@ -177,7 +177,7 @@ public sealed abstract class JVectorIndexQuantization {
     // PQ implementation
     // -----------------------------------------------------------------------
 
-    public static final class PQ extends JVectorIndexQuantization {
+    public static final class PQ implements JVectorIndexQuantization {
         private final Function<Integer, Integer> numSubspacesSupplier;
 
         public PQ(Function<Integer, Integer> numSubspacesSupplier) {

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorQuantizedNvqVectorValues.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorQuantizedNvqVectorValues.java
@@ -6,26 +6,20 @@
 package org.opensearch.knn.index.codec.jvector;
 
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
-import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
 import io.github.jbellis.jvector.quantization.NVQuantization;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
-import io.github.jbellis.jvector.vector.types.VectorFloat;
 import java.io.IOException;
 import org.apache.lucene.search.VectorScorer;
 
 /**
  * {@link org.apache.lucene.index.FloatVectorValues} implementation for NVQ-inline segments.
  *
- * <p>Vectors are stored as NVQ-quantized bytes inside the graph nodes and are dequantized back to
- * approximate float values on demand.  Because no full-precision vectors are available,
- * {@link #scorer(float[])} is not supported — filtered brute-force searches should not be issued
- * against NVQ-inline segments via this class.
+ * <p>Vectors are stored as NVQ-quantized bytes inside the graph nodes; dequantization back to
+ * approximate float values is delegated to {@link JVectorIndexQuantization.NVQ}. Because no
+ * full-precision vectors are available, {@link #scorer(float[])} is not supported — filtered
+ * brute-force searches should not be issued against NVQ-inline segments via this class.
  */
 public class JVectorQuantizedNvqVectorValues extends JVectorFloatVectorValues {
-
-    private final NVQuantization nvqInline;
-    // Reusable scratch buffer; access must be serialised by the caller.
-    private final NVQuantization.QuantizedVector nvqTemp;
 
     public JVectorQuantizedNvqVectorValues(
         OnDiskGraphIndex onDiskGraphIndex,
@@ -33,85 +27,11 @@ public class JVectorQuantizedNvqVectorValues extends JVectorFloatVectorValues {
         GraphNodeIdToDocMap graphNodeIdToDocMap,
         NVQuantization nvqInline
     ) throws IOException {
-        super(onDiskGraphIndex, similarityFunction, null, graphNodeIdToDocMap);
-        this.nvqInline = nvqInline;
-        this.nvqTemp = NVQuantization.QuantizedVector.createEmpty(nvqInline.subvectorSizesAndOffsets, nvqInline.bitsPerDimension);
-    }
-
-    /**
-     * Dequantizes the NVQ-encoded bytes for {@code ord} back to approximate float values.
-     */
-    @Override
-    public VectorFloat<?> vectorFloatValue(int ord) {
-        try {
-            var reader = getView().featureReaderForNode(ord, FeatureId.NVQ_VECTORS);
-            NVQuantization.QuantizedVector.loadInto(reader, nvqTemp);
-            return nvqDequantize(nvqTemp, nvqInline);
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to dequantize NVQ inline vector for ordinal " + ord, e);
-        }
+        super(onDiskGraphIndex, similarityFunction, null, graphNodeIdToDocMap, new JVectorIndexQuantization.NVQ(nvqInline));
     }
 
     @Override
     public VectorScorer scorer(float[] query) {
         throw new UnsupportedOperationException("vectorScorer() is not supported for NVQ-inline segments");
-    }
-
-    // -------------------------------------------------------------------------
-    // NVQ dequantization helpers
-    // -------------------------------------------------------------------------
-
-    /**
-     * Reconstructs an approximate float vector from a {@link NVQuantization.QuantizedVector}.
-     *
-     * The inverse of the NVQ encoding is:
-     * <pre>
-     *   scaledValue   = b * logisticScale + logisticBias      (map byte → sigmoid domain)
-     *   reconstructed = logit(scaledValue) / scaledGrowthRate + scaledMidpoint
-     * </pre>
-     * followed by adding back the {@code globalMean} that was subtracted during encoding.
-     */
-    private static VectorFloat<?> nvqDequantize(NVQuantization.QuantizedVector qv, NVQuantization nvq) {
-        VectorFloat<?> result = VECTOR_TYPE_SUPPORT.createFloatVector(nvq.originalDimension);
-        int offset = 0;
-        for (NVQuantization.QuantizedSubVector sv : qv.subVectors) {
-            float delta = sv.maxValue - sv.minValue;
-            float scaledGrowthRate = sv.growthRate / delta;
-            float scaledMidpoint = sv.midpoint * delta;
-            float logisticBias = logisticNQT(sv.minValue, scaledGrowthRate, scaledMidpoint);
-            float logisticScale = (logisticNQT(sv.maxValue, scaledGrowthRate, scaledMidpoint) - logisticBias) / 255.0f;
-            float inverseScaledGrowthRate = 1.0f / scaledGrowthRate;
-
-            for (int d = 0; d < sv.originalDimensions; d++) {
-                int b = Byte.toUnsignedInt(sv.bytes.get(d));
-                float scaledValue = Math.fma(b, logisticScale, logisticBias);
-                result.set(offset + d, logitNQT(scaledValue, inverseScaledGrowthRate, scaledMidpoint));
-            }
-            offset += sv.originalDimensions;
-        }
-        // Add back global mean (subtracted during encoding)
-        for (int i = 0; i < nvq.originalDimension; i++) {
-            result.set(i, result.get(i) + nvq.globalMean.get(i));
-        }
-        return result;
-    }
-
-    /** Fast logistic function used by NVQ (mirrors DefaultVectorUtilSupport.logisticFunctionNQT). */
-    private static float logisticNQT(float value, float alpha, float x0) {
-        float temp = Math.fma(value, alpha, -alpha * x0);
-        int p = Math.round(temp + 0.5f);
-        int m = Float.floatToIntBits(Math.fma(temp - p, 0.5f, 1));
-        temp = Float.intBitsToFloat(m + (p << 23));
-        return temp / (temp + 1);
-    }
-
-    /** Fast logit (inverse logistic) used by NVQ (mirrors DefaultVectorUtilSupport.logitNQT). */
-    private static float logitNQT(float scaledValue, float inverseAlpha, float x0) {
-        float z = scaledValue / (1 - scaledValue);
-        int temp = Float.floatToIntBits(z);
-        int e = temp & 0x7f800000;
-        float p = (float) ((e >> 23) - 128);
-        float m = Float.intBitsToFloat((temp & 0x007fffff) + 0x3f800000);
-        return (m + p) * inverseAlpha + x0;
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorQuantizedNvqVectorValues.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorQuantizedNvqVectorValues.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.jvector;
+
+import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
+import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
+import io.github.jbellis.jvector.quantization.NVQuantization;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import java.io.IOException;
+import org.apache.lucene.search.VectorScorer;
+
+/**
+ * {@link org.apache.lucene.index.FloatVectorValues} implementation for NVQ-inline segments.
+ *
+ * <p>Vectors are stored as NVQ-quantized bytes inside the graph nodes and are dequantized back to
+ * approximate float values on demand.  Because no full-precision vectors are available,
+ * {@link #scorer(float[])} is not supported — filtered brute-force searches should not be issued
+ * against NVQ-inline segments via this class.
+ */
+public class JVectorQuantizedNvqVectorValues extends JVectorFloatVectorValues {
+
+    private final NVQuantization nvqInline;
+    // Reusable scratch buffer; access must be serialised by the caller.
+    private final NVQuantization.QuantizedVector nvqTemp;
+
+    public JVectorQuantizedNvqVectorValues(
+        OnDiskGraphIndex onDiskGraphIndex,
+        VectorSimilarityFunction similarityFunction,
+        GraphNodeIdToDocMap graphNodeIdToDocMap,
+        NVQuantization nvqInline
+    ) throws IOException {
+        super(onDiskGraphIndex, similarityFunction, null, graphNodeIdToDocMap);
+        this.nvqInline = nvqInline;
+        this.nvqTemp = NVQuantization.QuantizedVector.createEmpty(nvqInline.subvectorSizesAndOffsets, nvqInline.bitsPerDimension);
+    }
+
+    /**
+     * Dequantizes the NVQ-encoded bytes for {@code ord} back to approximate float values.
+     */
+    @Override
+    public VectorFloat<?> vectorFloatValue(int ord) {
+        try {
+            var reader = getView().featureReaderForNode(ord, FeatureId.NVQ_VECTORS);
+            NVQuantization.QuantizedVector.loadInto(reader, nvqTemp);
+            return nvqDequantize(nvqTemp, nvqInline);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to dequantize NVQ inline vector for ordinal " + ord, e);
+        }
+    }
+
+    @Override
+    public VectorScorer scorer(float[] query) {
+        throw new UnsupportedOperationException("vectorScorer() is not supported for NVQ-inline segments");
+    }
+
+    // -------------------------------------------------------------------------
+    // NVQ dequantization helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Reconstructs an approximate float vector from a {@link NVQuantization.QuantizedVector}.
+     *
+     * The inverse of the NVQ encoding is:
+     * <pre>
+     *   scaledValue   = b * logisticScale + logisticBias      (map byte → sigmoid domain)
+     *   reconstructed = logit(scaledValue) / scaledGrowthRate + scaledMidpoint
+     * </pre>
+     * followed by adding back the {@code globalMean} that was subtracted during encoding.
+     */
+    private static VectorFloat<?> nvqDequantize(NVQuantization.QuantizedVector qv, NVQuantization nvq) {
+        VectorFloat<?> result = VECTOR_TYPE_SUPPORT.createFloatVector(nvq.originalDimension);
+        int offset = 0;
+        for (NVQuantization.QuantizedSubVector sv : qv.subVectors) {
+            float delta = sv.maxValue - sv.minValue;
+            float scaledGrowthRate = sv.growthRate / delta;
+            float scaledMidpoint = sv.midpoint * delta;
+            float logisticBias = logisticNQT(sv.minValue, scaledGrowthRate, scaledMidpoint);
+            float logisticScale = (logisticNQT(sv.maxValue, scaledGrowthRate, scaledMidpoint) - logisticBias) / 255.0f;
+            float inverseScaledGrowthRate = 1.0f / scaledGrowthRate;
+
+            for (int d = 0; d < sv.originalDimensions; d++) {
+                int b = Byte.toUnsignedInt(sv.bytes.get(d));
+                float scaledValue = Math.fma(b, logisticScale, logisticBias);
+                result.set(offset + d, logitNQT(scaledValue, inverseScaledGrowthRate, scaledMidpoint));
+            }
+            offset += sv.originalDimensions;
+        }
+        // Add back global mean (subtracted during encoding)
+        for (int i = 0; i < nvq.originalDimension; i++) {
+            result.set(i, result.get(i) + nvq.globalMean.get(i));
+        }
+        return result;
+    }
+
+    /** Fast logistic function used by NVQ (mirrors DefaultVectorUtilSupport.logisticFunctionNQT). */
+    private static float logisticNQT(float value, float alpha, float x0) {
+        float temp = Math.fma(value, alpha, -alpha * x0);
+        int p = Math.round(temp + 0.5f);
+        int m = Float.floatToIntBits(Math.fma(temp - p, 0.5f, 1));
+        temp = Float.intBitsToFloat(m + (p << 23));
+        return temp / (temp + 1);
+    }
+
+    /** Fast logit (inverse logistic) used by NVQ (mirrors DefaultVectorUtilSupport.logitNQT). */
+    private static float logitNQT(float scaledValue, float inverseAlpha, float x0) {
+        float z = scaledValue / (1 - scaledValue);
+        int temp = Float.floatToIntBits(z);
+        int e = temp & 0x7f800000;
+        float p = (float) ((e >> 23) - 128);
+        float m = Float.intBitsToFloat((temp & 0x007fffff) + 0x3f800000);
+        return (m + p) * inverseAlpha + x0;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
@@ -150,7 +150,7 @@ public class JVectorReader extends KnnVectorsReader {
 
         try (var view = index.getView()) {
             final long graphSearchStart = System.currentTimeMillis();
-            final SearchScoreProvider ssp = fieldEntry.buildSSP(q, view);
+            final SearchScoreProvider ssp = fieldEntry.buildScoreFunctionProvider(q, view);
             final GraphNodeIdToDocMap jvectorLuceneDocMap = fieldEntry.graphNodeIdToDocMap;
             // Convert the acceptDocs bitmap from Lucene to jVector ordinal bitmap filter
             // Logic works as follows: if acceptDocs is null, we accept all ordinals. Otherwise, we check if the jVector ordinal has a
@@ -350,7 +350,7 @@ public class JVectorReader extends KnnVectorsReader {
             }
         }
 
-        SearchScoreProvider buildSSP(VectorFloat<?> q, OnDiskGraphIndex.View view) {
+        SearchScoreProvider buildScoreFunctionProvider(VectorFloat<?> q, OnDiskGraphIndex.View view) {
             if (pqVectors != null) {
                 ScoreFunction.ApproximateScoreFunction asf = pqVectors.precomputedScoreFunctionFor(q, similarityFunction);
                 ScoreFunction.ExactScoreFunction reranker = view.rerankerFor(q, similarityFunction);

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
@@ -13,6 +13,8 @@ import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
 import io.github.jbellis.jvector.graph.similarity.DefaultSearchScoreProvider;
 import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
 import io.github.jbellis.jvector.graph.similarity.SearchScoreProvider;
+import io.github.jbellis.jvector.quantization.NVQVectors;
+import io.github.jbellis.jvector.quantization.NVQuantization;
 import io.github.jbellis.jvector.quantization.PQVectors;
 import io.github.jbellis.jvector.quantization.ProductQuantization;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
@@ -60,7 +62,7 @@ public class JVectorReader extends KnnVectorsReader {
         this.directory = state.directory;
         boolean success = false;
         try (ChecksumIndexInput meta = state.directory.openChecksumInput(metaFileName)) {
-            CodecUtil.checkIndexHeader(
+            final int version = CodecUtil.checkIndexHeader(
                 meta,
                 JVectorFormat.META_CODEC_NAME,
                 JVectorFormat.VERSION_START,
@@ -68,7 +70,7 @@ public class JVectorReader extends KnnVectorsReader {
                 state.segmentInfo.getId(),
                 state.segmentSuffix
             );
-            readFields(meta);
+            readFields(meta, version);
             CodecUtil.checkFooter(meta);
 
             success = true;
@@ -122,6 +124,15 @@ public class JVectorReader extends KnnVectorsReader {
         return Optional.of(fieldEntry.pqVectors.getCompressor());
     }
 
+    public Optional<NVQuantization> getNVQuantizationForField(String field) throws IOException {
+        final FieldEntry fieldEntry = fieldEntryMap.get(field);
+        if (fieldEntry.nvqVectors == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(fieldEntry.nvqVectors.getNVQuantization());
+    }
+
     public RandomAccessReader getNeighborsScoreCacheForField(String field) throws IOException {
         final FieldEntry fieldEntry = fieldEntryMap.get(field);
         return fieldEntry.neighborsScoreCacheIndexReaderSupplier.get();
@@ -161,23 +172,21 @@ public class JVectorReader extends KnnVectorsReader {
 
         try (var view = index.getView()) {
             final long graphSearchStart = System.currentTimeMillis();
-            if (fieldEntryMap.get(field).pqVectors != null) { // Quantized, use the precomputed score function
-                final PQVectors pqVectors = fieldEntryMap.get(field).pqVectors;
-                // SearchScoreProvider that does a first pass with the loaded-in-memory PQVectors,
+            final FieldEntry fe = fieldEntryMap.get(field);
+            if (fe.pqVectors != null || fe.nvqVectors != null) { // Quantized, use the precomputed score function
+                final var compressedVectors = fe.pqVectors != null ? fe.pqVectors : fe.nvqVectors;
+                // SearchScoreProvider that does a first pass with the loaded-in-memory compressed vectors,
                 // then reranks with the exact vectors that are stored on disk in the index
-                ScoreFunction.ApproximateScoreFunction asf = pqVectors.precomputedScoreFunctionFor(q, vectorSimilarityFunction);
-                ScoreFunction.ExactScoreFunction reranker = wrapExactScoreFunction(
-                    view.rerankerFor(q, vectorSimilarityFunction),
-                    luceneSimilarityFunction,
-                    vectorSimilarityFunction
+                ScoreFunction.ApproximateScoreFunction asf = compressedVectors.precomputedScoreFunctionFor(
+                    q,
+                    fe.similarityFunction
                 );
+                ScoreFunction.ExactScoreFunction reranker = view.rerankerFor(q, fe.similarityFunction);
                 ssp = new DefaultSearchScoreProvider(asf, reranker);
             } else { // Not quantized, used typical searcher
-                ScoreFunction.ExactScoreFunction esf = DefaultSearchScoreProvider.exact(q, vectorSimilarityFunction, view)
-                    .exactScoreFunction();
-                ssp = new DefaultSearchScoreProvider(wrapExactScoreFunction(esf, luceneSimilarityFunction, vectorSimilarityFunction));
+                ssp = DefaultSearchScoreProvider.exact(q, fe.similarityFunction, view);
             }
-            final GraphNodeIdToDocMap jvectorLuceneDocMap = fieldEntryMap.get(field).graphNodeIdToDocMap;
+            final GraphNodeIdToDocMap jvectorLuceneDocMap = fe.graphNodeIdToDocMap;
             // Convert the acceptDocs bitmap from Lucene to jVector ordinal bitmap filter
             // Logic works as follows: if acceptDocs is null, we accept all ordinals. Otherwise, we check if the jVector ordinal has a
             // corresponding Lucene doc ID accepted by acceptDocs filter.
@@ -279,10 +288,10 @@ public class JVectorReader extends KnnVectorsReader {
         fieldEntryMap.clear();
     }
 
-    private void readFields(ChecksumIndexInput meta) throws IOException {
+    private void readFields(ChecksumIndexInput meta, int version) throws IOException {
         for (int fieldNumber = meta.readInt(); fieldNumber != -1; fieldNumber = meta.readInt()) {
             final FieldInfo fieldInfo = fieldInfos.fieldInfo(fieldNumber); // read field number
-            JVectorWriter.VectorIndexFieldMetadata vectorIndexFieldMetadata = new JVectorWriter.VectorIndexFieldMetadata(meta);
+            JVectorWriter.VectorIndexFieldMetadata vectorIndexFieldMetadata = new JVectorWriter.VectorIndexFieldMetadata(meta, version);
             assert fieldInfo.number == vectorIndexFieldMetadata.getFieldNumber();
             fieldEntryMap.put(fieldInfo.name, new FieldEntry(fieldInfo, vectorIndexFieldMetadata));
         }
@@ -295,16 +304,17 @@ public class JVectorReader extends KnnVectorsReader {
         private final int dimension;
         private final long vectorIndexOffset;
         private final long vectorIndexLength;
-        private final long pqCodebooksAndVectorsLength;
-        private final long pqCodebooksAndVectorsOffset;
+        private final long compressedVectorsLength;
+        private final long compressedVectorsOffset;
         private final String vectorIndexFieldDataFileName;
         private final String neighborsScoreCacheIndexFieldFileName;
         private final GraphNodeIdToDocMap graphNodeIdToDocMap;
         private final ReaderSupplier indexReaderSupplier;
-        private final ReaderSupplier pqCodebooksReaderSupplier;
+        private final ReaderSupplier compressedVectorsReaderSupplier;
         private final ReaderSupplier neighborsScoreCacheIndexReaderSupplier;
         private final OnDiskGraphIndex index;
-        private final PQVectors pqVectors; // The product quantized vectors with their codebooks
+        private final PQVectors pqVectors; // non-null when quantizationType == PQ
+        private final NVQVectors nvqVectors; // non-null when quantizationType == NVQ
 
         public FieldEntry(FieldInfo fieldInfo, JVectorWriter.VectorIndexFieldMetadata vectorIndexFieldMetadata) throws IOException {
             this.fieldInfo = fieldInfo;
@@ -314,8 +324,8 @@ public class JVectorReader extends KnnVectorsReader {
             this.vectorEncoding = vectorIndexFieldMetadata.getVectorEncoding();
             this.vectorIndexOffset = vectorIndexFieldMetadata.getVectorIndexOffset();
             this.vectorIndexLength = vectorIndexFieldMetadata.getVectorIndexLength();
-            this.pqCodebooksAndVectorsLength = vectorIndexFieldMetadata.getPqCodebooksAndVectorsLength();
-            this.pqCodebooksAndVectorsOffset = vectorIndexFieldMetadata.getPqCodebooksAndVectorsOffset();
+            this.compressedVectorsLength = vectorIndexFieldMetadata.getCompressedVectorsLength();
+            this.compressedVectorsOffset = vectorIndexFieldMetadata.getCompressedVectorsOffset();
             this.dimension = vectorIndexFieldMetadata.getVectorDimension();
             this.graphNodeIdToDocMap = vectorIndexFieldMetadata.getGraphNodeIdToDocMap();
 
@@ -340,28 +350,35 @@ public class JVectorReader extends KnnVectorsReader {
             );
             this.index = OnDiskGraphIndex.load(indexReaderSupplier, vectorIndexOffset);
 
-            // If quantized load the compressed product quantized vectors with their codebooks
-            if (pqCodebooksAndVectorsLength > 0) {
-                assert pqCodebooksAndVectorsOffset > 0;
-                if (pqCodebooksAndVectorsOffset < vectorIndexOffset) {
-                    throw new IllegalArgumentException("pqCodebooksAndVectorsOffset must be greater than vectorIndexOffset");
+            // Load compressed vectors if present
+            if (compressedVectorsLength > 0) {
+                assert compressedVectorsOffset > 0;
+                if (compressedVectorsOffset < vectorIndexOffset) {
+                    throw new IllegalArgumentException("compressedVectorsOffset must be greater than vectorIndexOffset");
                 }
-                this.pqCodebooksReaderSupplier = new JVectorRandomAccessReader.Supplier(
+                this.compressedVectorsReaderSupplier = new JVectorRandomAccessReader.Supplier(
                     directory.openInput(vectorIndexFieldDataFileName, IOContext.READONCE),
-                    pqCodebooksAndVectorsOffset,
-                    pqCodebooksAndVectorsLength
+                    compressedVectorsOffset,
+                    compressedVectorsLength
                 );
-                log.debug(
-                    "Loading PQ codebooks and vectors for field {}, with numbers of vectors: {}",
-                    fieldInfo.name,
-                    state.segmentInfo.maxDoc()
-                );
-                try (final var randomAccessReader = pqCodebooksReaderSupplier.get()) {
-                    this.pqVectors = PQVectors.load(randomAccessReader);
+                final byte qType = vectorIndexFieldMetadata.getQuantizationType();
+                if (qType == JVectorWriter.QUANTIZATION_TYPE_NVQ) {
+                    log.debug("Loading NVQ vectors for field {}", fieldInfo.name);
+                    try (final var randomAccessReader = compressedVectorsReaderSupplier.get()) {
+                        this.nvqVectors = NVQVectors.load(randomAccessReader);
+                    }
+                    this.pqVectors = null;
+                } else {
+                    log.debug("Loading PQ codebooks and vectors for field {}", fieldInfo.name);
+                    try (final var randomAccessReader = compressedVectorsReaderSupplier.get()) {
+                        this.pqVectors = PQVectors.load(randomAccessReader);
+                    }
+                    this.nvqVectors = null;
                 }
             } else {
-                this.pqCodebooksReaderSupplier = null;
+                this.compressedVectorsReaderSupplier = null;
                 this.pqVectors = null;
+                this.nvqVectors = null;
             }
 
             final IndexInput indexInput = directory.openInput(neighborsScoreCacheIndexFieldFileName, state.context);
@@ -375,8 +392,8 @@ public class JVectorReader extends KnnVectorsReader {
             if (indexReaderSupplier != null) {
                 IOUtils.close(indexReaderSupplier::close);
             }
-            if (pqCodebooksReaderSupplier != null) {
-                IOUtils.close(pqCodebooksReaderSupplier::close);
+            if (compressedVectorsReaderSupplier != null) {
+                IOUtils.close(compressedVectorsReaderSupplier::close);
             }
             if (neighborsScoreCacheIndexReaderSupplier != null) {
                 IOUtils.close(neighborsScoreCacheIndexReaderSupplier::close);

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
@@ -24,6 +24,7 @@ import io.github.jbellis.jvector.vector.types.VectorFloat;
 import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 import java.io.Closeable;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,15 +40,6 @@ import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.IOUtils;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.plugin.stats.KNNCounter;
-
-import java.io.Closeable;
-import java.io.IOException;
-import java.lang.reflect.Field;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 @Log4j2
 public class JVectorReader extends KnnVectorsReader {
@@ -110,7 +102,7 @@ public class JVectorReader extends KnnVectorsReader {
     public FloatVectorValues getFloatVectorValues(String field) throws IOException {
         final FieldEntry fieldEntry = fieldEntryMap.get(field);
         if (fieldEntry.nvqInlineQuantization != null) {
-            return new JVectorFloatVectorValues(
+            return new JVectorQuantizedNvqVectorValues(
                 fieldEntry.index,
                 fieldEntry.similarityFunction,
                 fieldEntry.graphNodeIdToDocMap,
@@ -141,11 +133,6 @@ public class JVectorReader extends KnnVectorsReader {
         }
 
         return Optional.of(fieldEntry.pqVectors.getCompressor());
-    }
-
-    public Optional<NVQuantization> getNVQuantizationForField(String field) throws IOException {
-        final FieldEntry fieldEntry = fieldEntryMap.get(field);
-        return Optional.ofNullable(fieldEntry.nvqInlineQuantization);
     }
 
     public RandomAccessReader getNeighborsScoreCacheForField(String field) throws IOException {
@@ -329,7 +316,7 @@ public class JVectorReader extends KnnVectorsReader {
         private final OnDiskGraphIndex index;
         private final PQVectors pqVectors; // non-null when a PQ blob is present (PQ-only or NVQ+PQ)
         // NVQuantization extracted from the graph when NVQ is stored inline; null otherwise
-        final NVQuantization nvqInlineQuantization;
+        private final NVQuantization nvqInlineQuantization;
 
         public FieldEntry(FieldInfo fieldInfo, JVectorWriter.VectorIndexFieldMetadata vectorIndexFieldMetadata) throws IOException {
             this.fieldInfo = fieldInfo;

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
@@ -110,12 +110,21 @@ public class JVectorReader extends KnnVectorsReader {
     @Override
     public FloatVectorValues getFloatVectorValues(String field) throws IOException {
         final FieldEntry fieldEntry = fieldEntryMap.get(field);
-        return new JVectorFloatVectorValues(
-            fieldEntry.index,
-            fieldEntry.similarityFunction,
-            fieldEntry.graphNodeIdToDocMap,
-            fieldEntry.nvqInlineQuantization
-        );
+        if (fieldEntry.nvqInlineQuantization != null) {
+            return new JVectorFloatVectorValues(
+                fieldEntry.index,
+                fieldEntry.similarityFunction,
+                fieldEntry.graphNodeIdToDocMap,
+                fieldEntry.nvqInlineQuantization
+            );
+        } else {
+            return new JVectorFloatVectorValues(
+                fieldEntry.index,
+                fieldEntry.similarityFunction,
+                fieldEntry.fieldInfo.getVectorSimilarityFunction(),
+                fieldEntry.graphNodeIdToDocMap
+            );
+        }
     }
 
     @Override
@@ -185,12 +194,14 @@ public class JVectorReader extends KnnVectorsReader {
                 ScoreFunction.ApproximateScoreFunction asf = fe.pqVectors.precomputedScoreFunctionFor(q, fe.similarityFunction);
                 ScoreFunction.ExactScoreFunction reranker = view.rerankerFor(q, fe.similarityFunction);
                 ssp = new DefaultSearchScoreProvider(asf, reranker);
-            } else if (fe.nvqInlineQuantization != null) { // NVQ inline without PQ blob
-                ssp = new DefaultSearchScoreProvider(view.rerankerFor(q, fe.similarityFunction));
-            } else {
-                ssp = DefaultSearchScoreProvider.exact(q, fe.similarityFunction, view);
+            } else if (fieldEntry.nvqInlineQuantization != null) { // NVQ inline without PQ blob
+                ssp = new DefaultSearchScoreProvider(view.rerankerFor(q, vectorSimilarityFunction));
+            } else { // Not quantized, used typical searcher
+                ScoreFunction.ExactScoreFunction esf = DefaultSearchScoreProvider.exact(q, vectorSimilarityFunction, view)
+                    .exactScoreFunction();
+                ssp = new DefaultSearchScoreProvider(wrapExactScoreFunction(esf, luceneSimilarityFunction, vectorSimilarityFunction));
             }
-            final GraphNodeIdToDocMap jvectorLuceneDocMap = fe.graphNodeIdToDocMap;
+            final GraphNodeIdToDocMap jvectorLuceneDocMap = fieldEntry.graphNodeIdToDocMap;
             // Convert the acceptDocs bitmap from Lucene to jVector ordinal bitmap filter
             // Logic works as follows: if acceptDocs is null, we accept all ordinals. Otherwise, we check if the jVector ordinal has a
             // corresponding Lucene doc ID accepted by acceptDocs filter.

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
@@ -10,8 +10,6 @@ import io.github.jbellis.jvector.disk.ReaderSupplier;
 import io.github.jbellis.jvector.graph.GraphSearcher;
 import io.github.jbellis.jvector.graph.SearchResult;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
-import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
-import io.github.jbellis.jvector.graph.disk.feature.NVQ;
 import io.github.jbellis.jvector.graph.similarity.DefaultSearchScoreProvider;
 import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
 import io.github.jbellis.jvector.graph.similarity.SearchScoreProvider;
@@ -24,7 +22,6 @@ import io.github.jbellis.jvector.vector.types.VectorFloat;
 import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 import java.io.Closeable;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -321,45 +318,18 @@ public class JVectorReader extends KnnVectorsReader {
 
             // Load compressed vectors if present
             final byte qType = vectorIndexFieldMetadata.getQuantizationType();
-            if (qType == JVectorWriter.QUANTIZATION_TYPE_NVQ_INLINE) {
-                log.debug("NVQ vectors stored inline in graph for field {}", fieldInfo.name);
-                this.nvqInlineQuantization = extractNVQuantizationFromGraph(this.index);
-                if (compressedVectorsLength > 0) {
-                    // PQ blob alongside NVQ inline graph — used for approximate search traversal
-                    assert compressedVectorsOffset > 0;
-                    log.debug("Loading auxiliary PQ blob for NVQ field {}", fieldInfo.name);
-                    this.compressedVectorsReaderSupplier = new JVectorRandomAccessReader.Supplier(
-                        directory.openInput(vectorIndexFieldDataFileName, IOContext.READONCE),
-                        compressedVectorsOffset,
-                        compressedVectorsLength
-                    );
-                    try (final var randomAccessReader = compressedVectorsReaderSupplier.get()) {
-                        this.pqVectors = PQVectors.load(randomAccessReader);
-                    }
-                } else {
-                    this.compressedVectorsReaderSupplier = null;
-                    this.pqVectors = null;
-                }
-            } else if (compressedVectorsLength > 0) {
-                assert compressedVectorsOffset > 0;
-                if (compressedVectorsOffset < vectorIndexOffset) {
-                    throw new IllegalArgumentException("compressedVectorsOffset must be greater than vectorIndexOffset");
-                }
-                log.debug("Loading PQ codebooks and vectors for field {}", fieldInfo.name);
-                this.compressedVectorsReaderSupplier = new JVectorRandomAccessReader.Supplier(
-                    directory.openInput(vectorIndexFieldDataFileName, IOContext.READONCE),
-                    compressedVectorsOffset,
-                    compressedVectorsLength
-                );
-                try (final var randomAccessReader = compressedVectorsReaderSupplier.get()) {
-                    this.pqVectors = PQVectors.load(randomAccessReader);
-                }
-                this.nvqInlineQuantization = null;
-            } else {
-                this.compressedVectorsReaderSupplier = null;
-                this.pqVectors = null;
-                this.nvqInlineQuantization = null;
-            }
+            var qs = JVectorIndexQuantization.loadQuantizationState(
+                qType,
+                this.index,
+                directory,
+                vectorIndexFieldDataFileName,
+                compressedVectorsOffset,
+                compressedVectorsLength,
+                vectorIndexOffset
+            );
+            this.nvqInlineQuantization = qs.nvqInlineQuantization();
+            this.pqVectors = qs.pqVectors();
+            this.compressedVectorsReaderSupplier = qs.compressedVectorsReaderSupplier();
 
             final IndexInput indexInput = directory.openInput(neighborsScoreCacheIndexFieldFileName, state.context);
             CodecUtil.readIndexHeader(indexInput);
@@ -392,24 +362,6 @@ public class JVectorReader extends KnnVectorsReader {
                 return new DefaultSearchScoreProvider(
                     wrapExactScoreFunction(esf, fieldInfo.getVectorSimilarityFunction(), similarityFunction)
                 );
-            }
-        }
-
-        /**
-         * Extracts the {@link NVQuantization} object from the {@link NVQ} feature stored in the given graph index.
-         * This is needed so that the merge path can dequantize NVQ-inline vectors back to float.
-         */
-        private static NVQuantization extractNVQuantizationFromGraph(OnDiskGraphIndex index) throws IOException {
-            NVQ nvqFeature = (NVQ) index.getFeatures().get(FeatureId.NVQ_VECTORS);
-            if (nvqFeature == null) {
-                return null;
-            }
-            try {
-                Field nvqField = NVQ.class.getDeclaredField("nvq");
-                nvqField.setAccessible(true);
-                return (NVQuantization) nvqField.get(nvqFeature);
-            } catch (NoSuchFieldException | IllegalAccessException e) {
-                throw new IOException("Unable to extract NVQuantization from NVQ feature via reflection", e);
             }
         }
 

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
@@ -49,7 +49,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-
 @Log4j2
 public class JVectorReader extends KnnVectorsReader {
     private static final VectorTypeSupport VECTOR_TYPE_SUPPORT = VectorizationProvider.getInstance().getVectorTypeSupport();

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
@@ -15,7 +15,6 @@ import io.github.jbellis.jvector.graph.disk.feature.NVQ;
 import io.github.jbellis.jvector.graph.similarity.DefaultSearchScoreProvider;
 import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
 import io.github.jbellis.jvector.graph.similarity.SearchScoreProvider;
-import io.github.jbellis.jvector.quantization.NVQVectors;
 import io.github.jbellis.jvector.quantization.NVQuantization;
 import io.github.jbellis.jvector.quantization.PQVectors;
 import io.github.jbellis.jvector.quantization.ProductQuantization;
@@ -138,11 +137,7 @@ public class JVectorReader extends KnnVectorsReader {
 
     public Optional<NVQuantization> getNVQuantizationForField(String field) throws IOException {
         final FieldEntry fieldEntry = fieldEntryMap.get(field);
-        if (fieldEntry.nvqVectors == null) {
-            return Optional.empty();
-        }
-
-        return Optional.of(fieldEntry.nvqVectors.getNVQuantization());
+        return Optional.ofNullable(fieldEntry.nvqInlineQuantization);
     }
 
     public RandomAccessReader getNeighborsScoreCacheForField(String field) throws IOException {
@@ -185,20 +180,14 @@ public class JVectorReader extends KnnVectorsReader {
         try (var view = index.getView()) {
             final long graphSearchStart = System.currentTimeMillis();
             final FieldEntry fe = fieldEntryMap.get(field);
-            if (fe.pqVectors != null || fe.nvqVectors != null) { // Quantized, use the precomputed score function
-                final var compressedVectors = fe.pqVectors != null ? fe.pqVectors : fe.nvqVectors;
-                // SearchScoreProvider that does a first pass with the loaded-in-memory compressed vectors,
-                // then reranks with the exact vectors that are stored on disk in the index
-                ScoreFunction.ApproximateScoreFunction asf = compressedVectors.precomputedScoreFunctionFor(
-                    q,
-                    fe.similarityFunction
-                );
+            if (fe.pqVectors != null) {
+                // PQ blob as approximate first pass; reranker reads inline vectors (NVQ or full-precision)
+                ScoreFunction.ApproximateScoreFunction asf = fe.pqVectors.precomputedScoreFunctionFor(q, fe.similarityFunction);
                 ScoreFunction.ExactScoreFunction reranker = view.rerankerFor(q, fe.similarityFunction);
                 ssp = new DefaultSearchScoreProvider(asf, reranker);
-            } else if (fe.nvqVectorsInline) { // NVQ stored inline in graph nodes — use reranker backed by NVQ inline
-                ScoreFunction.ExactScoreFunction nvqReranker = view.rerankerFor(q, fe.similarityFunction);
-                ssp = new DefaultSearchScoreProvider(nvqReranker);
-            } else { // Not quantized, used typical searcher
+            } else if (fe.nvqInlineQuantization != null) { // NVQ inline without PQ blob
+                ssp = new DefaultSearchScoreProvider(view.rerankerFor(q, fe.similarityFunction));
+            } else {
                 ssp = DefaultSearchScoreProvider.exact(q, fe.similarityFunction, view);
             }
             final GraphNodeIdToDocMap jvectorLuceneDocMap = fe.graphNodeIdToDocMap;
@@ -328,10 +317,8 @@ public class JVectorReader extends KnnVectorsReader {
         private final ReaderSupplier compressedVectorsReaderSupplier;
         private final ReaderSupplier neighborsScoreCacheIndexReaderSupplier;
         private final OnDiskGraphIndex index;
-        private final PQVectors pqVectors; // non-null when quantizationType == PQ
-        private final NVQVectors nvqVectors; // non-null when quantizationType == NVQ (separate blob)
-        private final boolean nvqVectorsInline; // true when NVQ vectors are stored inline in the graph
-        // NVQuantization extracted from the graph's NVQ feature; non-null only when nvqVectorsInline == true
+        private final PQVectors pqVectors; // non-null when a PQ blob is present (PQ-only or NVQ+PQ)
+        // NVQuantization extracted from the graph when NVQ is stored inline; null otherwise
         final NVQuantization nvqInlineQuantization;
 
         public FieldEntry(FieldInfo fieldInfo, JVectorWriter.VectorIndexFieldMetadata vectorIndexFieldMetadata) throws IOException {
@@ -370,42 +357,44 @@ public class JVectorReader extends KnnVectorsReader {
 
             // Load compressed vectors if present
             final byte qType = vectorIndexFieldMetadata.getQuantizationType();
-            if (compressedVectorsLength > 0) {
+            if (qType == JVectorWriter.QUANTIZATION_TYPE_NVQ_INLINE) {
+                log.debug("NVQ vectors stored inline in graph for field {}", fieldInfo.name);
+                this.nvqInlineQuantization = extractNVQuantizationFromGraph(this.index);
+                if (compressedVectorsLength > 0) {
+                    // PQ blob alongside NVQ inline graph — used for approximate search traversal
+                    assert compressedVectorsOffset > 0;
+                    log.debug("Loading auxiliary PQ blob for NVQ field {}", fieldInfo.name);
+                    this.compressedVectorsReaderSupplier = new JVectorRandomAccessReader.Supplier(
+                        directory.openInput(vectorIndexFieldDataFileName, IOContext.READONCE),
+                        compressedVectorsOffset,
+                        compressedVectorsLength
+                    );
+                    try (final var randomAccessReader = compressedVectorsReaderSupplier.get()) {
+                        this.pqVectors = PQVectors.load(randomAccessReader);
+                    }
+                } else {
+                    this.compressedVectorsReaderSupplier = null;
+                    this.pqVectors = null;
+                }
+            } else if (compressedVectorsLength > 0) {
                 assert compressedVectorsOffset > 0;
                 if (compressedVectorsOffset < vectorIndexOffset) {
                     throw new IllegalArgumentException("compressedVectorsOffset must be greater than vectorIndexOffset");
                 }
+                log.debug("Loading PQ codebooks and vectors for field {}", fieldInfo.name);
                 this.compressedVectorsReaderSupplier = new JVectorRandomAccessReader.Supplier(
                     directory.openInput(vectorIndexFieldDataFileName, IOContext.READONCE),
                     compressedVectorsOffset,
                     compressedVectorsLength
                 );
-                if (qType == JVectorWriter.QUANTIZATION_TYPE_NVQ) {
-                    log.debug("Loading NVQ vectors for field {}", fieldInfo.name);
-                    try (final var randomAccessReader = compressedVectorsReaderSupplier.get()) {
-                        this.nvqVectors = NVQVectors.load(randomAccessReader);
-                    }
-                    this.pqVectors = null;
-                } else {
-                    log.debug("Loading PQ codebooks and vectors for field {}", fieldInfo.name);
-                    try (final var randomAccessReader = compressedVectorsReaderSupplier.get()) {
-                        this.pqVectors = PQVectors.load(randomAccessReader);
-                    }
-                    this.nvqVectors = null;
+                try (final var randomAccessReader = compressedVectorsReaderSupplier.get()) {
+                    this.pqVectors = PQVectors.load(randomAccessReader);
                 }
-                this.nvqVectorsInline = false;
                 this.nvqInlineQuantization = null;
             } else {
                 this.compressedVectorsReaderSupplier = null;
                 this.pqVectors = null;
-                this.nvqVectors = null;
-                this.nvqVectorsInline = (qType == JVectorWriter.QUANTIZATION_TYPE_NVQ_INLINE);
-                if (this.nvqVectorsInline) {
-                    log.debug("NVQ vectors stored inline in graph for field {}", fieldInfo.name);
-                    this.nvqInlineQuantization = extractNVQuantizationFromGraph(this.index);
-                } else {
-                    this.nvqInlineQuantization = null;
-                }
+                this.nvqInlineQuantization = null;
             }
 
             final IndexInput indexInput = directory.openInput(neighborsScoreCacheIndexFieldFileName, state.context);

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
@@ -10,6 +10,8 @@ import io.github.jbellis.jvector.disk.ReaderSupplier;
 import io.github.jbellis.jvector.graph.GraphSearcher;
 import io.github.jbellis.jvector.graph.SearchResult;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
+import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
+import io.github.jbellis.jvector.graph.disk.feature.NVQ;
 import io.github.jbellis.jvector.graph.similarity.DefaultSearchScoreProvider;
 import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
 import io.github.jbellis.jvector.graph.similarity.SearchScoreProvider;
@@ -38,6 +40,16 @@ import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.IOUtils;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.plugin.stats.KNNCounter;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.reflect.Field;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 
 @Log4j2
 public class JVectorReader extends KnnVectorsReader {
@@ -102,8 +114,8 @@ public class JVectorReader extends KnnVectorsReader {
         return new JVectorFloatVectorValues(
             fieldEntry.index,
             fieldEntry.similarityFunction,
-            fieldEntry.fieldInfo.getVectorSimilarityFunction(),
-            fieldEntry.graphNodeIdToDocMap
+            fieldEntry.graphNodeIdToDocMap,
+            fieldEntry.nvqInlineQuantization
         );
     }
 
@@ -183,6 +195,9 @@ public class JVectorReader extends KnnVectorsReader {
                 );
                 ScoreFunction.ExactScoreFunction reranker = view.rerankerFor(q, fe.similarityFunction);
                 ssp = new DefaultSearchScoreProvider(asf, reranker);
+            } else if (fe.nvqVectorsInline) { // NVQ stored inline in graph nodes — use reranker backed by NVQ inline
+                ScoreFunction.ExactScoreFunction nvqReranker = view.rerankerFor(q, fe.similarityFunction);
+                ssp = new DefaultSearchScoreProvider(nvqReranker);
             } else { // Not quantized, used typical searcher
                 ssp = DefaultSearchScoreProvider.exact(q, fe.similarityFunction, view);
             }
@@ -314,7 +329,10 @@ public class JVectorReader extends KnnVectorsReader {
         private final ReaderSupplier neighborsScoreCacheIndexReaderSupplier;
         private final OnDiskGraphIndex index;
         private final PQVectors pqVectors; // non-null when quantizationType == PQ
-        private final NVQVectors nvqVectors; // non-null when quantizationType == NVQ
+        private final NVQVectors nvqVectors; // non-null when quantizationType == NVQ (separate blob)
+        private final boolean nvqVectorsInline; // true when NVQ vectors are stored inline in the graph
+        // NVQuantization extracted from the graph's NVQ feature; non-null only when nvqVectorsInline == true
+        final NVQuantization nvqInlineQuantization;
 
         public FieldEntry(FieldInfo fieldInfo, JVectorWriter.VectorIndexFieldMetadata vectorIndexFieldMetadata) throws IOException {
             this.fieldInfo = fieldInfo;
@@ -351,6 +369,7 @@ public class JVectorReader extends KnnVectorsReader {
             this.index = OnDiskGraphIndex.load(indexReaderSupplier, vectorIndexOffset);
 
             // Load compressed vectors if present
+            final byte qType = vectorIndexFieldMetadata.getQuantizationType();
             if (compressedVectorsLength > 0) {
                 assert compressedVectorsOffset > 0;
                 if (compressedVectorsOffset < vectorIndexOffset) {
@@ -361,7 +380,6 @@ public class JVectorReader extends KnnVectorsReader {
                     compressedVectorsOffset,
                     compressedVectorsLength
                 );
-                final byte qType = vectorIndexFieldMetadata.getQuantizationType();
                 if (qType == JVectorWriter.QUANTIZATION_TYPE_NVQ) {
                     log.debug("Loading NVQ vectors for field {}", fieldInfo.name);
                     try (final var randomAccessReader = compressedVectorsReaderSupplier.get()) {
@@ -375,16 +393,47 @@ public class JVectorReader extends KnnVectorsReader {
                     }
                     this.nvqVectors = null;
                 }
+                this.nvqVectorsInline = false;
+                this.nvqInlineQuantization = null;
             } else {
                 this.compressedVectorsReaderSupplier = null;
                 this.pqVectors = null;
                 this.nvqVectors = null;
+                this.nvqVectorsInline = (qType == JVectorWriter.QUANTIZATION_TYPE_NVQ_INLINE);
+                if (this.nvqVectorsInline) {
+                    log.debug("NVQ vectors stored inline in graph for field {}", fieldInfo.name);
+                    this.nvqInlineQuantization = extractNVQuantizationFromGraph(this.index);
+                } else {
+                    this.nvqInlineQuantization = null;
+                }
             }
 
             final IndexInput indexInput = directory.openInput(neighborsScoreCacheIndexFieldFileName, state.context);
             CodecUtil.readIndexHeader(indexInput);
 
             this.neighborsScoreCacheIndexReaderSupplier = new JVectorRandomAccessReader.Supplier(indexInput);
+        }
+
+        /**
+         * Extracts the {@link NVQuantization} object from the private {@code nvq} field of
+         * the {@link NVQ} feature stored in the given graph index.  This is needed so that
+         * the merge path can dequantize NVQ-inline vectors back to float.
+         *
+         * The jVector {@link NVQ} class does not expose a public getter for its internal
+         * {@link NVQuantization}; reflection is the only alternative to modifying the library.
+         */
+        private static NVQuantization extractNVQuantizationFromGraph(OnDiskGraphIndex index) throws IOException {
+            NVQ nvqFeature = (NVQ) index.getFeatures().get(FeatureId.NVQ_VECTORS);
+            if (nvqFeature == null) {
+                return null;
+            }
+            try {
+                Field nvqField = NVQ.class.getDeclaredField("nvq");
+                nvqField.setAccessible(true);
+                return (NVQuantization) nvqField.get(nvqFeature);
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                throw new IOException("Unable to extract NVQuantization from NVQ feature via reflection", e);
+            }
         }
 
         @Override

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
@@ -100,22 +100,7 @@ public class JVectorReader extends KnnVectorsReader {
 
     @Override
     public FloatVectorValues getFloatVectorValues(String field) throws IOException {
-        final FieldEntry fieldEntry = fieldEntryMap.get(field);
-        if (fieldEntry.nvqInlineQuantization != null) {
-            return new JVectorQuantizedNvqVectorValues(
-                fieldEntry.index,
-                fieldEntry.similarityFunction,
-                fieldEntry.graphNodeIdToDocMap,
-                fieldEntry.nvqInlineQuantization
-            );
-        } else {
-            return new JVectorFloatVectorValues(
-                fieldEntry.index,
-                fieldEntry.similarityFunction,
-                fieldEntry.fieldInfo.getVectorSimilarityFunction(),
-                fieldEntry.graphNodeIdToDocMap
-            );
-        }
+        return fieldEntryMap.get(field).floatVectorValues();
     }
 
     @Override
@@ -164,29 +149,11 @@ public class JVectorReader extends KnnVectorsReader {
 
         // search for a random vector using a GraphSearcher and SearchScoreProvider
         VectorFloat<?> q = VECTOR_TYPE_SUPPORT.createFloatVector(target);
-        final SearchScoreProvider ssp;
-
-        // Get the Lucene similarity function to check if we need to transform scores
         final FieldEntry fieldEntry = fieldEntryMap.get(field);
-        final org.apache.lucene.index.VectorSimilarityFunction luceneSimilarityFunction = fieldEntry.fieldInfo
-            .getVectorSimilarityFunction();
-        final VectorSimilarityFunction vectorSimilarityFunction = fieldEntry.similarityFunction;
 
         try (var view = index.getView()) {
             final long graphSearchStart = System.currentTimeMillis();
-            final FieldEntry fe = fieldEntryMap.get(field);
-            if (fe.pqVectors != null) {
-                // PQ blob as approximate first pass; reranker reads inline vectors (NVQ or full-precision)
-                ScoreFunction.ApproximateScoreFunction asf = fe.pqVectors.precomputedScoreFunctionFor(q, fe.similarityFunction);
-                ScoreFunction.ExactScoreFunction reranker = view.rerankerFor(q, fe.similarityFunction);
-                ssp = new DefaultSearchScoreProvider(asf, reranker);
-            } else if (fieldEntry.nvqInlineQuantization != null) { // NVQ inline without PQ blob
-                ssp = new DefaultSearchScoreProvider(view.rerankerFor(q, vectorSimilarityFunction));
-            } else { // Not quantized, used typical searcher
-                ScoreFunction.ExactScoreFunction esf = DefaultSearchScoreProvider.exact(q, vectorSimilarityFunction, view)
-                    .exactScoreFunction();
-                ssp = new DefaultSearchScoreProvider(wrapExactScoreFunction(esf, luceneSimilarityFunction, vectorSimilarityFunction));
-            }
+            final SearchScoreProvider ssp = fieldEntry.buildSSP(q, view);
             final GraphNodeIdToDocMap jvectorLuceneDocMap = fieldEntry.graphNodeIdToDocMap;
             // Convert the acceptDocs bitmap from Lucene to jVector ordinal bitmap filter
             // Logic works as follows: if acceptDocs is null, we accept all ordinals. Otherwise, we check if the jVector ordinal has a
@@ -400,13 +367,37 @@ public class JVectorReader extends KnnVectorsReader {
             this.neighborsScoreCacheIndexReaderSupplier = new JVectorRandomAccessReader.Supplier(indexInput);
         }
 
+        FloatVectorValues floatVectorValues() throws IOException {
+            if (nvqInlineQuantization != null) {
+                return new JVectorQuantizedNvqVectorValues(index, similarityFunction, graphNodeIdToDocMap, nvqInlineQuantization);
+            } else {
+                return new JVectorFloatVectorValues(
+                    index,
+                    similarityFunction,
+                    fieldInfo.getVectorSimilarityFunction(),
+                    graphNodeIdToDocMap
+                );
+            }
+        }
+
+        SearchScoreProvider buildSSP(VectorFloat<?> q, OnDiskGraphIndex.View view) {
+            if (pqVectors != null) {
+                ScoreFunction.ApproximateScoreFunction asf = pqVectors.precomputedScoreFunctionFor(q, similarityFunction);
+                ScoreFunction.ExactScoreFunction reranker = view.rerankerFor(q, similarityFunction);
+                return new DefaultSearchScoreProvider(asf, reranker);
+            } else if (nvqInlineQuantization != null) {
+                return new DefaultSearchScoreProvider(view.rerankerFor(q, similarityFunction));
+            } else {
+                ScoreFunction.ExactScoreFunction esf = DefaultSearchScoreProvider.exact(q, similarityFunction, view).exactScoreFunction();
+                return new DefaultSearchScoreProvider(
+                    wrapExactScoreFunction(esf, fieldInfo.getVectorSimilarityFunction(), similarityFunction)
+                );
+            }
+        }
+
         /**
-         * Extracts the {@link NVQuantization} object from the private {@code nvq} field of
-         * the {@link NVQ} feature stored in the given graph index.  This is needed so that
-         * the merge path can dequantize NVQ-inline vectors back to float.
-         *
-         * The jVector {@link NVQ} class does not expose a public getter for its internal
-         * {@link NVQuantization}; reflection is the only alternative to modifying the library.
+         * Extracts the {@link NVQuantization} object from the {@link NVQ} feature stored in the given graph index.
+         * This is needed so that the merge path can dequantize NVQ-inline vectors back to float.
          */
         private static NVQuantization extractNVQuantizationFromGraph(OnDiskGraphIndex index) throws IOException {
             NVQ nvqFeature = (NVQ) index.getFeatures().get(FeatureId.NVQ_VECTORS);

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -12,6 +12,9 @@ import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
 import io.github.jbellis.jvector.graph.disk.feature.InlineVectors;
 import io.github.jbellis.jvector.graph.diversity.VamanaDiversityProvider;
 import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
+import io.github.jbellis.jvector.quantization.CompressedVectors;
+import io.github.jbellis.jvector.quantization.NVQVectors;
+import io.github.jbellis.jvector.quantization.NVQuantization;
 import io.github.jbellis.jvector.quantization.PQVectors;
 import io.github.jbellis.jvector.quantization.ProductQuantization;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
@@ -96,6 +99,8 @@ public class JVectorWriter extends KnnVectorsWriter {
     private final int minimumBatchSizeForQuantization; // Threshold for the vector count above which we will trigger PQ quantization
     private final boolean hierarchyEnabled;
     private final boolean leadingSegmentMergeDisabled;
+    private final String quantizationType;
+    private final int numNvqSubvectors;
 
     private final ForkJoinPool simdPoolMerge;
     private final ForkJoinPool simdPoolFlush;
@@ -113,6 +118,8 @@ public class JVectorWriter extends KnnVectorsWriter {
         int minimumBatchSizeForQuantization,
         boolean hierarchyEnabled,
         boolean leadingSegmentMergeDisabled,
+        String quantizationType,
+        int numNvqSubvectors,
         final ForkJoinPool simdPoolMerge,
         final ForkJoinPool simdPoolFlush,
         final ForkJoinPool parallelismPool
@@ -126,6 +133,8 @@ public class JVectorWriter extends KnnVectorsWriter {
         this.minimumBatchSizeForQuantization = minimumBatchSizeForQuantization;
         this.hierarchyEnabled = hierarchyEnabled;
         this.leadingSegmentMergeDisabled = leadingSegmentMergeDisabled;
+        this.quantizationType = quantizationType;
+        this.numNvqSubvectors = numNvqSubvectors;
         this.simdPoolMerge = simdPoolMerge;
         this.simdPoolFlush = simdPoolFlush;
         this.parallelismPool = parallelismPool;
@@ -220,19 +229,32 @@ public class JVectorWriter extends KnnVectorsWriter {
             final RandomAccessVectorValues randomAccessVectorValues = field.randomAccessVectorValues;
             final BuildScoreProvider buildScoreProvider;
             final PQVectors pqVectors;
+            final NVQVectors nvqVectors;
             final FieldInfo fieldInfo = field.fieldInfo;
             if (randomAccessVectorValues.size() >= minimumBatchSizeForQuantization) {
-                log.info("Calculating codebooks and compressed vectors for field {}", fieldInfo.name);
-                pqVectors = getPQVectors(randomAccessVectorValues, fieldInfo);
-                buildScoreProvider = BuildScoreProvider.pqBuildScoreProvider(getVectorSimilarityFunction(fieldInfo), pqVectors);
+                log.info("Calculating codebooks and compressed vectors for field {} using {}", fieldInfo.name, quantizationType);
+                if (isNVQ()) {
+                    nvqVectors = getNVQVectors(randomAccessVectorValues, fieldInfo);
+                    pqVectors = null;
+                    // NVQ has no pqBuildScoreProvider equivalent; use full-precision for graph building
+                    buildScoreProvider = BuildScoreProvider.randomAccessScoreProvider(
+                        randomAccessVectorValues,
+                        getVectorSimilarityFunction(fieldInfo)
+                    );
+                } else {
+                    pqVectors = getPQVectors(randomAccessVectorValues, fieldInfo);
+                    nvqVectors = null;
+                    buildScoreProvider = BuildScoreProvider.pqBuildScoreProvider(getVectorSimilarityFunction(fieldInfo), pqVectors);
+                }
             } else {
                 log.info(
-                    "Vector count: {}, less than limit to trigger PQ quantization: {}, for field {}, will use full precision vectors instead.",
+                    "Vector count: {}, less than limit to trigger quantization: {}, for field {}, will use full precision vectors instead.",
                     randomAccessVectorValues.size(),
                     minimumBatchSizeForQuantization,
                     fieldInfo.name
                 );
                 pqVectors = null;
+                nvqVectors = null;
                 buildScoreProvider = BuildScoreProvider.randomAccessScoreProvider(
                     randomAccessVectorValues,
                     getVectorSimilarityFunction(fieldInfo)
@@ -259,7 +281,8 @@ public class JVectorWriter extends KnnVectorsWriter {
                 segmentWriteState.segmentInfo.name,
                 simdPoolFlush
             );
-            writeField(field.fieldInfo, randomAccessVectorValues, pqVectors, graphNodeIdToDocMap, graph);
+            final CompressedVectors compressedVectors = nvqVectors != null ? nvqVectors : pqVectors;
+            writeField(field.fieldInfo, randomAccessVectorValues, compressedVectors, graphNodeIdToDocMap, graph);
 
         }
     }
@@ -267,7 +290,7 @@ public class JVectorWriter extends KnnVectorsWriter {
     private void writeField(
         FieldInfo fieldInfo,
         RandomAccessVectorValues randomAccessVectorValues,
-        PQVectors pqVectors,
+        CompressedVectors compressedVectors,
         GraphNodeIdToDocMap graphNodeIdToDocMap,
         OnHeapGraphIndex graph
     ) throws IOException {
@@ -277,7 +300,7 @@ public class JVectorWriter extends KnnVectorsWriter {
             randomAccessVectorValues.size(),
             segmentWriteState.segmentInfo.name
         );
-        final var vectorIndexFieldMetadata = writeGraph(graph, randomAccessVectorValues, fieldInfo, pqVectors, graphNodeIdToDocMap);
+        final var vectorIndexFieldMetadata = writeGraph(graph, randomAccessVectorValues, fieldInfo, compressedVectors, graphNodeIdToDocMap);
         meta.writeInt(fieldInfo.number);
         vectorIndexFieldMetadata.toOutput(meta);
 
@@ -308,18 +331,19 @@ public class JVectorWriter extends KnnVectorsWriter {
     }
 
     /**
-     * Writes the graph and PQ codebooks and compressed vectors to the vector index file
+     * Writes the graph and compressed vectors (PQ or NVQ) to the vector index file
      * @param graph graph
      * @param randomAccessVectorValues random access vector values with remapped ordinals
      * @param fieldInfo field info
-     * @return Tuple of start offset and length of the graph
+     * @param compressedVectors compressed vectors (PQVectors, NVQVectors, or null for no quantization)
+     * @return VectorIndexFieldMetadata for the written field
      * @throws IOException IOException
      */
     private VectorIndexFieldMetadata writeGraph(
         OnHeapGraphIndex graph,
         RandomAccessVectorValues randomAccessVectorValues,
         FieldInfo fieldInfo,
-        PQVectors pqVectors,
+        CompressedVectors compressedVectors,
         GraphNodeIdToDocMap graphNodeIdToDocMap
     ) throws IOException {
         // field data file, which contains the graph
@@ -361,21 +385,33 @@ public class JVectorWriter extends KnnVectorsWriter {
                 resultBuilder.vectorIndexOffset(startOffset);
                 resultBuilder.vectorIndexLength(endGraphOffset - startOffset);
 
-                // If PQ is enabled and we have enough vectors, write the PQ codebooks and compressed vectors
-                if (pqVectors != null) {
-                    log.info(
-                        "Writing PQ codebooks and vectors for field {} since the size is {} >= {}",
-                        fieldInfo.name,
-                        randomAccessVectorValues.size(),
-                        minimumBatchSizeForQuantization
-                    );
-                    resultBuilder.pqCodebooksAndVectorsOffset(endGraphOffset);
-                    // write the compressed vectors and codebooks to disk
-                    pqVectors.write(jVectorIndexWriter);
-                    resultBuilder.pqCodebooksAndVectorsLength(jVectorIndexWriter.position() - endGraphOffset);
+                if (compressedVectors != null) {
+                    final byte qType;
+                    if (compressedVectors instanceof NVQVectors) {
+                        qType = QUANTIZATION_TYPE_NVQ;
+                        log.info(
+                            "Writing NVQ compressed vectors for field {} since the size is {} >= {}",
+                            fieldInfo.name,
+                            randomAccessVectorValues.size(),
+                            minimumBatchSizeForQuantization
+                        );
+                    } else {
+                        qType = QUANTIZATION_TYPE_PQ;
+                        log.info(
+                            "Writing PQ codebooks and vectors for field {} since the size is {} >= {}",
+                            fieldInfo.name,
+                            randomAccessVectorValues.size(),
+                            minimumBatchSizeForQuantization
+                        );
+                    }
+                    resultBuilder.compressedVectorsOffset(endGraphOffset);
+                    compressedVectors.write(jVectorIndexWriter);
+                    resultBuilder.compressedVectorsLength(jVectorIndexWriter.position() - endGraphOffset);
+                    resultBuilder.quantizationType(qType);
                 } else {
-                    resultBuilder.pqCodebooksAndVectorsOffset(0);
-                    resultBuilder.pqCodebooksAndVectorsLength(0);
+                    resultBuilder.compressedVectorsOffset(0);
+                    resultBuilder.compressedVectorsLength(0);
+                    resultBuilder.quantizationType(QUANTIZATION_TYPE_NONE);
                 }
                 CodecUtil.writeFooter(indexOutput);
             }
@@ -418,6 +454,37 @@ public class JVectorWriter extends KnnVectorsWriter {
         return pqVectors;
     }
 
+    // quantizationType byte values stored in VectorIndexFieldMetadata
+    static final byte QUANTIZATION_TYPE_NONE = 0;
+    static final byte QUANTIZATION_TYPE_PQ = 1;
+    static final byte QUANTIZATION_TYPE_NVQ = 2;
+
+    private boolean isNVQ() {
+        return org.opensearch.knn.common.KNNConstants.QUANTIZATION_TYPE_NVQ.equals(quantizationType);
+    }
+
+    private NVQVectors getNVQVectors(RandomAccessVectorValues randomAccessVectorValues, FieldInfo fieldInfo) throws IOException {
+        final String fieldName = fieldInfo.name;
+        log.info("Computing NVQ parameters for field {} for {} vectors", fieldName, randomAccessVectorValues.size());
+        final long start = Clock.systemDefaultZone().millis();
+        final int nSubVectors = numNvqSubvectors == org.opensearch.knn.common.KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS
+            ? numberOfSubspacesPerVectorSupplier.apply(randomAccessVectorValues.dimension())
+            : numNvqSubvectors;
+        NVQuantization nvq = NVQuantization.compute(randomAccessVectorValues, nSubVectors);
+        final long trainingTime = Clock.systemDefaultZone().millis() - start;
+        log.info("Computed NVQ parameters for field {}, in {} millis", fieldName, trainingTime);
+        KNNCounter.KNN_QUANTIZATION_TRAINING_TIME.add(trainingTime);
+        log.info("Encoding NVQ vectors for field {} for {} vectors", fieldName, randomAccessVectorValues.size());
+        NVQVectors nvqVectors = nvq.encodeAll(randomAccessVectorValues, simdPoolMerge);
+        log.info(
+            "Encoded NVQ vectors for field {}, original size: {} bytes, compressed size: {} bytes",
+            fieldName,
+            nvqVectors.getOriginalSize(),
+            nvqVectors.getCompressedSize()
+        );
+        return nvqVectors;
+    }
+
     @Value
     @Builder(toBuilder = true)
     @AllArgsConstructor
@@ -428,8 +495,9 @@ public class JVectorWriter extends KnnVectorsWriter {
         int vectorDimension;
         long vectorIndexOffset;
         long vectorIndexLength;
-        long pqCodebooksAndVectorsOffset;
-        long pqCodebooksAndVectorsLength;
+        long compressedVectorsOffset;
+        long compressedVectorsLength;
+        byte quantizationType; // QUANTIZATION_TYPE_NONE/PQ/NVQ; added in VERSION_WITH_QUANTIZATION_TYPE
         float degreeOverflow; // important when leveraging cache
         GraphNodeIdToDocMap graphNodeIdToDocMap;
 
@@ -440,21 +508,28 @@ public class JVectorWriter extends KnnVectorsWriter {
             out.writeVInt(vectorDimension);
             out.writeVLong(vectorIndexOffset);
             out.writeVLong(vectorIndexLength);
-            out.writeVLong(pqCodebooksAndVectorsOffset);
-            out.writeVLong(pqCodebooksAndVectorsLength);
+            out.writeVLong(compressedVectorsOffset);
+            out.writeVLong(compressedVectorsLength);
+            out.writeByte(quantizationType);
             out.writeInt(Float.floatToIntBits(degreeOverflow));
             graphNodeIdToDocMap.toOutput(out);
         }
 
-        public VectorIndexFieldMetadata(IndexInput in) throws IOException {
+        public VectorIndexFieldMetadata(IndexInput in, int version) throws IOException {
             this.fieldNumber = in.readInt();
             this.vectorEncoding = readVectorEncoding(in);
             this.vectorSimilarityFunction = JVectorReader.VectorSimilarityMapper.ordToLuceneDistFunc(in.readInt());
             this.vectorDimension = in.readVInt();
             this.vectorIndexOffset = in.readVLong();
             this.vectorIndexLength = in.readVLong();
-            this.pqCodebooksAndVectorsOffset = in.readVLong();
-            this.pqCodebooksAndVectorsLength = in.readVLong();
+            this.compressedVectorsOffset = in.readVLong();
+            this.compressedVectorsLength = in.readVLong();
+            if (version >= JVectorFormat.VERSION_WITH_QUANTIZATION_TYPE) {
+                this.quantizationType = in.readByte();
+            } else {
+                // v0 segments: infer type — PQ if compressed vectors present, none otherwise
+                this.quantizationType = this.compressedVectorsLength > 0 ? QUANTIZATION_TYPE_PQ : QUANTIZATION_TYPE_NONE;
+            }
             this.degreeOverflow = Float.intBitsToFloat(in.readInt());
             this.graphNodeIdToDocMap = new GraphNodeIdToDocMap(in);
         }
@@ -911,17 +986,43 @@ public class JVectorWriter extends KnnVectorsWriter {
             // Get PQ compressor for leading reader
             final int totalVectorsCount = size;
             final String fieldName = fieldInfo.name;
+
+            final RemappedRandomAccessVectorValues compactRavvEarly = new RemappedRandomAccessVectorValues(this, compactOrdsToRavvOrds);
+            if (compactRavvEarly.size() == 0) {
+                log.info("No vectors for field {} in segment {}", fieldName, mergeState.segmentInfo.name);
+                return;
+            }
+
+            // NVQ merge: always recompute from scratch (no refine() equivalent)
+            if (isNVQ()) {
+                final NVQVectors compactNvqVectors;
+                if (totalLiveVectorsCount >= minimumBatchSizeForQuantization) {
+                    log.info(
+                        "Calculating NVQ compressed vectors for field: {}, with totalVectorCount: {}",
+                        fieldName,
+                        totalLiveVectorsCount
+                    );
+                    compactNvqVectors = getNVQVectors(compactRavvEarly, fieldInfo);
+                } else {
+                    log.info(
+                        "Not enough vectors for NVQ for field: {}, totalVectorCount: {} < minimumBatchSizeForQuantization: {}",
+                        fieldName,
+                        totalLiveVectorsCount,
+                        minimumBatchSizeForQuantization
+                    );
+                    compactNvqVectors = null;
+                }
+                var bsp = BuildScoreProvider.randomAccessScoreProvider(compactRavvEarly, getVectorSimilarityFunction(fieldInfo));
+                var graph = getGraph(bsp, compactRavvEarly, fieldInfo, segmentWriteState.segmentInfo.name, simdPoolMerge);
+                writeField(fieldInfo, compactRavvEarly, compactNvqVectors, compactOrdToDocMap, graph);
+                return;
+            }
+
             final PQVectors compactPqVectors;
             // Get the leading reader
             PerFieldKnnVectorsFormat.FieldsReader fieldsReader = (PerFieldKnnVectorsFormat.FieldsReader) readers[LEADING_READER_IDX];
             JVectorReader leadingReader = (JVectorReader) fieldsReader.getFieldReader(fieldName);
-            final RemappedRandomAccessVectorValues compactRavv = new RemappedRandomAccessVectorValues(this, compactOrdsToRavvOrds);
-
-            // The merged segments ends up with no vectors (empty graph), nothing to merge there
-            if (compactRavv.size() == 0) {
-                log.info("No vectors for field {} in segment {}", fieldName, mergeState.segmentInfo.name);
-                return;
-            }
+            final RemappedRandomAccessVectorValues compactRavv = compactRavvEarly;
 
             // Check if the leading reader has pre-existing PQ codebooks and if so, refine them with the remaining vectors
             if (leadingReader.getProductQuantizationForField(fieldInfo.name).isEmpty()) {
@@ -988,7 +1089,7 @@ public class JVectorWriter extends KnnVectorsWriter {
                     );
                     var bsp = BuildScoreProvider.randomAccessScoreProvider(compactRavv, getVectorSimilarityFunction(fieldInfo));
                     var graph = getGraph(bsp, compactRavv, fieldInfo, segmentWriteState.segmentInfo.name, simdPoolMerge);
-                    writeField(fieldInfo, compactRavv, null, compactOrdToDocMap, graph);
+                    writeField(fieldInfo, compactRavv, (CompressedVectors) null, compactOrdToDocMap, graph);
                 }
             } else {
                 log.info("PQ codebooks found, building graph from scratch with PQ vectors");
@@ -1184,7 +1285,7 @@ public class JVectorWriter extends KnnVectorsWriter {
                     // Note that the ordinals for the OnDiskGraphIndex will automatically be compacted
                     // But the OnHeapGraphIndex will not
                     var finalOrdToDocMap = new GraphNodeIdToDocMap(finalOrdToDocId);
-                    writeField(fieldInfo, heapRavv, null, finalOrdToDocMap, graph);
+                    writeField(fieldInfo, heapRavv, (CompressedVectors) null, finalOrdToDocMap, graph);
                     return true;
                 }
             }

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -220,35 +220,8 @@ public class JVectorWriter extends KnnVectorsWriter {
         log.info("Flushing jVector graph index");
         for (FieldWriter<?> field : fields) {
             final RandomAccessVectorValues randomAccessVectorValues = field.randomAccessVectorValues;
-            final BuildScoreProvider buildScoreProvider;
-            final PQVectors pqVectors;
-            final NVQVectors nvqVectors;
             final FieldInfo fieldInfo = field.fieldInfo;
-            if (randomAccessVectorValues.size() >= minimumBatchSizeForQuantization) {
-                log.info("Calculating codebooks and compressed vectors for field {} using {}", fieldInfo.name, quantization.getType());
-                if (isNVQ()) {
-                    nvqVectors = getNVQVectors(randomAccessVectorValues, fieldInfo);
-                    pqVectors = getPQVectors(randomAccessVectorValues, fieldInfo);
-                    buildScoreProvider = BuildScoreProvider.pqBuildScoreProvider(getVectorSimilarityFunction(fieldInfo), pqVectors);
-                } else {
-                    pqVectors = getPQVectors(randomAccessVectorValues, fieldInfo);
-                    nvqVectors = null;
-                    buildScoreProvider = BuildScoreProvider.pqBuildScoreProvider(getVectorSimilarityFunction(fieldInfo), pqVectors);
-                }
-            } else {
-                log.info(
-                    "Vector count: {}, less than limit to trigger quantization: {}, for field {}, will use full precision vectors instead.",
-                    randomAccessVectorValues.size(),
-                    minimumBatchSizeForQuantization,
-                    fieldInfo.name
-                );
-                pqVectors = null;
-                nvqVectors = null;
-                buildScoreProvider = BuildScoreProvider.randomAccessScoreProvider(
-                    randomAccessVectorValues,
-                    getVectorSimilarityFunction(fieldInfo)
-                );
-            }
+            final FieldQuantizationResult quantizationResult = quantizeForFlush(randomAccessVectorValues, fieldInfo);
 
             // Generate the ord to doc mapping
             final int[] ordinalsToDocIds = new int[randomAccessVectorValues.size()];
@@ -264,17 +237,72 @@ public class JVectorWriter extends KnnVectorsWriter {
             }
 
             OnHeapGraphIndex graph = getGraph(
-                buildScoreProvider,
+                quantizationResult.buildScoreProvider,
                 randomAccessVectorValues,
                 fieldInfo,
                 segmentWriteState.segmentInfo.name,
                 simdPoolFlush
             );
-            final CompressedVectors compressedVectors = nvqVectors != null ? nvqVectors : pqVectors;
-            final PQVectors auxiliaryPqVectors = nvqVectors != null ? pqVectors : null;
-            writeField(field.fieldInfo, randomAccessVectorValues, compressedVectors, auxiliaryPqVectors, graphNodeIdToDocMap, graph);
+            writeField(
+                field.fieldInfo,
+                randomAccessVectorValues,
+                quantizationResult.compressedVectors,
+                quantizationResult.auxiliaryPqVectors,
+                graphNodeIdToDocMap,
+                graph
+            );
 
         }
+    }
+
+    /** Holds the result of quantizing a field's vectors ahead of graph construction during flush. */
+    private static final class FieldQuantizationResult {
+        final CompressedVectors compressedVectors;
+        // Present only for NVQ: the auxiliary PQ vectors used as the build-time score provider.
+        final PQVectors auxiliaryPqVectors;
+        final BuildScoreProvider buildScoreProvider;
+
+        FieldQuantizationResult(CompressedVectors compressedVectors, PQVectors auxiliaryPqVectors, BuildScoreProvider buildScoreProvider) {
+            this.compressedVectors = compressedVectors;
+            this.auxiliaryPqVectors = auxiliaryPqVectors;
+            this.buildScoreProvider = buildScoreProvider;
+        }
+    }
+
+    private FieldQuantizationResult quantizeForFlush(RandomAccessVectorValues randomAccessVectorValues, FieldInfo fieldInfo)
+        throws IOException {
+        if (randomAccessVectorValues.size() < minimumBatchSizeForQuantization) {
+            log.info(
+                "Vector count: {}, less than limit to trigger quantization: {}, for field {}, will use full precision vectors instead.",
+                randomAccessVectorValues.size(),
+                minimumBatchSizeForQuantization,
+                fieldInfo.name
+            );
+            BuildScoreProvider buildScoreProvider = BuildScoreProvider.randomAccessScoreProvider(
+                randomAccessVectorValues,
+                getVectorSimilarityFunction(fieldInfo)
+            );
+            return new FieldQuantizationResult(null, null, buildScoreProvider);
+        }
+
+        log.info("Calculating codebooks and compressed vectors for field {} using {}", fieldInfo.name, quantization.getType());
+        return isNVQ() ? quantizeWithNVQ(randomAccessVectorValues, fieldInfo) : quantizeWithPQ(randomAccessVectorValues, fieldInfo);
+    }
+
+    private FieldQuantizationResult quantizeWithNVQ(RandomAccessVectorValues randomAccessVectorValues, FieldInfo fieldInfo)
+        throws IOException {
+        // NVQ (for disk) and PQ (for codebooks) are both used when NVQ is enabled
+        NVQVectors nvqVectors = getNVQVectors(randomAccessVectorValues, fieldInfo);
+        PQVectors pqVectors = getAuxiliaryPqVectorsForNvq(randomAccessVectorValues, fieldInfo);
+        BuildScoreProvider buildScoreProvider = BuildScoreProvider.pqBuildScoreProvider(getVectorSimilarityFunction(fieldInfo), pqVectors);
+        return new FieldQuantizationResult(nvqVectors, pqVectors, buildScoreProvider);
+    }
+
+    private FieldQuantizationResult quantizeWithPQ(RandomAccessVectorValues randomAccessVectorValues, FieldInfo fieldInfo)
+        throws IOException {
+        PQVectors pqVectors = getPrimaryPQVectors(randomAccessVectorValues, fieldInfo);
+        BuildScoreProvider buildScoreProvider = BuildScoreProvider.pqBuildScoreProvider(getVectorSimilarityFunction(fieldInfo), pqVectors);
+        return new FieldQuantizationResult(pqVectors, null, buildScoreProvider);
     }
 
     private void writeField(
@@ -370,83 +398,137 @@ public class JVectorWriter extends KnnVectorsWriter {
                 .vectorDimension(randomAccessVectorValues.dimension())
                 .graphNodeIdToDocMap(graphNodeIdToDocMap);
 
-            if (compressedVectors instanceof NVQVectors) {
-                final NVQVectors nvqVectors = (NVQVectors) compressedVectors;
-                final NVQuantization nvQuantization = nvqVectors.getNVQuantization();
-                log.info("Writing NVQ vectors inline with graph nodes for field {}", fieldInfo.name);
-                try (
-                    var writer = new OnDiskSequentialGraphIndexWriter.Builder(graph, jVectorIndexWriter).with(new NVQ(nvQuantization))
-                        .build()
-                ) {
-                    var suppliers = Feature.singleStateFactory(FeatureId.NVQ_VECTORS, nodeId -> new NVQ.State(nvqVectors.get(nodeId)));
-                    writer.write(suppliers);
-                    long endGraphOffset = jVectorIndexWriter.position();
-                    resultBuilder.vectorIndexOffset(startOffset);
-                    resultBuilder.vectorIndexLength(endGraphOffset - startOffset);
-                    if (auxiliaryPqVectors != null) {
-                        log.info("Writing auxiliary PQ blob for NVQ field {} for approximate search traversal", fieldInfo.name);
-                        resultBuilder.compressedVectorsOffset(endGraphOffset);
-                        auxiliaryPqVectors.write(jVectorIndexWriter);
-                        resultBuilder.compressedVectorsLength(jVectorIndexWriter.position() - endGraphOffset);
-                    } else {
-                        resultBuilder.compressedVectorsOffset(0);
-                        resultBuilder.compressedVectorsLength(0);
-                    }
-                    resultBuilder.quantizationType(QUANTIZATION_TYPE_NVQ_INLINE);
-                    CodecUtil.writeFooter(indexOutput);
-                }
+            if (compressedVectors instanceof NVQVectors nvqVectors) {
+                writeNVQGraph(
+                    graph,
+                    fieldInfo,
+                    nvqVectors,
+                    auxiliaryPqVectors,
+                    jVectorIndexWriter,
+                    indexOutput,
+                    startOffset,
+                    resultBuilder
+                );
             } else {
-                try (
-                    var writer = new OnDiskSequentialGraphIndexWriter.Builder(graph, jVectorIndexWriter).with(
-                        new InlineVectors(randomAccessVectorValues.dimension())
-                    ).build()
-                ) {
-                    var suppliers = Feature.singleStateFactory(
-                        FeatureId.INLINE_VECTORS,
-                        nodeId -> new InlineVectors.State(randomAccessVectorValues.getVector(nodeId))
-                    );
-                    writer.write(suppliers);
-                    long endGraphOffset = jVectorIndexWriter.position();
-                    resultBuilder.vectorIndexOffset(startOffset);
-                    resultBuilder.vectorIndexLength(endGraphOffset - startOffset);
-                    if (compressedVectors != null) {
-                        log.info(
-                            "Writing PQ codebooks and vectors for field {} since the size is {} >= {}",
-                            fieldInfo.name,
-                            randomAccessVectorValues.size(),
-                            minimumBatchSizeForQuantization
-                        );
-                        resultBuilder.compressedVectorsOffset(endGraphOffset);
-                        compressedVectors.write(jVectorIndexWriter);
-                        resultBuilder.compressedVectorsLength(jVectorIndexWriter.position() - endGraphOffset);
-                        resultBuilder.quantizationType(QUANTIZATION_TYPE_PQ);
-                    } else {
-                        resultBuilder.compressedVectorsOffset(0);
-                        resultBuilder.compressedVectorsLength(0);
-                        resultBuilder.quantizationType(QUANTIZATION_TYPE_NONE);
-                    }
-                    CodecUtil.writeFooter(indexOutput);
-                }
+                writeFullPrecisionGraph(
+                    graph,
+                    randomAccessVectorValues,
+                    fieldInfo,
+                    compressedVectors,
+                    jVectorIndexWriter,
+                    indexOutput,
+                    startOffset,
+                    resultBuilder
+                );
             }
 
             return resultBuilder.build();
         }
     }
 
-    private PQVectors getPQVectors(RandomAccessVectorValues randomAccessVectorValues, FieldInfo fieldInfo) throws IOException {
+    /** Writes the graph with NVQ vectors stored inline in each node, plus an optional auxiliary PQ blob. */
+    private void writeNVQGraph(
+        OnHeapGraphIndex graph,
+        FieldInfo fieldInfo,
+        NVQVectors nvqVectors,
+        PQVectors auxiliaryPqVectors,
+        JVectorIndexWriter jVectorIndexWriter,
+        IndexOutput indexOutput,
+        long startOffset,
+        VectorIndexFieldMetadata.VectorIndexFieldMetadataBuilder resultBuilder
+    ) throws IOException {
+        final NVQuantization nvQuantization = nvqVectors.getNVQuantization();
+        log.info("Writing NVQ vectors inline with graph nodes for field {}", fieldInfo.name);
+        try (var writer = new OnDiskSequentialGraphIndexWriter.Builder(graph, jVectorIndexWriter).with(new NVQ(nvQuantization)).build()) {
+            var suppliers = Feature.singleStateFactory(FeatureId.NVQ_VECTORS, nodeId -> new NVQ.State(nvqVectors.get(nodeId)));
+            writer.write(suppliers);
+            long endGraphOffset = jVectorIndexWriter.position();
+            resultBuilder.vectorIndexOffset(startOffset);
+            resultBuilder.vectorIndexLength(endGraphOffset - startOffset);
+            if (auxiliaryPqVectors != null) {
+                log.info("Writing auxiliary PQ blob for NVQ field {} for approximate search traversal", fieldInfo.name);
+                resultBuilder.compressedVectorsOffset(endGraphOffset);
+                auxiliaryPqVectors.write(jVectorIndexWriter);
+                resultBuilder.compressedVectorsLength(jVectorIndexWriter.position() - endGraphOffset);
+            } else {
+                resultBuilder.compressedVectorsOffset(0);
+                resultBuilder.compressedVectorsLength(0);
+            }
+            resultBuilder.quantizationType(QUANTIZATION_TYPE_NVQ_INLINE);
+            CodecUtil.writeFooter(indexOutput);
+        }
+    }
+
+    /** Writes the graph with full-precision vectors stored inline in each node, plus an optional PQ blob. */
+    private void writeFullPrecisionGraph(
+        OnHeapGraphIndex graph,
+        RandomAccessVectorValues randomAccessVectorValues,
+        FieldInfo fieldInfo,
+        CompressedVectors compressedVectors,
+        JVectorIndexWriter jVectorIndexWriter,
+        IndexOutput indexOutput,
+        long startOffset,
+        VectorIndexFieldMetadata.VectorIndexFieldMetadataBuilder resultBuilder
+    ) throws IOException {
+        try (
+            var writer = new OnDiskSequentialGraphIndexWriter.Builder(graph, jVectorIndexWriter).with(
+                new InlineVectors(randomAccessVectorValues.dimension())
+            ).build()
+        ) {
+            var suppliers = Feature.singleStateFactory(
+                FeatureId.INLINE_VECTORS,
+                nodeId -> new InlineVectors.State(randomAccessVectorValues.getVector(nodeId))
+            );
+            writer.write(suppliers);
+            long endGraphOffset = jVectorIndexWriter.position();
+            resultBuilder.vectorIndexOffset(startOffset);
+            resultBuilder.vectorIndexLength(endGraphOffset - startOffset);
+            if (compressedVectors != null) {
+                log.info(
+                    "Writing PQ codebooks and vectors for field {} since the size is {} >= {}",
+                    fieldInfo.name,
+                    randomAccessVectorValues.size(),
+                    minimumBatchSizeForQuantization
+                );
+                resultBuilder.compressedVectorsOffset(endGraphOffset);
+                compressedVectors.write(jVectorIndexWriter);
+                resultBuilder.compressedVectorsLength(jVectorIndexWriter.position() - endGraphOffset);
+                resultBuilder.quantizationType(QUANTIZATION_TYPE_PQ);
+            } else {
+                resultBuilder.compressedVectorsOffset(0);
+                resultBuilder.compressedVectorsLength(0);
+                resultBuilder.quantizationType(QUANTIZATION_TYPE_NONE);
+            }
+            CodecUtil.writeFooter(indexOutput);
+        }
+    }
+
+    /** PQ-only field: subspace count comes from the configured {@link JVectorIndexQuantization}. */
+    private PQVectors getPrimaryPQVectors(RandomAccessVectorValues randomAccessVectorValues, FieldInfo fieldInfo) throws IOException {
+        return computePQVectors(randomAccessVectorValues, fieldInfo, quantization.numSubspaces(randomAccessVectorValues.dimension()));
+    }
+
+    /** NVQ field: the auxiliary PQ blob always uses the PQ-default subspace count, never the NVQ subvector count. */
+    private PQVectors getAuxiliaryPqVectorsForNvq(RandomAccessVectorValues randomAccessVectorValues, FieldInfo fieldInfo)
+        throws IOException {
+        return computePQVectors(
+            randomAccessVectorValues,
+            fieldInfo,
+            JVectorIndexQuantization.PQ.defaultNumSubspaces(randomAccessVectorValues.dimension())
+        );
+    }
+
+    private PQVectors computePQVectors(RandomAccessVectorValues randomAccessVectorValues, FieldInfo fieldInfo, int numSubspaces)
+        throws IOException {
         final String fieldName = fieldInfo.name;
         final VectorSimilarityFunction vectorSimilarityFunction = fieldInfo.getVectorSimilarityFunction();
         log.info("Computing PQ codebooks for field {} for {} vectors", fieldName, randomAccessVectorValues.size());
         final long start = Clock.systemDefaultZone().millis();
-        // NVQ auxiliary PQ always uses the PQ-default subspace count, not the NVQ subvector count
-        final int M = isNVQ()
-            ? JVectorIndexQuantization.PQ.defaultNumSubspaces(randomAccessVectorValues.dimension())
-            : quantization.numSubspaces(randomAccessVectorValues.dimension());
         final var numberOfClustersPerSubspace = Math.min(256, randomAccessVectorValues.size()); // number of centroids per
         // subspace
         ProductQuantization pq = ProductQuantization.compute(
             randomAccessVectorValues,
-            M, // number of subspaces
+            numSubspaces,
             numberOfClustersPerSubspace, // number of centroids per subspace
             vectorSimilarityFunction == VectorSimilarityFunction.EUCLIDEAN, // center the dataset
             UNWEIGHTED,
@@ -996,56 +1078,62 @@ public class JVectorWriter extends KnnVectorsWriter {
          * @throws IOException if there is an issue during reading or writing vector data.
          */
         public void merge() throws IOException {
-            // This section creates the PQVectors to be used for this merge
-            // Get PQ compressor for leading reader
-            final int totalVectorsCount = size;
-            final String fieldName = fieldInfo.name;
-
             final RemappedRandomAccessVectorValues compactRavvEarly = new RemappedRandomAccessVectorValues(this, compactOrdsToRavvOrds);
             if (compactRavvEarly.size() == 0) {
-                log.info("No vectors for field {} in segment {}", fieldName, mergeState.segmentInfo.name);
+                log.info("No vectors for field {} in segment {}", fieldInfo.name, mergeState.segmentInfo.name);
                 return;
             }
 
-            // NVQ merge: always recompute from scratch (no refine() equivalent)
             if (isNVQ()) {
-                final NVQVectors compactNvqVectors;
-                final PQVectors compactNvqAuxPqVectors;
-                if (totalLiveVectorsCount >= minimumBatchSizeForQuantization) {
-                    log.info(
-                        "Calculating NVQ compressed vectors for field: {}, with totalVectorCount: {}",
-                        fieldName,
-                        totalLiveVectorsCount
-                    );
-                    compactNvqVectors = getNVQVectors(compactRavvEarly, fieldInfo);
-                    compactNvqAuxPqVectors = getPQVectors(compactRavvEarly, fieldInfo);
-                } else {
-                    log.info(
-                        "Not enough vectors for NVQ for field: {}, totalVectorCount: {} < minimumBatchSizeForQuantization: {}",
-                        fieldName,
-                        totalLiveVectorsCount,
-                        minimumBatchSizeForQuantization
-                    );
-                    compactNvqVectors = null;
-                    compactNvqAuxPqVectors = null;
-                }
-                final BuildScoreProvider bsp;
-                if (compactNvqAuxPqVectors != null) {
-                    bsp = BuildScoreProvider.pqBuildScoreProvider(getVectorSimilarityFunction(fieldInfo), compactNvqAuxPqVectors);
-                    bsp.diversityProviderFor(0);
-                } else {
-                    bsp = BuildScoreProvider.randomAccessScoreProvider(compactRavvEarly, getVectorSimilarityFunction(fieldInfo));
-                }
-                var graph = getGraph(bsp, compactRavvEarly, fieldInfo, segmentWriteState.segmentInfo.name, simdPoolMerge);
-                writeField(fieldInfo, compactRavvEarly, compactNvqVectors, compactNvqAuxPqVectors, compactOrdToDocMap, graph);
-                return;
+                mergeNVQ(compactRavvEarly);
+            } else {
+                mergePQ(compactRavvEarly);
             }
+        }
 
+        /**
+         * NVQ merge: always recompute from scratch (no refine() equivalent).
+         */
+        private void mergeNVQ(RemappedRandomAccessVectorValues compactRavvEarly) throws IOException {
+            final String fieldName = fieldInfo.name;
+            final NVQVectors compactNvqVectors;
+            final PQVectors compactNvqAuxPqVectors;
+            if (totalLiveVectorsCount >= minimumBatchSizeForQuantization) {
+                log.info("Calculating NVQ compressed vectors for field: {}, with totalVectorCount: {}", fieldName, totalLiveVectorsCount);
+                compactNvqVectors = getNVQVectors(compactRavvEarly, fieldInfo);
+                compactNvqAuxPqVectors = getAuxiliaryPqVectorsForNvq(compactRavvEarly, fieldInfo);
+            } else {
+                log.info(
+                    "Not enough vectors for NVQ for field: {}, totalVectorCount: {} < minimumBatchSizeForQuantization: {}",
+                    fieldName,
+                    totalLiveVectorsCount,
+                    minimumBatchSizeForQuantization
+                );
+                compactNvqVectors = null;
+                compactNvqAuxPqVectors = null;
+            }
+            final BuildScoreProvider bsp;
+            if (compactNvqAuxPqVectors != null) {
+                bsp = BuildScoreProvider.pqBuildScoreProvider(getVectorSimilarityFunction(fieldInfo), compactNvqAuxPqVectors);
+                bsp.diversityProviderFor(0);
+            } else {
+                bsp = BuildScoreProvider.randomAccessScoreProvider(compactRavvEarly, getVectorSimilarityFunction(fieldInfo));
+            }
+            var graph = getGraph(bsp, compactRavvEarly, fieldInfo, segmentWriteState.segmentInfo.name, simdPoolMerge);
+            writeField(fieldInfo, compactRavvEarly, compactNvqVectors, compactNvqAuxPqVectors, compactOrdToDocMap, graph);
+        }
+
+        /**
+         * PQ merge: refines the leading reader's pre-existing codebooks with the remaining vectors when
+         * available, otherwise computes new codebooks from scratch (or falls back to full-precision vectors).
+         */
+        private void mergePQ(RemappedRandomAccessVectorValues compactRavv) throws IOException {
+            final int totalVectorsCount = size;
+            final String fieldName = fieldInfo.name;
             final PQVectors compactPqVectors;
             // Get the leading reader
             PerFieldKnnVectorsFormat.FieldsReader fieldsReader = (PerFieldKnnVectorsFormat.FieldsReader) readers[LEADING_READER_IDX];
             JVectorReader leadingReader = (JVectorReader) fieldsReader.getFieldReader(fieldName);
-            final RemappedRandomAccessVectorValues compactRavv = compactRavvEarly;
 
             // Check if the leading reader has pre-existing PQ codebooks and if so, refine them with the remaining vectors
             if (leadingReader.getProductQuantizationForField(fieldInfo.name).isEmpty()) {
@@ -1062,7 +1150,7 @@ public class JVectorWriter extends KnnVectorsWriter {
                         totalVectorsCount,
                         minimumBatchSizeForQuantization
                     );
-                    compactPqVectors = getPQVectors(compactRavv, fieldInfo);
+                    compactPqVectors = getPrimaryPQVectors(compactRavv, fieldInfo);
                 } else {
                     log.info(
                         "Not enough vectors found for field: {}, totalVectorCount: {}, is below minimumBatchSizeForQuantization: {}",

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -47,7 +47,6 @@ import java.io.UnsupportedEncodingException;
 import java.time.Clock;
 import java.util.*;
 import java.util.concurrent.ForkJoinPool;
-import java.util.function.Function;
 import java.util.stream.IntStream;
 
 import static io.github.jbellis.jvector.quantization.KMeansPlusPlusClusterer.UNWEIGHTED;
@@ -95,13 +94,10 @@ public class JVectorWriter extends KnnVectorsWriter {
     private final int beamWidth;
     private final float degreeOverflow;
     private final float alpha;
-    private final Function<Integer, Integer> numberOfSubspacesPerVectorSupplier; // Number of subspaces used per vector for PQ quantization
-                                                                                 // as a function of the original dimension
+    private final JVectorIndexQuantization quantization;
     private final int minimumBatchSizeForQuantization; // Threshold for the vector count above which we will trigger PQ quantization
     private final boolean hierarchyEnabled;
     private final boolean leadingSegmentMergeDisabled;
-    private final String quantizationType;
-    private final int numNvqSubvectors;
 
     private final ForkJoinPool simdPoolMerge;
     private final ForkJoinPool simdPoolFlush;
@@ -115,12 +111,10 @@ public class JVectorWriter extends KnnVectorsWriter {
         int beamWidth,
         float degreeOverflow,
         float alpha,
-        Function<Integer, Integer> numberOfSubspacesPerVectorSupplier,
+        JVectorIndexQuantization quantization,
         int minimumBatchSizeForQuantization,
         boolean hierarchyEnabled,
         boolean leadingSegmentMergeDisabled,
-        String quantizationType,
-        int numNvqSubvectors,
         final ForkJoinPool simdPoolMerge,
         final ForkJoinPool simdPoolFlush,
         final ForkJoinPool parallelismPool
@@ -130,12 +124,10 @@ public class JVectorWriter extends KnnVectorsWriter {
         this.beamWidth = beamWidth;
         this.degreeOverflow = degreeOverflow;
         this.alpha = alpha;
-        this.numberOfSubspacesPerVectorSupplier = numberOfSubspacesPerVectorSupplier;
+        this.quantization = quantization;
         this.minimumBatchSizeForQuantization = minimumBatchSizeForQuantization;
         this.hierarchyEnabled = hierarchyEnabled;
         this.leadingSegmentMergeDisabled = leadingSegmentMergeDisabled;
-        this.quantizationType = quantizationType;
-        this.numNvqSubvectors = numNvqSubvectors;
         this.simdPoolMerge = simdPoolMerge;
         this.simdPoolFlush = simdPoolFlush;
         this.parallelismPool = parallelismPool;
@@ -233,7 +225,7 @@ public class JVectorWriter extends KnnVectorsWriter {
             final NVQVectors nvqVectors;
             final FieldInfo fieldInfo = field.fieldInfo;
             if (randomAccessVectorValues.size() >= minimumBatchSizeForQuantization) {
-                log.info("Calculating codebooks and compressed vectors for field {} using {}", fieldInfo.name, quantizationType);
+                log.info("Calculating codebooks and compressed vectors for field {} using {}", fieldInfo.name, quantization.getType());
                 if (isNVQ()) {
                     nvqVectors = getNVQVectors(randomAccessVectorValues, fieldInfo);
                     pqVectors = getPQVectors(randomAccessVectorValues, fieldInfo);
@@ -446,7 +438,10 @@ public class JVectorWriter extends KnnVectorsWriter {
         final VectorSimilarityFunction vectorSimilarityFunction = fieldInfo.getVectorSimilarityFunction();
         log.info("Computing PQ codebooks for field {} for {} vectors", fieldName, randomAccessVectorValues.size());
         final long start = Clock.systemDefaultZone().millis();
-        final var M = numberOfSubspacesPerVectorSupplier.apply(randomAccessVectorValues.dimension());
+        // NVQ auxiliary PQ always uses the PQ-default subspace count, not the NVQ subvector count
+        final int M = isNVQ()
+            ? JVectorIndexQuantization.PQ.defaultNumSubspaces(randomAccessVectorValues.dimension())
+            : quantization.numSubspaces(randomAccessVectorValues.dimension());
         final var numberOfClustersPerSubspace = Math.min(256, randomAccessVectorValues.size()); // number of centroids per
         // subspace
         ProductQuantization pq = ProductQuantization.compute(
@@ -481,14 +476,14 @@ public class JVectorWriter extends KnnVectorsWriter {
     static final byte QUANTIZATION_TYPE_NVQ_INLINE = 2;
 
     private boolean isNVQ() {
-        return org.opensearch.knn.common.KNNConstants.QUANTIZATION_TYPE_NVQ.equals(quantizationType);
+        return quantization instanceof JVectorIndexQuantization.NVQ;
     }
 
     private NVQVectors getNVQVectors(RandomAccessVectorValues randomAccessVectorValues, FieldInfo fieldInfo) throws IOException {
         final String fieldName = fieldInfo.name;
         log.info("Computing NVQ parameters for field {} for {} vectors", fieldName, randomAccessVectorValues.size());
         final long start = Clock.systemDefaultZone().millis();
-        final int nSubVectors = numNvqSubvectors;
+        final int nSubVectors = ((JVectorIndexQuantization.NVQ) quantization).getNumSubvectors();
         NVQuantization nvq = NVQuantization.compute(randomAccessVectorValues, nSubVectors);
         final long trainingTime = Clock.systemDefaultZone().millis() - start;
         log.info("Computed NVQ parameters for field {}, in {} millis", fieldName, trainingTime);

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -49,7 +49,6 @@ import java.util.*;
 import java.util.concurrent.ForkJoinPool;
 import java.util.stream.IntStream;
 
-import static io.github.jbellis.jvector.quantization.KMeansPlusPlusClusterer.UNWEIGHTED;
 import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsReader.readVectorEncoding;
 
 /**
@@ -221,7 +220,7 @@ public class JVectorWriter extends KnnVectorsWriter {
         for (FieldWriter<?> field : fields) {
             final RandomAccessVectorValues randomAccessVectorValues = field.randomAccessVectorValues;
             final FieldInfo fieldInfo = field.fieldInfo;
-            final FieldQuantizationResult quantizationResult = quantizeForFlush(randomAccessVectorValues, fieldInfo);
+            final JVectorIndexQuantization.QuantizationResult quantizationResult = quantizeForFlush(randomAccessVectorValues, fieldInfo);
 
             // Generate the ord to doc mapping
             final int[] ordinalsToDocIds = new int[randomAccessVectorValues.size()];
@@ -237,22 +236,22 @@ public class JVectorWriter extends KnnVectorsWriter {
             }
 
             OnHeapGraphIndex graph = getGraph(
-                quantizationResult.buildScoreProvider,
+                quantizationResult.buildScoreProvider(),
                 randomAccessVectorValues,
                 fieldInfo,
                 segmentWriteState.segmentInfo.name,
                 simdPoolFlush
             );
-            if (quantizationResult.compressedVectors instanceof NVQVectors nvqVectors) {
+            if (quantizationResult.compressedVectors() instanceof NVQVectors nvqVectors) {
                 writeField(
                     field.fieldInfo,
                     randomAccessVectorValues,
                     nvqVectors,
-                    quantizationResult.auxiliaryPqVectors,
+                    quantizationResult.auxiliaryPqVectors(),
                     graphNodeIdToDocMap,
                     graph
                 );
-            } else if (quantizationResult.compressedVectors instanceof PQVectors pqVectors) {
+            } else if (quantizationResult.compressedVectors() instanceof PQVectors pqVectors) {
                 writeField(field.fieldInfo, randomAccessVectorValues, pqVectors, graphNodeIdToDocMap, graph);
             } else {
                 writeField(field.fieldInfo, randomAccessVectorValues, graphNodeIdToDocMap, graph);
@@ -261,22 +260,10 @@ public class JVectorWriter extends KnnVectorsWriter {
         }
     }
 
-    /** Holds the result of quantizing a field's vectors ahead of graph construction during flush. */
-    private static final class FieldQuantizationResult {
-        final CompressedVectors compressedVectors;
-        // Present only for NVQ: the auxiliary PQ vectors used as the build-time score provider.
-        final PQVectors auxiliaryPqVectors;
-        final BuildScoreProvider buildScoreProvider;
-
-        FieldQuantizationResult(CompressedVectors compressedVectors, PQVectors auxiliaryPqVectors, BuildScoreProvider buildScoreProvider) {
-            this.compressedVectors = compressedVectors;
-            this.auxiliaryPqVectors = auxiliaryPqVectors;
-            this.buildScoreProvider = buildScoreProvider;
-        }
-    }
-
-    private FieldQuantizationResult quantizeForFlush(RandomAccessVectorValues randomAccessVectorValues, FieldInfo fieldInfo)
-        throws IOException {
+    private JVectorIndexQuantization.QuantizationResult quantizeForFlush(
+        RandomAccessVectorValues randomAccessVectorValues,
+        FieldInfo fieldInfo
+    ) throws IOException {
         if (randomAccessVectorValues.size() < minimumBatchSizeForQuantization) {
             log.info(
                 "Vector count: {}, less than limit to trigger quantization: {}, for field {}, will use full precision vectors instead.",
@@ -288,27 +275,11 @@ public class JVectorWriter extends KnnVectorsWriter {
                 randomAccessVectorValues,
                 getVectorSimilarityFunction(fieldInfo)
             );
-            return new FieldQuantizationResult(null, null, buildScoreProvider);
+            return new JVectorIndexQuantization.QuantizationResult(null, null, buildScoreProvider);
         }
 
         log.info("Calculating codebooks and compressed vectors for field {} using {}", fieldInfo.name, quantization.getType());
-        return isNVQ() ? quantizeWithNVQ(randomAccessVectorValues, fieldInfo) : quantizeWithPQ(randomAccessVectorValues, fieldInfo);
-    }
-
-    private FieldQuantizationResult quantizeWithNVQ(RandomAccessVectorValues randomAccessVectorValues, FieldInfo fieldInfo)
-        throws IOException {
-        // NVQ (for disk) and PQ (for codebooks) are both used when NVQ is enabled
-        NVQVectors nvqVectors = getNVQVectors(randomAccessVectorValues, fieldInfo);
-        PQVectors pqVectors = getAuxiliaryPqVectorsForNvq(randomAccessVectorValues, fieldInfo);
-        BuildScoreProvider buildScoreProvider = BuildScoreProvider.pqBuildScoreProvider(getVectorSimilarityFunction(fieldInfo), pqVectors);
-        return new FieldQuantizationResult(nvqVectors, pqVectors, buildScoreProvider);
-    }
-
-    private FieldQuantizationResult quantizeWithPQ(RandomAccessVectorValues randomAccessVectorValues, FieldInfo fieldInfo)
-        throws IOException {
-        PQVectors pqVectors = getPrimaryPQVectors(randomAccessVectorValues, fieldInfo);
-        BuildScoreProvider buildScoreProvider = BuildScoreProvider.pqBuildScoreProvider(getVectorSimilarityFunction(fieldInfo), pqVectors);
-        return new FieldQuantizationResult(pqVectors, null, buildScoreProvider);
+        return quantization.quantize(randomAccessVectorValues, getVectorSimilarityFunction(fieldInfo), simdPoolMerge);
     }
 
     private void writeField(
@@ -489,7 +460,7 @@ public class JVectorWriter extends KnnVectorsWriter {
                 resultBuilder.compressedVectorsOffset(0);
                 resultBuilder.compressedVectorsLength(0);
             }
-            resultBuilder.quantizationType(JVectorIndexQuantization.QUANTIZATION_TYPE_NVQ);
+            resultBuilder.quantizationType(JVectorIndexQuantization.QUANTIZATION_TYPE_NVQ_INLINE);
             CodecUtil.writeFooter(indexOutput);
         }
     }
@@ -536,79 +507,6 @@ public class JVectorWriter extends KnnVectorsWriter {
             }
             CodecUtil.writeFooter(indexOutput);
         }
-    }
-
-    /** PQ-only field: subspace count comes from the configured {@link JVectorIndexQuantization}. */
-    private PQVectors getPrimaryPQVectors(RandomAccessVectorValues randomAccessVectorValues, FieldInfo fieldInfo) throws IOException {
-        return computePQVectors(randomAccessVectorValues, fieldInfo, quantization.numSubspaces(randomAccessVectorValues.dimension()));
-    }
-
-    /** NVQ field: the auxiliary PQ blob always uses the PQ-default subspace count, never the NVQ subvector count. */
-    private PQVectors getAuxiliaryPqVectorsForNvq(RandomAccessVectorValues randomAccessVectorValues, FieldInfo fieldInfo)
-        throws IOException {
-        return computePQVectors(
-            randomAccessVectorValues,
-            fieldInfo,
-            JVectorIndexQuantization.PQ.defaultNumSubspaces(randomAccessVectorValues.dimension())
-        );
-    }
-
-    private PQVectors computePQVectors(RandomAccessVectorValues randomAccessVectorValues, FieldInfo fieldInfo, int numSubspaces)
-        throws IOException {
-        final String fieldName = fieldInfo.name;
-        final VectorSimilarityFunction vectorSimilarityFunction = fieldInfo.getVectorSimilarityFunction();
-        log.info("Computing PQ codebooks for field {} for {} vectors", fieldName, randomAccessVectorValues.size());
-        final long start = Clock.systemDefaultZone().millis();
-        final var numberOfClustersPerSubspace = Math.min(256, randomAccessVectorValues.size()); // number of centroids per
-        // subspace
-        ProductQuantization pq = ProductQuantization.compute(
-            randomAccessVectorValues,
-            numSubspaces,
-            numberOfClustersPerSubspace, // number of centroids per subspace
-            vectorSimilarityFunction == VectorSimilarityFunction.EUCLIDEAN, // center the dataset
-            UNWEIGHTED,
-            simdPoolMerge,
-            ForkJoinPool.commonPool()
-        );
-
-        final long end = Clock.systemDefaultZone().millis();
-        final long trainingTime = end - start;
-        log.info("Computed PQ codebooks for field {}, in {} millis", fieldName, trainingTime);
-        KNNCounter.KNN_QUANTIZATION_TRAINING_TIME.add(trainingTime);
-        log.info("Encoding and building PQ vectors for field {} for {} vectors", fieldName, randomAccessVectorValues.size());
-        // PQVectors pqVectors = pq.encodeAll(randomAccessVectorValues, SIMD_POOL);
-        PQVectors pqVectors = PQVectors.encodeAndBuild(pq, randomAccessVectorValues.size(), randomAccessVectorValues, simdPoolMerge);
-        log.info(
-            "Encoded and built PQ vectors for field {}, original size: {} bytes, compressed size: {} bytes",
-            fieldName,
-            pqVectors.getOriginalSize(),
-            pqVectors.getCompressedSize()
-        );
-        return pqVectors;
-    }
-
-    private boolean isNVQ() {
-        return quantization instanceof JVectorIndexQuantization.NVQ;
-    }
-
-    private NVQVectors getNVQVectors(RandomAccessVectorValues randomAccessVectorValues, FieldInfo fieldInfo) throws IOException {
-        final String fieldName = fieldInfo.name;
-        log.info("Computing NVQ parameters for field {} for {} vectors", fieldName, randomAccessVectorValues.size());
-        final long start = Clock.systemDefaultZone().millis();
-        final int nSubVectors = ((JVectorIndexQuantization.NVQ) quantization).getNumSubvectors();
-        NVQuantization nvq = NVQuantization.compute(randomAccessVectorValues, nSubVectors);
-        final long trainingTime = Clock.systemDefaultZone().millis() - start;
-        log.info("Computed NVQ parameters for field {}, in {} millis", fieldName, trainingTime);
-        KNNCounter.KNN_QUANTIZATION_TRAINING_TIME.add(trainingTime);
-        log.info("Encoding NVQ vectors for field {} for {} vectors", fieldName, randomAccessVectorValues.size());
-        NVQVectors nvqVectors = nvq.encodeAll(randomAccessVectorValues, simdPoolMerge);
-        log.info(
-            "Encoded NVQ vectors for field {}, original size: {} bytes, compressed size: {} bytes",
-            fieldName,
-            nvqVectors.getOriginalSize(),
-            nvqVectors.getCompressedSize()
-        );
-        return nvqVectors;
     }
 
     @Value
@@ -1116,7 +1014,7 @@ public class JVectorWriter extends KnnVectorsWriter {
                 return;
             }
 
-            if (isNVQ()) {
+            if (quantization instanceof JVectorIndexQuantization.NVQ) {
                 mergeNVQ(compactRavvEarly);
             } else {
                 mergePQ(compactRavvEarly);
@@ -1132,8 +1030,17 @@ public class JVectorWriter extends KnnVectorsWriter {
             final PQVectors compactNvqAuxPqVectors;
             if (totalLiveVectorsCount >= minimumBatchSizeForQuantization) {
                 log.info("Calculating NVQ compressed vectors for field: {}, with totalVectorCount: {}", fieldName, totalLiveVectorsCount);
-                compactNvqVectors = getNVQVectors(compactRavvEarly, fieldInfo);
-                compactNvqAuxPqVectors = getAuxiliaryPqVectorsForNvq(compactRavvEarly, fieldInfo);
+                compactNvqVectors = JVectorIndexQuantization.computeNvqVectors(
+                    ((JVectorIndexQuantization.NVQ) quantization).getNumSubvectors(),
+                    compactRavvEarly,
+                    simdPoolMerge
+                );
+                compactNvqAuxPqVectors = JVectorIndexQuantization.computePqVectors(
+                    compactRavvEarly,
+                    getVectorSimilarityFunction(fieldInfo),
+                    JVectorIndexQuantization.PQ.defaultNumSubspaces(compactRavvEarly.dimension()),
+                    simdPoolMerge
+                );
             } else {
                 log.info(
                     "Not enough vectors for NVQ for field: {}, totalVectorCount: {} < minimumBatchSizeForQuantization: {}",
@@ -1182,7 +1089,12 @@ public class JVectorWriter extends KnnVectorsWriter {
                         totalVectorsCount,
                         minimumBatchSizeForQuantization
                     );
-                    compactPqVectors = getPrimaryPQVectors(compactRavv, fieldInfo);
+                    compactPqVectors = JVectorIndexQuantization.computePqVectors(
+                        compactRavv,
+                        getVectorSimilarityFunction(fieldInfo),
+                        quantization.numSubspaces(compactRavv.dimension()),
+                        simdPoolMerge
+                    );
                 } else {
                     log.info(
                         "Not enough vectors found for field: {}, totalVectorCount: {}, is below minimumBatchSizeForQuantization: {}",

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -243,14 +243,13 @@ public class JVectorWriter extends KnnVectorsWriter {
                 segmentWriteState.segmentInfo.name,
                 simdPoolFlush
             );
-            writeField(
-                field.fieldInfo,
-                randomAccessVectorValues,
-                quantizationResult.compressedVectors,
-                quantizationResult.auxiliaryPqVectors,
-                graphNodeIdToDocMap,
-                graph
-            );
+            if (quantizationResult.compressedVectors instanceof NVQVectors nvqVectors) {
+                writeField(field.fieldInfo, randomAccessVectorValues, nvqVectors, quantizationResult.auxiliaryPqVectors, graphNodeIdToDocMap, graph);
+            } else if (quantizationResult.compressedVectors instanceof PQVectors pqVectors) {
+                writeField(field.fieldInfo, randomAccessVectorValues, pqVectors, graphNodeIdToDocMap, graph);
+            } else {
+                writeField(field.fieldInfo, randomAccessVectorValues, graphNodeIdToDocMap, graph);
+            }
 
         }
     }
@@ -308,7 +307,7 @@ public class JVectorWriter extends KnnVectorsWriter {
     private void writeField(
         FieldInfo fieldInfo,
         RandomAccessVectorValues randomAccessVectorValues,
-        CompressedVectors compressedVectors,
+        NVQVectors nvqVectors,
         PQVectors auxiliaryPqVectors,
         GraphNodeIdToDocMap graphNodeIdToDocMap,
         OnHeapGraphIndex graph
@@ -319,19 +318,48 @@ public class JVectorWriter extends KnnVectorsWriter {
             randomAccessVectorValues.size(),
             segmentWriteState.segmentInfo.name
         );
-        final var vectorIndexFieldMetadata = writeGraph(
-            graph,
-            randomAccessVectorValues,
-            fieldInfo,
-            compressedVectors,
-            auxiliaryPqVectors,
-            graphNodeIdToDocMap
+        meta.writeInt(fieldInfo.number);
+        writeGraph(graph, randomAccessVectorValues, fieldInfo, nvqVectors, auxiliaryPqVectors, graphNodeIdToDocMap).toOutput(meta);
+        writeScoreCacheFile(fieldInfo, graph);
+    }
+
+    private void writeField(
+        FieldInfo fieldInfo,
+        RandomAccessVectorValues randomAccessVectorValues,
+        PQVectors pqVectors,
+        GraphNodeIdToDocMap graphNodeIdToDocMap,
+        OnHeapGraphIndex graph
+    ) throws IOException {
+        log.info(
+            "Writing field {} with vector count: {}, for segment: {}",
+            fieldInfo.name,
+            randomAccessVectorValues.size(),
+            segmentWriteState.segmentInfo.name
         );
         meta.writeInt(fieldInfo.number);
-        vectorIndexFieldMetadata.toOutput(meta);
+        writeGraph(graph, randomAccessVectorValues, fieldInfo, pqVectors, null, graphNodeIdToDocMap).toOutput(meta);
+        writeScoreCacheFile(fieldInfo, graph);
+    }
 
+    private void writeField(
+        FieldInfo fieldInfo,
+        RandomAccessVectorValues randomAccessVectorValues,
+        GraphNodeIdToDocMap graphNodeIdToDocMap,
+        OnHeapGraphIndex graph
+    ) throws IOException {
+        log.info(
+            "Writing field {} with vector count: {}, for segment: {}",
+            fieldInfo.name,
+            randomAccessVectorValues.size(),
+            segmentWriteState.segmentInfo.name
+        );
+        meta.writeInt(fieldInfo.number);
+        writeGraph(graph, randomAccessVectorValues, fieldInfo, null, null, graphNodeIdToDocMap).toOutput(meta);
+        writeScoreCacheFile(fieldInfo, graph);
+    }
+
+    private void writeScoreCacheFile(FieldInfo fieldInfo, OnHeapGraphIndex graph) throws IOException {
         log.info("Writing neighbors score cache for field {}", fieldInfo.name);
-        // field data file, which contains the graph
         final String neighborsScoreCacheIndexFieldFileName = baseDataFileName
             + "_"
             + fieldInfo.name
@@ -1200,7 +1228,7 @@ public class JVectorWriter extends KnnVectorsWriter {
                     );
                     var bsp = BuildScoreProvider.randomAccessScoreProvider(compactRavv, getVectorSimilarityFunction(fieldInfo));
                     var graph = getGraph(bsp, compactRavv, fieldInfo, segmentWriteState.segmentInfo.name, simdPoolMerge);
-                    writeField(fieldInfo, compactRavv, (CompressedVectors) null, null, compactOrdToDocMap, graph);
+                    writeField(fieldInfo, compactRavv, compactOrdToDocMap, graph);
                 }
             } else {
                 log.info("PQ codebooks found, building graph from scratch with PQ vectors");
@@ -1209,7 +1237,7 @@ public class JVectorWriter extends KnnVectorsWriter {
                 // Pre-init the diversity provider here to avoid doing it lazily (as it could block the SIMD threads)
                 buildScoreProvider.diversityProviderFor(0);
                 var graph = getGraph(buildScoreProvider, compactRavv, fieldInfo, segmentWriteState.segmentInfo.name, simdPoolMerge);
-                writeField(fieldInfo, compactRavv, compactPqVectors, null, compactOrdToDocMap, graph);
+                writeField(fieldInfo, compactRavv, compactPqVectors, compactOrdToDocMap, graph);
             }
         }
 
@@ -1396,7 +1424,7 @@ public class JVectorWriter extends KnnVectorsWriter {
                     // Note that the ordinals for the OnDiskGraphIndex will automatically be compacted
                     // But the OnHeapGraphIndex will not
                     var finalOrdToDocMap = new GraphNodeIdToDocMap(finalOrdToDocId);
-                    writeField(fieldInfo, heapRavv, (CompressedVectors) null, null, finalOrdToDocMap, graph);
+                    writeField(fieldInfo, heapRavv, finalOrdToDocMap, graph);
                     return true;
                 }
             }

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -244,7 +244,14 @@ public class JVectorWriter extends KnnVectorsWriter {
                 simdPoolFlush
             );
             if (quantizationResult.compressedVectors instanceof NVQVectors nvqVectors) {
-                writeField(field.fieldInfo, randomAccessVectorValues, nvqVectors, quantizationResult.auxiliaryPqVectors, graphNodeIdToDocMap, graph);
+                writeField(
+                    field.fieldInfo,
+                    randomAccessVectorValues,
+                    nvqVectors,
+                    quantizationResult.auxiliaryPqVectors,
+                    graphNodeIdToDocMap,
+                    graph
+                );
             } else if (quantizationResult.compressedVectors instanceof PQVectors pqVectors) {
                 writeField(field.fieldInfo, randomAccessVectorValues, pqVectors, graphNodeIdToDocMap, graph);
             } else {
@@ -482,7 +489,7 @@ public class JVectorWriter extends KnnVectorsWriter {
                 resultBuilder.compressedVectorsOffset(0);
                 resultBuilder.compressedVectorsLength(0);
             }
-            resultBuilder.quantizationType(QUANTIZATION_TYPE_NVQ_INLINE);
+            resultBuilder.quantizationType(JVectorIndexQuantization.QUANTIZATION_TYPE_NVQ);
             CodecUtil.writeFooter(indexOutput);
         }
     }
@@ -521,11 +528,11 @@ public class JVectorWriter extends KnnVectorsWriter {
                 resultBuilder.compressedVectorsOffset(endGraphOffset);
                 compressedVectors.write(jVectorIndexWriter);
                 resultBuilder.compressedVectorsLength(jVectorIndexWriter.position() - endGraphOffset);
-                resultBuilder.quantizationType(QUANTIZATION_TYPE_PQ);
+                resultBuilder.quantizationType(JVectorIndexQuantization.QUANTIZATION_TYPE_PQ);
             } else {
                 resultBuilder.compressedVectorsOffset(0);
                 resultBuilder.compressedVectorsLength(0);
-                resultBuilder.quantizationType(QUANTIZATION_TYPE_NONE);
+                resultBuilder.quantizationType(JVectorIndexQuantization.QUANTIZATION_TYPE_NONE);
             }
             CodecUtil.writeFooter(indexOutput);
         }
@@ -579,11 +586,6 @@ public class JVectorWriter extends KnnVectorsWriter {
         );
         return pqVectors;
     }
-
-    // quantizationType byte values stored in VectorIndexFieldMetadata
-    static final byte QUANTIZATION_TYPE_NONE = 0;
-    static final byte QUANTIZATION_TYPE_PQ = 1;
-    static final byte QUANTIZATION_TYPE_NVQ_INLINE = 2;
 
     private boolean isNVQ() {
         return quantization instanceof JVectorIndexQuantization.NVQ;
@@ -652,7 +654,9 @@ public class JVectorWriter extends KnnVectorsWriter {
                 this.quantizationType = in.readByte();
             } else {
                 // v0 segments: infer type — PQ if compressed vectors present, none otherwise
-                this.quantizationType = this.compressedVectorsLength > 0 ? QUANTIZATION_TYPE_PQ : QUANTIZATION_TYPE_NONE;
+                this.quantizationType = this.compressedVectorsLength > 0
+                    ? JVectorIndexQuantization.QUANTIZATION_TYPE_PQ
+                    : JVectorIndexQuantization.QUANTIZATION_TYPE_NONE;
             }
             this.degreeOverflow = Float.intBitsToFloat(in.readInt());
             this.graphNodeIdToDocMap = new GraphNodeIdToDocMap(in);

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -102,7 +102,6 @@ public class JVectorWriter extends KnnVectorsWriter {
     private final boolean leadingSegmentMergeDisabled;
     private final String quantizationType;
     private final int numNvqSubvectors;
-    private final boolean nvqVectorsInline;
 
     private final ForkJoinPool simdPoolMerge;
     private final ForkJoinPool simdPoolFlush;
@@ -122,7 +121,6 @@ public class JVectorWriter extends KnnVectorsWriter {
         boolean leadingSegmentMergeDisabled,
         String quantizationType,
         int numNvqSubvectors,
-        boolean nvqVectorsInline,
         final ForkJoinPool simdPoolMerge,
         final ForkJoinPool simdPoolFlush,
         final ForkJoinPool parallelismPool
@@ -138,7 +136,6 @@ public class JVectorWriter extends KnnVectorsWriter {
         this.leadingSegmentMergeDisabled = leadingSegmentMergeDisabled;
         this.quantizationType = quantizationType;
         this.numNvqSubvectors = numNvqSubvectors;
-        this.nvqVectorsInline = nvqVectorsInline;
         this.simdPoolMerge = simdPoolMerge;
         this.simdPoolFlush = simdPoolFlush;
         this.parallelismPool = parallelismPool;
@@ -239,12 +236,8 @@ public class JVectorWriter extends KnnVectorsWriter {
                 log.info("Calculating codebooks and compressed vectors for field {} using {}", fieldInfo.name, quantizationType);
                 if (isNVQ()) {
                     nvqVectors = getNVQVectors(randomAccessVectorValues, fieldInfo);
-                    pqVectors = null;
-                    // NVQ has no pqBuildScoreProvider equivalent; use full-precision for graph building
-                    buildScoreProvider = BuildScoreProvider.randomAccessScoreProvider(
-                        randomAccessVectorValues,
-                        getVectorSimilarityFunction(fieldInfo)
-                    );
+                    pqVectors = getPQVectors(randomAccessVectorValues, fieldInfo);
+                    buildScoreProvider = BuildScoreProvider.pqBuildScoreProvider(getVectorSimilarityFunction(fieldInfo), pqVectors);
                 } else {
                     pqVectors = getPQVectors(randomAccessVectorValues, fieldInfo);
                     nvqVectors = null;
@@ -286,7 +279,8 @@ public class JVectorWriter extends KnnVectorsWriter {
                 simdPoolFlush
             );
             final CompressedVectors compressedVectors = nvqVectors != null ? nvqVectors : pqVectors;
-            writeField(field.fieldInfo, randomAccessVectorValues, compressedVectors, graphNodeIdToDocMap, graph);
+            final PQVectors auxiliaryPqVectors = nvqVectors != null ? pqVectors : null;
+            writeField(field.fieldInfo, randomAccessVectorValues, compressedVectors, auxiliaryPqVectors, graphNodeIdToDocMap, graph);
 
         }
     }
@@ -295,6 +289,7 @@ public class JVectorWriter extends KnnVectorsWriter {
         FieldInfo fieldInfo,
         RandomAccessVectorValues randomAccessVectorValues,
         CompressedVectors compressedVectors,
+        PQVectors auxiliaryPqVectors,
         GraphNodeIdToDocMap graphNodeIdToDocMap,
         OnHeapGraphIndex graph
     ) throws IOException {
@@ -304,7 +299,7 @@ public class JVectorWriter extends KnnVectorsWriter {
             randomAccessVectorValues.size(),
             segmentWriteState.segmentInfo.name
         );
-        final var vectorIndexFieldMetadata = writeGraph(graph, randomAccessVectorValues, fieldInfo, compressedVectors, graphNodeIdToDocMap);
+        final var vectorIndexFieldMetadata = writeGraph(graph, randomAccessVectorValues, fieldInfo, compressedVectors, auxiliaryPqVectors, graphNodeIdToDocMap);
         meta.writeInt(fieldInfo.number);
         vectorIndexFieldMetadata.toOutput(meta);
 
@@ -348,6 +343,7 @@ public class JVectorWriter extends KnnVectorsWriter {
         RandomAccessVectorValues randomAccessVectorValues,
         FieldInfo fieldInfo,
         CompressedVectors compressedVectors,
+        PQVectors auxiliaryPqVectors,
         GraphNodeIdToDocMap graphNodeIdToDocMap
     ) throws IOException {
         // field data file, which contains the graph
@@ -375,14 +371,10 @@ public class JVectorWriter extends KnnVectorsWriter {
                 .vectorDimension(randomAccessVectorValues.dimension())
                 .graphNodeIdToDocMap(graphNodeIdToDocMap);
 
-            final boolean useNvqInline = compressedVectors instanceof NVQVectors;
-            if (useNvqInline) {
+            if (compressedVectors instanceof NVQVectors) {
                 final NVQVectors nvqVectors = (NVQVectors) compressedVectors;
                 final NVQuantization nvQuantization = nvqVectors.getNVQuantization();
-                log.info(
-                    "Writing NVQ vectors inline with graph nodes for field {} (nvq_vectors_inline=true)",
-                    fieldInfo.name
-                );
+                log.info("Writing NVQ vectors inline with graph nodes for field {}", fieldInfo.name);
                 try (
                     var writer = new OnDiskSequentialGraphIndexWriter.Builder(graph, jVectorIndexWriter).with(
                         new NVQ(nvQuantization)
@@ -396,8 +388,15 @@ public class JVectorWriter extends KnnVectorsWriter {
                     long endGraphOffset = jVectorIndexWriter.position();
                     resultBuilder.vectorIndexOffset(startOffset);
                     resultBuilder.vectorIndexLength(endGraphOffset - startOffset);
-                    resultBuilder.compressedVectorsOffset(0);
-                    resultBuilder.compressedVectorsLength(0);
+                    if (auxiliaryPqVectors != null) {
+                        log.info("Writing auxiliary PQ blob for NVQ field {} for approximate search traversal", fieldInfo.name);
+                        resultBuilder.compressedVectorsOffset(endGraphOffset);
+                        auxiliaryPqVectors.write(jVectorIndexWriter);
+                        resultBuilder.compressedVectorsLength(jVectorIndexWriter.position() - endGraphOffset);
+                    } else {
+                        resultBuilder.compressedVectorsOffset(0);
+                        resultBuilder.compressedVectorsLength(0);
+                    }
                     resultBuilder.quantizationType(QUANTIZATION_TYPE_NVQ_INLINE);
                     CodecUtil.writeFooter(indexOutput);
                 }
@@ -415,30 +414,17 @@ public class JVectorWriter extends KnnVectorsWriter {
                     long endGraphOffset = jVectorIndexWriter.position();
                     resultBuilder.vectorIndexOffset(startOffset);
                     resultBuilder.vectorIndexLength(endGraphOffset - startOffset);
-
                     if (compressedVectors != null) {
-                        final byte qType;
-                        if (compressedVectors instanceof NVQVectors) {
-                            qType = QUANTIZATION_TYPE_NVQ;
-                            log.info(
-                                "Writing NVQ compressed vectors for field {} since the size is {} >= {}",
-                                fieldInfo.name,
-                                randomAccessVectorValues.size(),
-                                minimumBatchSizeForQuantization
-                            );
-                        } else {
-                            qType = QUANTIZATION_TYPE_PQ;
-                            log.info(
-                                "Writing PQ codebooks and vectors for field {} since the size is {} >= {}",
-                                fieldInfo.name,
-                                randomAccessVectorValues.size(),
-                                minimumBatchSizeForQuantization
-                            );
-                        }
+                        log.info(
+                            "Writing PQ codebooks and vectors for field {} since the size is {} >= {}",
+                            fieldInfo.name,
+                            randomAccessVectorValues.size(),
+                            minimumBatchSizeForQuantization
+                        );
                         resultBuilder.compressedVectorsOffset(endGraphOffset);
                         compressedVectors.write(jVectorIndexWriter);
                         resultBuilder.compressedVectorsLength(jVectorIndexWriter.position() - endGraphOffset);
-                        resultBuilder.quantizationType(qType);
+                        resultBuilder.quantizationType(QUANTIZATION_TYPE_PQ);
                     } else {
                         resultBuilder.compressedVectorsOffset(0);
                         resultBuilder.compressedVectorsLength(0);
@@ -489,9 +475,7 @@ public class JVectorWriter extends KnnVectorsWriter {
     // quantizationType byte values stored in VectorIndexFieldMetadata
     static final byte QUANTIZATION_TYPE_NONE = 0;
     static final byte QUANTIZATION_TYPE_PQ = 1;
-    static final byte QUANTIZATION_TYPE_NVQ = 2;
-    // NVQ encoded inline with each graph node (no separate compressed-vector blob)
-    static final byte QUANTIZATION_TYPE_NVQ_INLINE = 3;
+    static final byte QUANTIZATION_TYPE_NVQ_INLINE = 2;
 
     private boolean isNVQ() {
         return org.opensearch.knn.common.KNNConstants.QUANTIZATION_TYPE_NVQ.equals(quantizationType);
@@ -1030,6 +1014,7 @@ public class JVectorWriter extends KnnVectorsWriter {
             // NVQ merge: always recompute from scratch (no refine() equivalent)
             if (isNVQ()) {
                 final NVQVectors compactNvqVectors;
+                final PQVectors compactNvqAuxPqVectors;
                 if (totalLiveVectorsCount >= minimumBatchSizeForQuantization) {
                     log.info(
                         "Calculating NVQ compressed vectors for field: {}, with totalVectorCount: {}",
@@ -1037,6 +1022,7 @@ public class JVectorWriter extends KnnVectorsWriter {
                         totalLiveVectorsCount
                     );
                     compactNvqVectors = getNVQVectors(compactRavvEarly, fieldInfo);
+                    compactNvqAuxPqVectors = getPQVectors(compactRavvEarly, fieldInfo);
                 } else {
                     log.info(
                         "Not enough vectors for NVQ for field: {}, totalVectorCount: {} < minimumBatchSizeForQuantization: {}",
@@ -1045,10 +1031,17 @@ public class JVectorWriter extends KnnVectorsWriter {
                         minimumBatchSizeForQuantization
                     );
                     compactNvqVectors = null;
+                    compactNvqAuxPqVectors = null;
                 }
-                var bsp = BuildScoreProvider.randomAccessScoreProvider(compactRavvEarly, getVectorSimilarityFunction(fieldInfo));
+                final BuildScoreProvider bsp;
+                if (compactNvqAuxPqVectors != null) {
+                    bsp = BuildScoreProvider.pqBuildScoreProvider(getVectorSimilarityFunction(fieldInfo), compactNvqAuxPqVectors);
+                    bsp.diversityProviderFor(0);
+                } else {
+                    bsp = BuildScoreProvider.randomAccessScoreProvider(compactRavvEarly, getVectorSimilarityFunction(fieldInfo));
+                }
                 var graph = getGraph(bsp, compactRavvEarly, fieldInfo, segmentWriteState.segmentInfo.name, simdPoolMerge);
-                writeField(fieldInfo, compactRavvEarly, compactNvqVectors, compactOrdToDocMap, graph);
+                writeField(fieldInfo, compactRavvEarly, compactNvqVectors, compactNvqAuxPqVectors, compactOrdToDocMap, graph);
                 return;
             }
 
@@ -1123,7 +1116,7 @@ public class JVectorWriter extends KnnVectorsWriter {
                     );
                     var bsp = BuildScoreProvider.randomAccessScoreProvider(compactRavv, getVectorSimilarityFunction(fieldInfo));
                     var graph = getGraph(bsp, compactRavv, fieldInfo, segmentWriteState.segmentInfo.name, simdPoolMerge);
-                    writeField(fieldInfo, compactRavv, (CompressedVectors) null, compactOrdToDocMap, graph);
+                    writeField(fieldInfo, compactRavv, (CompressedVectors) null, null, compactOrdToDocMap, graph);
                 }
             } else {
                 log.info("PQ codebooks found, building graph from scratch with PQ vectors");
@@ -1132,7 +1125,7 @@ public class JVectorWriter extends KnnVectorsWriter {
                 // Pre-init the diversity provider here to avoid doing it lazily (as it could block the SIMD threads)
                 buildScoreProvider.diversityProviderFor(0);
                 var graph = getGraph(buildScoreProvider, compactRavv, fieldInfo, segmentWriteState.segmentInfo.name, simdPoolMerge);
-                writeField(fieldInfo, compactRavv, compactPqVectors, compactOrdToDocMap, graph);
+                writeField(fieldInfo, compactRavv, compactPqVectors, null, compactOrdToDocMap, graph);
             }
         }
 
@@ -1319,7 +1312,7 @@ public class JVectorWriter extends KnnVectorsWriter {
                     // Note that the ordinals for the OnDiskGraphIndex will automatically be compacted
                     // But the OnHeapGraphIndex will not
                     var finalOrdToDocMap = new GraphNodeIdToDocMap(finalOrdToDocId);
-                    writeField(fieldInfo, heapRavv, (CompressedVectors) null, finalOrdToDocMap, graph);
+                    writeField(fieldInfo, heapRavv, (CompressedVectors) null, null, finalOrdToDocMap, graph);
                     return true;
                 }
             }

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -299,7 +299,14 @@ public class JVectorWriter extends KnnVectorsWriter {
             randomAccessVectorValues.size(),
             segmentWriteState.segmentInfo.name
         );
-        final var vectorIndexFieldMetadata = writeGraph(graph, randomAccessVectorValues, fieldInfo, compressedVectors, auxiliaryPqVectors, graphNodeIdToDocMap);
+        final var vectorIndexFieldMetadata = writeGraph(
+            graph,
+            randomAccessVectorValues,
+            fieldInfo,
+            compressedVectors,
+            auxiliaryPqVectors,
+            graphNodeIdToDocMap
+        );
         meta.writeInt(fieldInfo.number);
         vectorIndexFieldMetadata.toOutput(meta);
 
@@ -376,14 +383,10 @@ public class JVectorWriter extends KnnVectorsWriter {
                 final NVQuantization nvQuantization = nvqVectors.getNVQuantization();
                 log.info("Writing NVQ vectors inline with graph nodes for field {}", fieldInfo.name);
                 try (
-                    var writer = new OnDiskSequentialGraphIndexWriter.Builder(graph, jVectorIndexWriter).with(
-                        new NVQ(nvQuantization)
-                    ).build()
+                    var writer = new OnDiskSequentialGraphIndexWriter.Builder(graph, jVectorIndexWriter).with(new NVQ(nvQuantization))
+                        .build()
                 ) {
-                    var suppliers = Feature.singleStateFactory(
-                        FeatureId.NVQ_VECTORS,
-                        nodeId -> new NVQ.State(nvqVectors.get(nodeId))
-                    );
+                    var suppliers = Feature.singleStateFactory(FeatureId.NVQ_VECTORS, nodeId -> new NVQ.State(nvqVectors.get(nodeId)));
                     writer.write(suppliers);
                     long endGraphOffset = jVectorIndexWriter.position();
                     resultBuilder.vectorIndexOffset(startOffset);
@@ -485,9 +488,7 @@ public class JVectorWriter extends KnnVectorsWriter {
         final String fieldName = fieldInfo.name;
         log.info("Computing NVQ parameters for field {} for {} vectors", fieldName, randomAccessVectorValues.size());
         final long start = Clock.systemDefaultZone().millis();
-        final int nSubVectors = numNvqSubvectors == org.opensearch.knn.common.KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS
-            ? numberOfSubspacesPerVectorSupplier.apply(randomAccessVectorValues.dimension())
-            : numNvqSubvectors;
+        final int nSubVectors = numNvqSubvectors;
         NVQuantization nvq = NVQuantization.compute(randomAccessVectorValues, nSubVectors);
         final long trainingTime = Clock.systemDefaultZone().millis() - start;
         log.info("Computed NVQ parameters for field {}, in {} millis", fieldName, trainingTime);

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -10,6 +10,7 @@ import io.github.jbellis.jvector.graph.disk.*;
 import io.github.jbellis.jvector.graph.disk.feature.Feature;
 import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
 import io.github.jbellis.jvector.graph.disk.feature.InlineVectors;
+import io.github.jbellis.jvector.graph.disk.feature.NVQ;
 import io.github.jbellis.jvector.graph.diversity.VamanaDiversityProvider;
 import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
 import io.github.jbellis.jvector.quantization.CompressedVectors;
@@ -101,6 +102,7 @@ public class JVectorWriter extends KnnVectorsWriter {
     private final boolean leadingSegmentMergeDisabled;
     private final String quantizationType;
     private final int numNvqSubvectors;
+    private final boolean nvqVectorsInline;
 
     private final ForkJoinPool simdPoolMerge;
     private final ForkJoinPool simdPoolFlush;
@@ -120,6 +122,7 @@ public class JVectorWriter extends KnnVectorsWriter {
         boolean leadingSegmentMergeDisabled,
         String quantizationType,
         int numNvqSubvectors,
+        boolean nvqVectorsInline,
         final ForkJoinPool simdPoolMerge,
         final ForkJoinPool simdPoolFlush,
         final ForkJoinPool parallelismPool
@@ -135,6 +138,7 @@ public class JVectorWriter extends KnnVectorsWriter {
         this.leadingSegmentMergeDisabled = leadingSegmentMergeDisabled;
         this.quantizationType = quantizationType;
         this.numNvqSubvectors = numNvqSubvectors;
+        this.nvqVectorsInline = nvqVectorsInline;
         this.simdPoolMerge = simdPoolMerge;
         this.simdPoolFlush = simdPoolFlush;
         this.parallelismPool = parallelismPool;
@@ -371,49 +375,77 @@ public class JVectorWriter extends KnnVectorsWriter {
                 .vectorDimension(randomAccessVectorValues.dimension())
                 .graphNodeIdToDocMap(graphNodeIdToDocMap);
 
-            try (
-                var writer = new OnDiskSequentialGraphIndexWriter.Builder(graph, jVectorIndexWriter).with(
-                    new InlineVectors(randomAccessVectorValues.dimension())
-                ).build()
-            ) {
-                var suppliers = Feature.singleStateFactory(
-                    FeatureId.INLINE_VECTORS,
-                    nodeId -> new InlineVectors.State(randomAccessVectorValues.getVector(nodeId))
+            final boolean useNvqInline = compressedVectors instanceof NVQVectors;
+            if (useNvqInline) {
+                final NVQVectors nvqVectors = (NVQVectors) compressedVectors;
+                final NVQuantization nvQuantization = nvqVectors.getNVQuantization();
+                log.info(
+                    "Writing NVQ vectors inline with graph nodes for field {} (nvq_vectors_inline=true)",
+                    fieldInfo.name
                 );
-                writer.write(suppliers);
-                long endGraphOffset = jVectorIndexWriter.position();
-                resultBuilder.vectorIndexOffset(startOffset);
-                resultBuilder.vectorIndexLength(endGraphOffset - startOffset);
-
-                if (compressedVectors != null) {
-                    final byte qType;
-                    if (compressedVectors instanceof NVQVectors) {
-                        qType = QUANTIZATION_TYPE_NVQ;
-                        log.info(
-                            "Writing NVQ compressed vectors for field {} since the size is {} >= {}",
-                            fieldInfo.name,
-                            randomAccessVectorValues.size(),
-                            minimumBatchSizeForQuantization
-                        );
-                    } else {
-                        qType = QUANTIZATION_TYPE_PQ;
-                        log.info(
-                            "Writing PQ codebooks and vectors for field {} since the size is {} >= {}",
-                            fieldInfo.name,
-                            randomAccessVectorValues.size(),
-                            minimumBatchSizeForQuantization
-                        );
-                    }
-                    resultBuilder.compressedVectorsOffset(endGraphOffset);
-                    compressedVectors.write(jVectorIndexWriter);
-                    resultBuilder.compressedVectorsLength(jVectorIndexWriter.position() - endGraphOffset);
-                    resultBuilder.quantizationType(qType);
-                } else {
+                try (
+                    var writer = new OnDiskSequentialGraphIndexWriter.Builder(graph, jVectorIndexWriter).with(
+                        new NVQ(nvQuantization)
+                    ).build()
+                ) {
+                    var suppliers = Feature.singleStateFactory(
+                        FeatureId.NVQ_VECTORS,
+                        nodeId -> new NVQ.State(nvqVectors.get(nodeId))
+                    );
+                    writer.write(suppliers);
+                    long endGraphOffset = jVectorIndexWriter.position();
+                    resultBuilder.vectorIndexOffset(startOffset);
+                    resultBuilder.vectorIndexLength(endGraphOffset - startOffset);
                     resultBuilder.compressedVectorsOffset(0);
                     resultBuilder.compressedVectorsLength(0);
-                    resultBuilder.quantizationType(QUANTIZATION_TYPE_NONE);
+                    resultBuilder.quantizationType(QUANTIZATION_TYPE_NVQ_INLINE);
+                    CodecUtil.writeFooter(indexOutput);
                 }
-                CodecUtil.writeFooter(indexOutput);
+            } else {
+                try (
+                    var writer = new OnDiskSequentialGraphIndexWriter.Builder(graph, jVectorIndexWriter).with(
+                        new InlineVectors(randomAccessVectorValues.dimension())
+                    ).build()
+                ) {
+                    var suppliers = Feature.singleStateFactory(
+                        FeatureId.INLINE_VECTORS,
+                        nodeId -> new InlineVectors.State(randomAccessVectorValues.getVector(nodeId))
+                    );
+                    writer.write(suppliers);
+                    long endGraphOffset = jVectorIndexWriter.position();
+                    resultBuilder.vectorIndexOffset(startOffset);
+                    resultBuilder.vectorIndexLength(endGraphOffset - startOffset);
+
+                    if (compressedVectors != null) {
+                        final byte qType;
+                        if (compressedVectors instanceof NVQVectors) {
+                            qType = QUANTIZATION_TYPE_NVQ;
+                            log.info(
+                                "Writing NVQ compressed vectors for field {} since the size is {} >= {}",
+                                fieldInfo.name,
+                                randomAccessVectorValues.size(),
+                                minimumBatchSizeForQuantization
+                            );
+                        } else {
+                            qType = QUANTIZATION_TYPE_PQ;
+                            log.info(
+                                "Writing PQ codebooks and vectors for field {} since the size is {} >= {}",
+                                fieldInfo.name,
+                                randomAccessVectorValues.size(),
+                                minimumBatchSizeForQuantization
+                            );
+                        }
+                        resultBuilder.compressedVectorsOffset(endGraphOffset);
+                        compressedVectors.write(jVectorIndexWriter);
+                        resultBuilder.compressedVectorsLength(jVectorIndexWriter.position() - endGraphOffset);
+                        resultBuilder.quantizationType(qType);
+                    } else {
+                        resultBuilder.compressedVectorsOffset(0);
+                        resultBuilder.compressedVectorsLength(0);
+                        resultBuilder.quantizationType(QUANTIZATION_TYPE_NONE);
+                    }
+                    CodecUtil.writeFooter(indexOutput);
+                }
             }
 
             return resultBuilder.build();
@@ -458,6 +490,8 @@ public class JVectorWriter extends KnnVectorsWriter {
     static final byte QUANTIZATION_TYPE_NONE = 0;
     static final byte QUANTIZATION_TYPE_PQ = 1;
     static final byte QUANTIZATION_TYPE_NVQ = 2;
+    // NVQ encoded inline with each graph node (no separate compressed-vector blob)
+    static final byte QUANTIZATION_TYPE_NVQ_INLINE = 3;
 
     private boolean isNVQ() {
         return org.opensearch.knn.common.KNNConstants.QUANTIZATION_TYPE_NVQ.equals(quantizationType);

--- a/src/main/java/org/opensearch/knn/index/codec/params/KNNVectorsFormatParams.java
+++ b/src/main/java/org/opensearch/knn/index/codec/params/KNNVectorsFormatParams.java
@@ -27,6 +27,8 @@ public class KNNVectorsFormatParams {
     private Function<Integer, Integer> numberOfSubspacesPerVectorSupplier;
     private final SpaceType spaceType;
     private boolean leadingSegmentMergeDisabled;
+    private String quantizationType;
+    private int numNvqSubvectors;
 
     public KNNVectorsFormatParams(final Map<String, Object> params, int defaultMaxConnections, int defaultBeamWidth) {
         this(
@@ -60,6 +62,8 @@ public class KNNVectorsFormatParams {
         initNumberOfSubspacesPerVectorSupplier(params);
         this.spaceType = spaceType;
         initLeadingSegmentMergeDisabled(params, KNNConstants.DEFAULT_LEADING_SEGMENT_MERGE_DISABLED);
+        initQuantizationType(params);
+        initNumNvqSubvectors(params);
     }
 
     public boolean validate(final Map<String, Object> params) {
@@ -129,5 +133,21 @@ public class KNNVectorsFormatParams {
             return;
         }
         this.leadingSegmentMergeDisabled = defaultLsmDisabled;
+    }
+
+    private void initQuantizationType(final Map<String, Object> params) {
+        if (params != null && params.containsKey(KNNConstants.METHOD_PARAMETER_QUANTIZATION_TYPE)) {
+            this.quantizationType = (String) params.get(KNNConstants.METHOD_PARAMETER_QUANTIZATION_TYPE);
+            return;
+        }
+        this.quantizationType = KNNConstants.DEFAULT_QUANTIZATION_TYPE;
+    }
+
+    private void initNumNvqSubvectors(final Map<String, Object> params) {
+        if (params != null && params.containsKey(KNNConstants.METHOD_PARAMETER_NUM_NVQ_SUBVECTORS)) {
+            this.numNvqSubvectors = (int) params.get(KNNConstants.METHOD_PARAMETER_NUM_NVQ_SUBVECTORS);
+            return;
+        }
+        this.numNvqSubvectors = KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS;
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/params/KNNVectorsFormatParams.java
+++ b/src/main/java/org/opensearch/knn/index/codec/params/KNNVectorsFormatParams.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.index.codec.params;
 
 import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.codec.jvector.JVectorFormat;
@@ -17,6 +18,7 @@ import java.util.function.Function;
  * Class provides params for LuceneHNSWVectorsFormat
  */
 @Getter
+@Log4j2
 public class KNNVectorsFormatParams {
     private int maxConnections;
     private int beamWidth;
@@ -146,8 +148,19 @@ public class KNNVectorsFormatParams {
     private void initNumNvqSubvectors(final Map<String, Object> params) {
         if (params != null && params.containsKey(KNNConstants.METHOD_PARAMETER_NUM_NVQ_SUBVECTORS)) {
             this.numNvqSubvectors = (int) params.get(KNNConstants.METHOD_PARAMETER_NUM_NVQ_SUBVECTORS);
-            return;
-        }
+            log.info(
+                "NVQ is used, and {} is set to {}",
+                KNNConstants.METHOD_PARAMETER_NUM_NVQ_SUBVECTORS,
+                KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS
+            );
+        } else if (params.containsKey(KNNConstants.METHOD_PARAMETER_QUANTIZATION_TYPE)
+            && params.get(KNNConstants.METHOD_PARAMETER_QUANTIZATION_TYPE).equals(KNNConstants.QUANTIZATION_TYPE_NVQ)) {
+                log.info(
+                    "NVQ is used, and {} not set; defaulting to {}",
+                    KNNConstants.METHOD_PARAMETER_NUM_NVQ_SUBVECTORS,
+                    KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS
+                );
+            }
         this.numNvqSubvectors = KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS;
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/params/KNNVectorsFormatParams.java
+++ b/src/main/java/org/opensearch/knn/index/codec/params/KNNVectorsFormatParams.java
@@ -29,7 +29,6 @@ public class KNNVectorsFormatParams {
     private boolean leadingSegmentMergeDisabled;
     private String quantizationType;
     private int numNvqSubvectors;
-    private boolean nvqVectorsInline;
 
     public KNNVectorsFormatParams(final Map<String, Object> params, int defaultMaxConnections, int defaultBeamWidth) {
         this(
@@ -65,7 +64,6 @@ public class KNNVectorsFormatParams {
         initLeadingSegmentMergeDisabled(params, KNNConstants.DEFAULT_LEADING_SEGMENT_MERGE_DISABLED);
         initQuantizationType(params);
         initNumNvqSubvectors(params);
-        initNvqVectorsInline(params);
     }
 
     public boolean validate(final Map<String, Object> params) {
@@ -153,11 +151,4 @@ public class KNNVectorsFormatParams {
         this.numNvqSubvectors = KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS;
     }
 
-    private void initNvqVectorsInline(final Map<String, Object> params) {
-        if (params != null && params.containsKey(KNNConstants.METHOD_PARAMETER_NVQ_VECTORS_INLINE)) {
-            this.nvqVectorsInline = (boolean) params.get(KNNConstants.METHOD_PARAMETER_NVQ_VECTORS_INLINE);
-            return;
-        }
-        this.nvqVectorsInline = KNNConstants.DEFAULT_NVQ_VECTORS_INLINE;
-    }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/params/KNNVectorsFormatParams.java
+++ b/src/main/java/org/opensearch/knn/index/codec/params/KNNVectorsFormatParams.java
@@ -148,20 +148,19 @@ public class KNNVectorsFormatParams {
     private void initNumNvqSubvectors(final Map<String, Object> params) {
         if (params != null && params.containsKey(KNNConstants.METHOD_PARAMETER_NUM_NVQ_SUBVECTORS)) {
             this.numNvqSubvectors = (int) params.get(KNNConstants.METHOD_PARAMETER_NUM_NVQ_SUBVECTORS);
+            log.info("NVQ is used, and {} is set to {}", KNNConstants.METHOD_PARAMETER_NUM_NVQ_SUBVECTORS, this.numNvqSubvectors);
+            return;
+        }
+        this.numNvqSubvectors = KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS;
+        if (params != null
+            && params.containsKey(KNNConstants.METHOD_PARAMETER_QUANTIZATION_TYPE)
+            && params.get(KNNConstants.METHOD_PARAMETER_QUANTIZATION_TYPE).equals(KNNConstants.QUANTIZATION_TYPE_NVQ)) {
             log.info(
-                "NVQ is used, and {} is set to {}",
+                "NVQ is used, and {} not set; defaulting to {}",
                 KNNConstants.METHOD_PARAMETER_NUM_NVQ_SUBVECTORS,
                 KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS
             );
-        } else if (params.containsKey(KNNConstants.METHOD_PARAMETER_QUANTIZATION_TYPE)
-            && params.get(KNNConstants.METHOD_PARAMETER_QUANTIZATION_TYPE).equals(KNNConstants.QUANTIZATION_TYPE_NVQ)) {
-                log.info(
-                    "NVQ is used, and {} not set; defaulting to {}",
-                    KNNConstants.METHOD_PARAMETER_NUM_NVQ_SUBVECTORS,
-                    KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS
-                );
-            }
-        this.numNvqSubvectors = KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS;
+        }
     }
 
 }

--- a/src/main/java/org/opensearch/knn/index/codec/params/KNNVectorsFormatParams.java
+++ b/src/main/java/org/opensearch/knn/index/codec/params/KNNVectorsFormatParams.java
@@ -29,6 +29,7 @@ public class KNNVectorsFormatParams {
     private boolean leadingSegmentMergeDisabled;
     private String quantizationType;
     private int numNvqSubvectors;
+    private boolean nvqVectorsInline;
 
     public KNNVectorsFormatParams(final Map<String, Object> params, int defaultMaxConnections, int defaultBeamWidth) {
         this(
@@ -64,6 +65,7 @@ public class KNNVectorsFormatParams {
         initLeadingSegmentMergeDisabled(params, KNNConstants.DEFAULT_LEADING_SEGMENT_MERGE_DISABLED);
         initQuantizationType(params);
         initNumNvqSubvectors(params);
+        initNvqVectorsInline(params);
     }
 
     public boolean validate(final Map<String, Object> params) {
@@ -149,5 +151,13 @@ public class KNNVectorsFormatParams {
             return;
         }
         this.numNvqSubvectors = KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS;
+    }
+
+    private void initNvqVectorsInline(final Map<String, Object> params) {
+        if (params != null && params.containsKey(KNNConstants.METHOD_PARAMETER_NVQ_VECTORS_INLINE)) {
+            this.nvqVectorsInline = (boolean) params.get(KNNConstants.METHOD_PARAMETER_NVQ_VECTORS_INLINE);
+            return;
+        }
+        this.nvqVectorsInline = KNNConstants.DEFAULT_NVQ_VECTORS_INLINE;
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/params/KNNVectorsFormatParams.java
+++ b/src/main/java/org/opensearch/knn/index/codec/params/KNNVectorsFormatParams.java
@@ -9,10 +9,9 @@ import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.SpaceType;
-import org.opensearch.knn.index.codec.jvector.JVectorFormat;
+import org.opensearch.knn.index.codec.jvector.JVectorIndexQuantization;
 
 import java.util.Map;
-import java.util.function.Function;
 
 /**
  * Class provides params for LuceneHNSWVectorsFormat
@@ -26,11 +25,9 @@ public class KNNVectorsFormatParams {
     private float neighborOverflow;
     private int minBatchSizeForQuantization;
     private boolean hierarchyEnabled;
-    private Function<Integer, Integer> numberOfSubspacesPerVectorSupplier;
+    private JVectorIndexQuantization quantization;
     private final SpaceType spaceType;
     private boolean leadingSegmentMergeDisabled;
-    private String quantizationType;
-    private int numNvqSubvectors;
 
     public KNNVectorsFormatParams(final Map<String, Object> params, int defaultMaxConnections, int defaultBeamWidth) {
         this(
@@ -61,11 +58,9 @@ public class KNNVectorsFormatParams {
         initNeighborOverflow(params, defaultNeighborOverflow);
         initMinBatchSizeForQuantization(params, defaultMinBatchSizeForQuantization);
         initHierarchyEnabled(params, defaultHierarchyEnabled);
-        initNumberOfSubspacesPerVectorSupplier(params);
         this.spaceType = spaceType;
         initLeadingSegmentMergeDisabled(params, KNNConstants.DEFAULT_LEADING_SEGMENT_MERGE_DISABLED);
-        initQuantizationType(params);
-        initNumNvqSubvectors(params);
+        initQuantization(params);
     }
 
     public boolean validate(final Map<String, Object> params) {
@@ -120,15 +115,6 @@ public class KNNVectorsFormatParams {
         this.hierarchyEnabled = defaultHierarchyEnabled;
     }
 
-    private void initNumberOfSubspacesPerVectorSupplier(final Map<String, Object> params) {
-        if (params != null && params.containsKey(KNNConstants.METHOD_PARAMETER_NUM_PQ_SUBSPACES)) {
-            int numPQSubspaces = (int) params.get(KNNConstants.METHOD_PARAMETER_NUM_PQ_SUBSPACES);
-            this.numberOfSubspacesPerVectorSupplier = (originalDimension) -> numPQSubspaces;
-            return;
-        }
-        this.numberOfSubspacesPerVectorSupplier = JVectorFormat::getDefaultNumberOfSubspacesPerVector;
-    }
-
     private void initLeadingSegmentMergeDisabled(final Map<String, Object> params, boolean defaultLsmDisabled) {
         if (params != null && params.containsKey(KNNConstants.METHOD_PARAMETER_LEADING_SEGMENT_MERGE_DISABLED)) {
             this.leadingSegmentMergeDisabled = (boolean) params.get(KNNConstants.METHOD_PARAMETER_LEADING_SEGMENT_MERGE_DISABLED);
@@ -137,29 +123,28 @@ public class KNNVectorsFormatParams {
         this.leadingSegmentMergeDisabled = defaultLsmDisabled;
     }
 
-    private void initQuantizationType(final Map<String, Object> params) {
-        if (params != null && params.containsKey(KNNConstants.METHOD_PARAMETER_QUANTIZATION_TYPE)) {
-            this.quantizationType = (String) params.get(KNNConstants.METHOD_PARAMETER_QUANTIZATION_TYPE);
-            return;
-        }
-        this.quantizationType = KNNConstants.DEFAULT_QUANTIZATION_TYPE;
-    }
+    private void initQuantization(final Map<String, Object> params) {
+        String type = (params != null && params.containsKey(KNNConstants.METHOD_PARAMETER_QUANTIZATION_TYPE))
+            ? (String) params.get(KNNConstants.METHOD_PARAMETER_QUANTIZATION_TYPE)
+            : KNNConstants.DEFAULT_QUANTIZATION_TYPE;
 
-    private void initNumNvqSubvectors(final Map<String, Object> params) {
-        if (params != null && params.containsKey(KNNConstants.METHOD_PARAMETER_NUM_NVQ_SUBVECTORS)) {
-            this.numNvqSubvectors = (int) params.get(KNNConstants.METHOD_PARAMETER_NUM_NVQ_SUBVECTORS);
-            log.info("NVQ is used, and {} is set to {}", KNNConstants.METHOD_PARAMETER_NUM_NVQ_SUBVECTORS, this.numNvqSubvectors);
-            return;
-        }
-        this.numNvqSubvectors = KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS;
-        if (params != null
-            && params.containsKey(KNNConstants.METHOD_PARAMETER_QUANTIZATION_TYPE)
-            && params.get(KNNConstants.METHOD_PARAMETER_QUANTIZATION_TYPE).equals(KNNConstants.QUANTIZATION_TYPE_NVQ)) {
-            log.info(
-                "NVQ is used, and {} not set; defaulting to {}",
-                KNNConstants.METHOD_PARAMETER_NUM_NVQ_SUBVECTORS,
-                KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS
-            );
+        if (KNNConstants.QUANTIZATION_TYPE_NVQ.equals(type)) {
+            int numSubvectors = KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS;
+            if (params != null && params.containsKey(KNNConstants.METHOD_PARAMETER_NUM_NVQ_SUBVECTORS)) {
+                numSubvectors = (int) params.get(KNNConstants.METHOD_PARAMETER_NUM_NVQ_SUBVECTORS);
+                log.info("NVQ quantization: {} set to {}", KNNConstants.METHOD_PARAMETER_NUM_NVQ_SUBVECTORS, numSubvectors);
+            } else {
+                log.info("NVQ quantization: {} not set; defaulting to {}", KNNConstants.METHOD_PARAMETER_NUM_NVQ_SUBVECTORS, numSubvectors);
+                numSubvectors = JVectorIndexQuantization.NVQ.defaultNumSubvectors();
+            }
+            this.quantization = new JVectorIndexQuantization.NVQ(numSubvectors);
+        } else {
+            if (params != null && params.containsKey(KNNConstants.METHOD_PARAMETER_NUM_PQ_SUBSPACES)) {
+                int numSubspaces = (int) params.get(KNNConstants.METHOD_PARAMETER_NUM_PQ_SUBSPACES);
+                this.quantization = new JVectorIndexQuantization.PQ(numSubspaces);
+            } else {
+                this.quantization = new JVectorIndexQuantization.PQ();
+            }
         }
     }
 

--- a/src/test/java/org/opensearch/knn/index/ThreadLeakFiltersForTests.java
+++ b/src/test/java/org/opensearch/knn/index/ThreadLeakFiltersForTests.java
@@ -24,6 +24,7 @@ public class ThreadLeakFiltersForTests implements ThreadFilter {
                 || threadGroup.getName().startsWith("TGRP-JVectorWriterMergeTests")
                 || threadGroup.getName().startsWith("TGRP-MemoryUsageAnalysisTests")
                 || threadGroup.getName().startsWith("TGRP-KNN1030CodecTests")
-                || threadGroup.getName().startsWith("TGRP-KNN1040CodecTests"));
+                || threadGroup.getName().startsWith("TGRP-KNN1040CodecTests")
+                || threadGroup.getName().startsWith("TGRP-JVectorNVQTests"));
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/JVectorNVQTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/JVectorNVQTests.java
@@ -6,7 +6,6 @@
 package org.opensearch.knn.index.codec.jvector;
 
 import static org.opensearch.knn.index.engine.CommonTestUtils.getCodecWithNVQ;
-import static org.opensearch.knn.index.engine.CommonTestUtils.getCodecWithNVQInline;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -130,19 +129,7 @@ public class JVectorNVQTests extends LuceneTestCase {
         runScenarioWithPool(scenario, null);
     }
 
-    void runScenarioInline(MergeTestScenario scenario) throws IOException {
-        runScenarioInlineWithPool(scenario, null);
-    }
-
-    void runScenarioInlineWithPool(MergeTestScenario scenario, ForkJoinPool mergePool) throws IOException {
-        runScenarioCore(scenario, mergePool, true);
-    }
-
     void runScenarioWithPool(MergeTestScenario scenario, ForkJoinPool mergePool) throws IOException {
-        runScenarioCore(scenario, mergePool, false);
-    }
-
-    void runScenarioCore(MergeTestScenario scenario, ForkJoinPool mergePool, boolean nvqVectorsInline) throws IOException {
         int nBase = scenario.rounds.stream().mapToInt(r -> r.segmentSizes.stream().mapToInt(x -> x).sum()).sum();
         var baseVecs = TestUtils.randomlyGenerateStandardVectors(nBase, scenario.dimension, RANDOM_SEED);
         var queryVecs = TestUtils.randomlyGenerateStandardVectors(scenario.nQueries, scenario.dimension, RANDOM_SEED + 1);
@@ -152,11 +139,7 @@ public class JVectorNVQTests extends LuceneTestCase {
 
         IndexWriterConfig iwc = LuceneTestCase.newIndexWriterConfig();
         iwc.setUseCompoundFile(false);
-        iwc.setCodec(
-            nvqVectorsInline
-                ? getCodecWithNVQInline(scenario.minNvqThreshold, scenario.leadingSegmentMergeDisabled, mergePool)
-                : getCodecWithNVQ(scenario.minNvqThreshold, scenario.leadingSegmentMergeDisabled, mergePool)
-        );
+        iwc.setCodec(getCodecWithNVQ(scenario.minNvqThreshold, scenario.leadingSegmentMergeDisabled, mergePool));
         iwc.setMergePolicy(new ForceMergesOnlyMergePolicy(false));
         iwc.setMaxBufferedDocs(-1);
 
@@ -363,53 +346,4 @@ public class JVectorNVQTests extends LuceneTestCase {
         runScenarioWithPool(scenario, singleThreadGraphMergePool);
     }
 
-    // -------------------------------------------------------------------------
-    // NVQ inline tests (FeatureId.NVQ_VECTORS stored inline with graph nodes)
-    // -------------------------------------------------------------------------
-
-    /**
-     * Single segment, NVQ inline active. Verifies the flush → inline-encode → search path
-     * when {@code nvq_vectors_inline=true}. No separate blob is written; NVQ vectors are
-     * stored directly in the graph nodes.
-     */
-    @Test
-    public void testNVQInlineFlushRecall() throws IOException {
-        var scenario = MergeTestScenario.builder()
-            .minNvqThreshold(1)
-            .round(MergeTestRound.builder().segmentSizes(List.of(500)).build())
-            .minimumRecall(0.80)
-            .overqueryFactor(15)
-            .build();
-        runScenarioInline(scenario);
-    }
-
-    /**
-     * Two segments merged under NVQ inline. Verifies the merge path correctly encodes
-     * NVQ vectors inline with graph nodes after merge.
-     */
-    @Test
-    public void testNVQInlineSimpleMerge() throws IOException {
-        var scenario = MergeTestScenario.builder()
-            .minNvqThreshold(1)
-            .round(MergeTestRound.builder().segmentSizes(List.of(250, 250)).build())
-            .minimumRecall(0.80)
-            .overqueryFactor(15)
-            .build();
-        runScenarioInlineWithPool(scenario, singleThreadGraphMergePool);
-    }
-
-    /**
-     * NVQ inline with minThreshold=MAX_VALUE falls back to raw float32 inline vectors
-     * (no NVQ training triggered). Recall must be perfect since full-precision is used.
-     */
-    @Test
-    public void testNVQInlineBelowThresholdFallbackToFullPrecision() throws IOException {
-        var scenario = MergeTestScenario.builder()
-            .minNvqThreshold(Integer.MAX_VALUE)
-            .round(MergeTestRound.builder().segmentSizes(List.of(200)).build())
-            .minimumRecall(1.0)
-            .overqueryFactor(KNNConstants.DEFAULT_OVER_QUERY_FACTOR)
-            .build();
-        runScenarioInline(scenario);
-    }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/JVectorNVQTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/JVectorNVQTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.index.codec.jvector;
 
 import static org.opensearch.knn.index.engine.CommonTestUtils.getCodecWithNVQ;
+import static org.opensearch.knn.index.engine.CommonTestUtils.getCodecWithNVQInline;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -129,7 +130,19 @@ public class JVectorNVQTests extends LuceneTestCase {
         runScenarioWithPool(scenario, null);
     }
 
+    void runScenarioInline(MergeTestScenario scenario) throws IOException {
+        runScenarioInlineWithPool(scenario, null);
+    }
+
+    void runScenarioInlineWithPool(MergeTestScenario scenario, ForkJoinPool mergePool) throws IOException {
+        runScenarioCore(scenario, mergePool, true);
+    }
+
     void runScenarioWithPool(MergeTestScenario scenario, ForkJoinPool mergePool) throws IOException {
+        runScenarioCore(scenario, mergePool, false);
+    }
+
+    void runScenarioCore(MergeTestScenario scenario, ForkJoinPool mergePool, boolean nvqVectorsInline) throws IOException {
         int nBase = scenario.rounds.stream().mapToInt(r -> r.segmentSizes.stream().mapToInt(x -> x).sum()).sum();
         var baseVecs = TestUtils.randomlyGenerateStandardVectors(nBase, scenario.dimension, RANDOM_SEED);
         var queryVecs = TestUtils.randomlyGenerateStandardVectors(scenario.nQueries, scenario.dimension, RANDOM_SEED + 1);
@@ -139,7 +152,11 @@ public class JVectorNVQTests extends LuceneTestCase {
 
         IndexWriterConfig iwc = LuceneTestCase.newIndexWriterConfig();
         iwc.setUseCompoundFile(false);
-        iwc.setCodec(getCodecWithNVQ(scenario.minNvqThreshold, scenario.leadingSegmentMergeDisabled, mergePool));
+        iwc.setCodec(
+            nvqVectorsInline
+                ? getCodecWithNVQInline(scenario.minNvqThreshold, scenario.leadingSegmentMergeDisabled, mergePool)
+                : getCodecWithNVQ(scenario.minNvqThreshold, scenario.leadingSegmentMergeDisabled, mergePool)
+        );
         iwc.setMergePolicy(new ForceMergesOnlyMergePolicy(false));
         iwc.setMaxBufferedDocs(-1);
 
@@ -344,5 +361,55 @@ public class JVectorNVQTests extends LuceneTestCase {
             .minimumRecall(0.85)
             .build();
         runScenarioWithPool(scenario, singleThreadGraphMergePool);
+    }
+
+    // -------------------------------------------------------------------------
+    // NVQ inline tests (FeatureId.NVQ_VECTORS stored inline with graph nodes)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Single segment, NVQ inline active. Verifies the flush → inline-encode → search path
+     * when {@code nvq_vectors_inline=true}. No separate blob is written; NVQ vectors are
+     * stored directly in the graph nodes.
+     */
+    @Test
+    public void testNVQInlineFlushRecall() throws IOException {
+        var scenario = MergeTestScenario.builder()
+            .minNvqThreshold(1)
+            .round(MergeTestRound.builder().segmentSizes(List.of(500)).build())
+            .minimumRecall(0.80)
+            .overqueryFactor(15)
+            .build();
+        runScenarioInline(scenario);
+    }
+
+    /**
+     * Two segments merged under NVQ inline. Verifies the merge path correctly encodes
+     * NVQ vectors inline with graph nodes after merge.
+     */
+    @Test
+    public void testNVQInlineSimpleMerge() throws IOException {
+        var scenario = MergeTestScenario.builder()
+            .minNvqThreshold(1)
+            .round(MergeTestRound.builder().segmentSizes(List.of(250, 250)).build())
+            .minimumRecall(0.80)
+            .overqueryFactor(15)
+            .build();
+        runScenarioInlineWithPool(scenario, singleThreadGraphMergePool);
+    }
+
+    /**
+     * NVQ inline with minThreshold=MAX_VALUE falls back to raw float32 inline vectors
+     * (no NVQ training triggered). Recall must be perfect since full-precision is used.
+     */
+    @Test
+    public void testNVQInlineBelowThresholdFallbackToFullPrecision() throws IOException {
+        var scenario = MergeTestScenario.builder()
+            .minNvqThreshold(Integer.MAX_VALUE)
+            .round(MergeTestRound.builder().segmentSizes(List.of(200)).build())
+            .minimumRecall(1.0)
+            .overqueryFactor(KNNConstants.DEFAULT_OVER_QUERY_FACTOR)
+            .build();
+        runScenarioInline(scenario);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/JVectorNVQTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/JVectorNVQTests.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.knn.index.codec.jvector;
 
-import static org.opensearch.knn.index.engine.CommonTestUtils.getCodecWithNVQ;
+import static org.opensearch.knn.index.engine.CommonTestUtils.getCodec;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -139,7 +139,14 @@ public class JVectorNVQTests extends LuceneTestCase {
 
         IndexWriterConfig iwc = LuceneTestCase.newIndexWriterConfig();
         iwc.setUseCompoundFile(false);
-        iwc.setCodec(getCodecWithNVQ(scenario.minNvqThreshold, scenario.leadingSegmentMergeDisabled, mergePool));
+        iwc.setCodec(
+            getCodec(
+                scenario.minNvqThreshold,
+                scenario.leadingSegmentMergeDisabled,
+                mergePool,
+                new JVectorIndexQuantization.NVQ(KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS)
+            )
+        );
         iwc.setMergePolicy(new ForceMergesOnlyMergePolicy(false));
         iwc.setMaxBufferedDocs(-1);
 

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/JVectorNVQTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/JVectorNVQTests.java
@@ -1,0 +1,348 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.jvector;
+
+import static org.opensearch.knn.index.engine.CommonTestUtils.getCodecWithNVQ;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Set;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field.Store;
+import org.apache.lucene.document.IntField;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.BitSet;
+import org.apache.lucene.util.FixedBitSet;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.opensearch.knn.TestUtils;
+import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.ThreadLeakFiltersForTests;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
+import io.github.jbellis.jvector.util.DocIdSetIterator;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Builder.Default;
+import lombok.Singular;
+
+/**
+ * Tests for the NVQ (Non-uniform Vector Quantization) write, merge, and search paths.
+ *
+ * These tests mirror the PQ scenarios in {@link JVectorWriterMergeTests} but use
+ * {@link KNNConstants#QUANTIZATION_TYPE_NVQ} as the quantization type. They cover:
+ * <ul>
+ *   <li>Single-segment flush with NVQ enabled</li>
+ *   <li>Fallback to full-precision when vector count is below the batch threshold</li>
+ *   <li>Simple two-segment merge with NVQ</li>
+ *   <li>Multi-segment merge with deletions under NVQ</li>
+ *   <li>Multi-phase progressive merge once the vector count crosses the NVQ threshold</li>
+ * </ul>
+ *
+ * NVQ is a lossy compressor, so recall targets are set slightly lower than the PQ
+ * equivalents, and overqueryFactor is raised to compensate.
+ */
+@ThreadLeakFilters(defaultFilters = true, filters = { ThreadLeakFiltersForTests.class })
+@LuceneTestCase.SuppressSysoutChecks(bugUrl = "")
+public class JVectorNVQTests extends LuceneTestCase {
+
+    static final int RANDOM_SEED = 73;
+    static final String ID_FIELD = "doc_id";
+    static final String VECTOR_FIELD = "vectors";
+
+    @AllArgsConstructor
+    static class DeletionRange {
+        int start;
+        int end;
+    }
+
+    @Builder
+    static class MergeTestRound {
+        @Default
+        List<Integer> segmentSizes = List.of();
+        @Default
+        List<DeletionRange> deletionRanges = List.of();
+    }
+
+    @Builder
+    static class MergeTestScenario {
+        @Singular
+        List<MergeTestRound> rounds;
+        @Default
+        int minNvqThreshold = 1; // always apply NVQ by default
+        @Default
+        int dimension = 128;
+        @Default
+        int nQueries = 10;
+        @Default
+        int topK = 10;
+        @Default
+        int overqueryFactor = 10;
+        @Default
+        double minimumRecall = 0.85;
+        @Default
+        boolean leadingSegmentMergeDisabled = KNNConstants.DEFAULT_LEADING_SEGMENT_MERGE_DISABLED;
+    }
+
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
+    private ForkJoinPool singleThreadGraphMergePool;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        singleThreadGraphMergePool = new ForkJoinPool(1);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        singleThreadGraphMergePool.shutdown();
+        if (singleThreadGraphMergePool.awaitTermination(30, TimeUnit.SECONDS) == false) {
+            singleThreadGraphMergePool.shutdownNow();
+        }
+    }
+
+    void runScenario(MergeTestScenario scenario) throws IOException {
+        runScenarioWithPool(scenario, null);
+    }
+
+    void runScenarioWithPool(MergeTestScenario scenario, ForkJoinPool mergePool) throws IOException {
+        int nBase = scenario.rounds.stream().mapToInt(r -> r.segmentSizes.stream().mapToInt(x -> x).sum()).sum();
+        var baseVecs = TestUtils.randomlyGenerateStandardVectors(nBase, scenario.dimension, RANDOM_SEED);
+        var queryVecs = TestUtils.randomlyGenerateStandardVectors(scenario.nQueries, scenario.dimension, RANDOM_SEED + 1);
+
+        var liveVecs = new FixedBitSet(nBase);
+        liveVecs.clear();
+
+        IndexWriterConfig iwc = LuceneTestCase.newIndexWriterConfig();
+        iwc.setUseCompoundFile(false);
+        iwc.setCodec(getCodecWithNVQ(scenario.minNvqThreshold, scenario.leadingSegmentMergeDisabled, mergePool));
+        iwc.setMergePolicy(new ForceMergesOnlyMergePolicy(false));
+        iwc.setMaxBufferedDocs(-1);
+
+        try (var fsd = FSDirectory.open(tempDir.getRoot().toPath()); var writer = new IndexWriter(fsd, iwc)) {
+            int vectorOffset = 0;
+            for (int roundId = 0; roundId < scenario.rounds.size(); roundId++) {
+                var round = scenario.rounds.get(roundId);
+
+                for (int segInRound = 0; segInRound < round.segmentSizes.size(); segInRound++) {
+                    var segmentSize = round.segmentSizes.get(segInRound);
+
+                    for (int i = 0; i < segmentSize; i++) {
+                        int id = vectorOffset + i;
+                        Document doc = new Document();
+                        doc.add(new KnnFloatVectorField(VECTOR_FIELD, baseVecs[id], VectorSimilarityFunction.EUCLIDEAN));
+                        doc.add(new IntField(ID_FIELD, id, Store.YES));
+                        writer.addDocument(doc);
+                        liveVecs.set(id);
+                    }
+                    writer.flush();
+                    writer.commit();
+                    vectorOffset += segmentSize;
+                }
+
+                for (var dl : round.deletionRanges) {
+                    var query = IntField.newRangeQuery(ID_FIELD, dl.start, dl.end - 1);
+                    writer.deleteDocuments(query);
+                    liveVecs.clear(dl.start, dl.end);
+                    writer.commit();
+                }
+
+                writer.forceMerge(1);
+                writer.commit();
+
+                try (var reader = DirectoryReader.open(writer)) {
+                    Assert.assertTrue("Should have one segment after merge", 1 >= reader.getContext().leaves().size());
+                    assertEquals(liveVecs.cardinality(), reader.numDocs());
+
+                    var searcher = LuceneTestCase.newSearcher(reader);
+                    int totalCorrect = 0;
+
+                    for (var queryVec : queryVecs) {
+                        var gt = computeL2GroundTruth(baseVecs, liveVecs, queryVec, scenario.topK);
+                        var query = new JVectorKnnFloatVectorQuery(
+                            VECTOR_FIELD,
+                            queryVec,
+                            scenario.topK,
+                            scenario.overqueryFactor,
+                            0.0f,
+                            0.0f,
+                            false
+                        );
+                        var results = searcher.search(query, scenario.topK).scoreDocs;
+
+                        var pred = Arrays.stream(results).map(r -> {
+                            try {
+                                return reader.storedFields().document(r.doc).getField(ID_FIELD).numericValue().intValue();
+                            } catch (IOException e) {
+                                throw new UncheckedIOException(e);
+                            }
+                        }).collect(Collectors.toSet());
+
+                        assertEquals(scenario.topK, pred.size());
+                        for (var doc : pred) {
+                            if (gt.contains(doc)) {
+                                totalCorrect++;
+                            }
+                        }
+                    }
+
+                    double recall = totalCorrect / (double) (scenario.topK * queryVecs.length);
+                    Assert.assertTrue(
+                        String.format("NVQ recall too low [round %d]: got %.3f < %.3f", roundId, recall, scenario.minimumRecall),
+                        recall >= scenario.minimumRecall
+                    );
+                }
+            }
+        }
+    }
+
+    Set<Integer> computeL2GroundTruth(float[][] baseVectors, BitSet liveVectors, float[] query, int k) {
+        if (liveVectors.length() == 0) {
+            return Set.of();
+        }
+        var pq = new PriorityQueue<ScoreDoc>(k, (a, b) -> Float.compare(a.score, b.score));
+        for (int i = liveVectors.nextSetBit(0); i != DocIdSetIterator.NO_MORE_DOCS; i = liveVectors.nextSetBit(i + 1)) {
+            var score = VectorSimilarityFunction.EUCLIDEAN.compare(baseVectors[i], query);
+            var sd = new ScoreDoc(i, score);
+            if (pq.size() < k) {
+                pq.add(sd);
+            } else if (pq.peek().score < sd.score) {
+                pq.poll();
+                pq.add(sd);
+            }
+            if (i + 1 >= liveVectors.length()) break;
+        }
+        return pq.stream().map(sd -> sd.doc).collect(Collectors.toSet());
+    }
+
+    /**
+     * Single segment, NVQ always active (minThreshold=1). Verifies the full
+     * flush → encode → search path for NVQ.
+     */
+    @Test
+    public void testNVQFlushRecall() throws IOException {
+        var scenario = MergeTestScenario.builder()
+            .minNvqThreshold(1)
+            .round(MergeTestRound.builder().segmentSizes(List.of(500)).build())
+            .minimumRecall(0.85)
+            .build();
+        runScenario(scenario);
+    }
+
+    /**
+     * NVQ type configured but minThreshold=MAX_VALUE so no quantization is ever
+     * applied. Recall must be perfect since full-precision vectors are used.
+     */
+    @Test
+    public void testNVQBelowThresholdFallbackToFullPrecision() throws IOException {
+        var scenario = MergeTestScenario.builder()
+            .minNvqThreshold(Integer.MAX_VALUE)
+            .round(MergeTestRound.builder().segmentSizes(List.of(200)).build())
+            .minimumRecall(1.0)
+            .overqueryFactor(KNNConstants.DEFAULT_OVER_QUERY_FACTOR)
+            .build();
+        runScenario(scenario);
+    }
+
+    /**
+     * Two segments merged into one under NVQ. NVQ must recompute from scratch
+     * during the merge (no refine() equivalent like PQ).
+     */
+    @Test
+    public void testNVQSimpleMerge() throws IOException {
+        var scenario = MergeTestScenario.builder()
+            .minNvqThreshold(1)
+            .round(MergeTestRound.builder().segmentSizes(List.of(250, 250)).build())
+            .minimumRecall(0.85)
+            .build();
+        runScenarioWithPool(scenario, singleThreadGraphMergePool);
+    }
+
+    /**
+     * Multiple segments with deletions merged under NVQ. Tests that the recompute-from-scratch
+     * merge path handles live-doc filtering correctly.
+     */
+    @Test
+    public void testNVQMergeWithDeletions() throws IOException {
+        var scenario = MergeTestScenario.builder()
+            .minNvqThreshold(1)
+            .round(
+                MergeTestRound.builder()
+                    .segmentSizes(List.of(100, 200, 100, 100))
+                    .deletionRanges(List.of(new DeletionRange(0, 50), new DeletionRange(300, 350)))
+                    .build()
+            )
+            .minimumRecall(0.85)
+            .build();
+        runScenarioWithPool(scenario, singleThreadGraphMergePool);
+    }
+
+    /**
+     * Multi-phase scenario: first two rounds stay below the NVQ threshold (full precision),
+     * then the third round crosses it and NVQ is applied. Validates the progressive path
+     * where earlier full-precision segments are eventually recompressed with NVQ on merge.
+     */
+    @Test
+    public void testNVQMultiPhaseMergeProgressiveThreshold() throws IOException {
+        var scenario = MergeTestScenario.builder()
+            .minNvqThreshold(600)
+            .round(MergeTestRound.builder().segmentSizes(List.of(50, 100, 100)).build())   // 250 < 600, no NVQ
+            .round(MergeTestRound.builder().segmentSizes(List.of(50, 100, 100)).build())   // 500 < 600, no NVQ
+            .round(MergeTestRound.builder().segmentSizes(List.of(50, 100, 100)).build())   // 750 > 600, NVQ kicks in
+            .overqueryFactor(20)
+            .minimumRecall(0.85)
+            .build();
+        runScenarioWithPool(scenario, singleThreadGraphMergePool);
+    }
+
+    /**
+     * Multi-phase scenario with NVQ always active and complex deletions across rounds.
+     * Mirrors {@code multiPhaseMergeWithDeletesAlwaysPQ} from {@link JVectorWriterMergeTests}.
+     */
+    @Test
+    public void testNVQMultiPhaseMergeWithDeletions() throws IOException {
+        var scenario = MergeTestScenario.builder()
+            .minNvqThreshold(1)
+            .round(
+                MergeTestRound.builder()
+                    .segmentSizes(List.of(100, 150, 100, 100))
+                    .deletionRanges(List.of(new DeletionRange(0, 30), new DeletionRange(300, 350)))
+                    .build()
+            )
+            .round(
+                MergeTestRound.builder()
+                    .segmentSizes(List.of(50, 100, 150))
+                    .deletionRanges(List.of(new DeletionRange(400, 480), new DeletionRange(50, 55)))
+                    .build()
+            )
+            .round(MergeTestRound.builder().segmentSizes(List.of(200)).build())
+            .overqueryFactor(20)
+            .minimumRecall(0.85)
+            .build();
+        runScenarioWithPool(scenario, singleThreadGraphMergePool);
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/engine/CommonTestUtils.java
+++ b/src/test/java/org/opensearch/knn/index/engine/CommonTestUtils.java
@@ -182,23 +182,6 @@ public class CommonTestUtils {
     }
 
     public static Codec getCodecWithNVQ(int minBatchSizeForQuantization, boolean leadingSegmentMergeDisabled, ForkJoinPool graphMergePool) {
-        return getCodecWithNVQ(minBatchSizeForQuantization, leadingSegmentMergeDisabled, false, graphMergePool);
-    }
-
-    public static Codec getCodecWithNVQInline(int minBatchSizeForQuantization, boolean leadingSegmentMergeDisabled) {
-        return getCodecWithNVQ(minBatchSizeForQuantization, leadingSegmentMergeDisabled, true, null);
-    }
-
-    public static Codec getCodecWithNVQInline(int minBatchSizeForQuantization, boolean leadingSegmentMergeDisabled, ForkJoinPool graphMergePool) {
-        return getCodecWithNVQ(minBatchSizeForQuantization, leadingSegmentMergeDisabled, true, graphMergePool);
-    }
-
-    private static Codec getCodecWithNVQ(
-        int minBatchSizeForQuantization,
-        boolean leadingSegmentMergeDisabled,
-        boolean nvqVectorsInline,
-        ForkJoinPool graphMergePool
-    ) {
         if (graphMergePool == null) {
             return new FilterCodec(KNNCodecVersion.V_10_04_0.getCodecName(), new Lucene104Codec()) {
                 @Override
@@ -216,8 +199,7 @@ public class CommonTestUtils {
                                 KNNConstants.DEFAULT_HIERARCHY_ENABLED,
                                 leadingSegmentMergeDisabled,
                                 KNNConstants.QUANTIZATION_TYPE_NVQ,
-                                KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS,
-                                nvqVectorsInline
+                                KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS
                             );
                         }
                     };
@@ -242,7 +224,6 @@ public class CommonTestUtils {
                                 leadingSegmentMergeDisabled,
                                 KNNConstants.QUANTIZATION_TYPE_NVQ,
                                 KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS,
-                                nvqVectorsInline,
                                 graphMergePool,
                                 graphMergePool,
                                 graphMergePool

--- a/src/test/java/org/opensearch/knn/index/engine/CommonTestUtils.java
+++ b/src/test/java/org/opensearch/knn/index/engine/CommonTestUtils.java
@@ -31,6 +31,7 @@ import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.codec.KNNCodecVersion;
 import org.opensearch.knn.index.codec.jvector.JVectorFormat;
+import org.opensearch.knn.index.codec.jvector.JVectorIndexQuantization;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.knn.plugin.JVectorKNNPlugin;
 
@@ -194,12 +195,10 @@ public class CommonTestUtils {
                                 JVectorFormat.DEFAULT_BEAM_WIDTH,
                                 KNNConstants.DEFAULT_NEIGHBOR_OVERFLOW_VALUE.floatValue(),
                                 KNNConstants.DEFAULT_ALPHA_VALUE.floatValue(),
-                                JVectorFormat::getDefaultNumberOfSubspacesPerVector,
+                                new JVectorIndexQuantization.NVQ(KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS),
                                 minBatchSizeForQuantization,
                                 KNNConstants.DEFAULT_HIERARCHY_ENABLED,
-                                leadingSegmentMergeDisabled,
-                                KNNConstants.QUANTIZATION_TYPE_NVQ,
-                                KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS
+                                leadingSegmentMergeDisabled
                             );
                         }
                     };
@@ -218,12 +217,10 @@ public class CommonTestUtils {
                                 JVectorFormat.DEFAULT_BEAM_WIDTH,
                                 KNNConstants.DEFAULT_NEIGHBOR_OVERFLOW_VALUE.floatValue(),
                                 KNNConstants.DEFAULT_ALPHA_VALUE.floatValue(),
-                                JVectorFormat::getDefaultNumberOfSubspacesPerVector,
+                                new JVectorIndexQuantization.NVQ(KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS),
                                 minBatchSizeForQuantization,
                                 KNNConstants.DEFAULT_HIERARCHY_ENABLED,
                                 leadingSegmentMergeDisabled,
-                                KNNConstants.QUANTIZATION_TYPE_NVQ,
-                                KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS,
                                 graphMergePool,
                                 graphMergePool,
                                 graphMergePool

--- a/src/test/java/org/opensearch/knn/index/engine/CommonTestUtils.java
+++ b/src/test/java/org/opensearch/knn/index/engine/CommonTestUtils.java
@@ -182,6 +182,23 @@ public class CommonTestUtils {
     }
 
     public static Codec getCodecWithNVQ(int minBatchSizeForQuantization, boolean leadingSegmentMergeDisabled, ForkJoinPool graphMergePool) {
+        return getCodecWithNVQ(minBatchSizeForQuantization, leadingSegmentMergeDisabled, false, graphMergePool);
+    }
+
+    public static Codec getCodecWithNVQInline(int minBatchSizeForQuantization, boolean leadingSegmentMergeDisabled) {
+        return getCodecWithNVQ(minBatchSizeForQuantization, leadingSegmentMergeDisabled, true, null);
+    }
+
+    public static Codec getCodecWithNVQInline(int minBatchSizeForQuantization, boolean leadingSegmentMergeDisabled, ForkJoinPool graphMergePool) {
+        return getCodecWithNVQ(minBatchSizeForQuantization, leadingSegmentMergeDisabled, true, graphMergePool);
+    }
+
+    private static Codec getCodecWithNVQ(
+        int minBatchSizeForQuantization,
+        boolean leadingSegmentMergeDisabled,
+        boolean nvqVectorsInline,
+        ForkJoinPool graphMergePool
+    ) {
         if (graphMergePool == null) {
             return new FilterCodec(KNNCodecVersion.V_10_04_0.getCodecName(), new Lucene104Codec()) {
                 @Override
@@ -199,7 +216,8 @@ public class CommonTestUtils {
                                 KNNConstants.DEFAULT_HIERARCHY_ENABLED,
                                 leadingSegmentMergeDisabled,
                                 KNNConstants.QUANTIZATION_TYPE_NVQ,
-                                KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS
+                                KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS,
+                                nvqVectorsInline
                             );
                         }
                     };
@@ -224,6 +242,7 @@ public class CommonTestUtils {
                                 leadingSegmentMergeDisabled,
                                 KNNConstants.QUANTIZATION_TYPE_NVQ,
                                 KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS,
+                                nvqVectorsInline,
                                 graphMergePool,
                                 graphMergePool,
                                 graphMergePool

--- a/src/test/java/org/opensearch/knn/index/engine/CommonTestUtils.java
+++ b/src/test/java/org/opensearch/knn/index/engine/CommonTestUtils.java
@@ -177,6 +177,64 @@ public class CommonTestUtils {
         }
     }
 
+    public static Codec getCodecWithNVQ(int minBatchSizeForQuantization, boolean leadingSegmentMergeDisabled) {
+        return getCodecWithNVQ(minBatchSizeForQuantization, leadingSegmentMergeDisabled, null);
+    }
+
+    public static Codec getCodecWithNVQ(int minBatchSizeForQuantization, boolean leadingSegmentMergeDisabled, ForkJoinPool graphMergePool) {
+        if (graphMergePool == null) {
+            return new FilterCodec(KNNCodecVersion.V_10_04_0.getCodecName(), new Lucene104Codec()) {
+                @Override
+                public KnnVectorsFormat knnVectorsFormat() {
+                    return new PerFieldKnnVectorsFormat() {
+                        @Override
+                        public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+                            return new JVectorFormat(
+                                JVectorFormat.DEFAULT_MAX_CONN,
+                                JVectorFormat.DEFAULT_BEAM_WIDTH,
+                                KNNConstants.DEFAULT_NEIGHBOR_OVERFLOW_VALUE.floatValue(),
+                                KNNConstants.DEFAULT_ALPHA_VALUE.floatValue(),
+                                JVectorFormat::getDefaultNumberOfSubspacesPerVector,
+                                minBatchSizeForQuantization,
+                                KNNConstants.DEFAULT_HIERARCHY_ENABLED,
+                                leadingSegmentMergeDisabled,
+                                KNNConstants.QUANTIZATION_TYPE_NVQ,
+                                KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS
+                            );
+                        }
+                    };
+                }
+            };
+        } else {
+            return new FilterCodec(KNNCodecVersion.V_10_04_0.getCodecName(), new Lucene104Codec()) {
+                @Override
+                public KnnVectorsFormat knnVectorsFormat() {
+                    return new PerFieldKnnVectorsFormat() {
+                        @Override
+                        public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+                            return new JVectorFormat(
+                                JVectorFormat.NAME,
+                                JVectorFormat.DEFAULT_MAX_CONN,
+                                JVectorFormat.DEFAULT_BEAM_WIDTH,
+                                KNNConstants.DEFAULT_NEIGHBOR_OVERFLOW_VALUE.floatValue(),
+                                KNNConstants.DEFAULT_ALPHA_VALUE.floatValue(),
+                                JVectorFormat::getDefaultNumberOfSubspacesPerVector,
+                                minBatchSizeForQuantization,
+                                KNNConstants.DEFAULT_HIERARCHY_ENABLED,
+                                leadingSegmentMergeDisabled,
+                                KNNConstants.QUANTIZATION_TYPE_NVQ,
+                                KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS,
+                                graphMergePool,
+                                graphMergePool,
+                                graphMergePool
+                            );
+                        }
+                    };
+                }
+            };
+        }
+    }
+
     /**
      * Get Stats from KNN Plugin
      */

--- a/src/test/java/org/opensearch/knn/index/engine/CommonTestUtils.java
+++ b/src/test/java/org/opensearch/knn/index/engine/CommonTestUtils.java
@@ -146,27 +146,7 @@ public class CommonTestUtils {
     }
 
     public static Codec getCodec(int minBatchSizeForQuantization, boolean leadingSegmentMergeDisabled, boolean hierarchical) {
-        return new FilterCodec(KNNCodecVersion.V_10_04_0.getCodecName(), new Lucene104Codec()) {
-            @Override
-            public KnnVectorsFormat knnVectorsFormat() {
-                return new PerFieldKnnVectorsFormat() {
-
-                    @Override
-                    public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
-                        return new JVectorFormat(
-                            JVectorFormat.DEFAULT_MAX_CONN,
-                            JVectorFormat.DEFAULT_BEAM_WIDTH,
-                            KNNConstants.DEFAULT_NEIGHBOR_OVERFLOW_VALUE.floatValue(),
-                            KNNConstants.DEFAULT_ALPHA_VALUE.floatValue(),
-                            quantization,
-                            minBatchSizeForQuantization,
-                            hierarchical,
-                            leadingSegmentMergeDisabled
-                        );
-                    }
-                };
-            }
-        };
+        return getCodec(minBatchSizeForQuantization, leadingSegmentMergeDisabled, hierarchical, null, new JVectorIndexQuantization.PQ());
     }
 
     public static Codec getCodec(
@@ -175,8 +155,52 @@ public class CommonTestUtils {
         boolean hierarchical,
         ForkJoinPool graphMergePool
     ) {
+        return getCodec(
+            minBatchSizeForQuantization,
+            leadingSegmentMergeDisabled,
+            hierarchical,
+            graphMergePool,
+            new JVectorIndexQuantization.PQ()
+        );
+    }
+
+    public static Codec getCodec(
+        int minBatchSizeForQuantization,
+        boolean leadingSegmentMergeDisabled,
+        ForkJoinPool graphMergePool,
+        JVectorIndexQuantization quantization
+    ) {
+        return getCodec(minBatchSizeForQuantization, leadingSegmentMergeDisabled, DEFAULT_HIERARCHY_ENABLED, graphMergePool, quantization);
+    }
+
+    public static Codec getCodec(
+        int minBatchSizeForQuantization,
+        boolean leadingSegmentMergeDisabled,
+        boolean hierarchical,
+        ForkJoinPool graphMergePool,
+        JVectorIndexQuantization quantization
+    ) {
         if (graphMergePool == null) {
-            return getCodec(minBatchSizeForQuantization, leadingSegmentMergeDisabled, hierarchical);
+            return new FilterCodec(KNNCodecVersion.V_10_04_0.getCodecName(), new Lucene104Codec()) {
+                @Override
+                public KnnVectorsFormat knnVectorsFormat() {
+                    return new PerFieldKnnVectorsFormat() {
+                        @Override
+                        public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+                            return new JVectorFormat(
+                                JVectorFormat.DEFAULT_MAX_CONN,
+                                JVectorFormat.DEFAULT_BEAM_WIDTH,
+                                KNNConstants.DEFAULT_NEIGHBOR_OVERFLOW_VALUE.floatValue(),
+                                KNNConstants.DEFAULT_ALPHA_VALUE.floatValue(),
+                                quantization,
+                                minBatchSizeForQuantization,
+                                hierarchical,
+                                leadingSegmentMergeDisabled
+                            );
+                        }
+                    };
+                }
+            };
         } else {
             return new FilterCodec(KNNCodecVersion.V_10_04_0.getCodecName(), new Lucene104Codec()) {
                 @Override

--- a/src/test/java/org/opensearch/knn/index/engine/CommonTestUtils.java
+++ b/src/test/java/org/opensearch/knn/index/engine/CommonTestUtils.java
@@ -139,50 +139,19 @@ public class CommonTestUtils {
     }
 
     public static Codec getCodec(int minBatchSizeForQuantization, boolean leadingSegmentMergeDisabled) {
-        return new FilterCodec(KNNCodecVersion.V_10_04_0.getCodecName(), new Lucene104Codec()) {
-            @Override
-            public KnnVectorsFormat knnVectorsFormat() {
-                return new PerFieldKnnVectorsFormat() {
-
-                    @Override
-                    public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
-                        return new JVectorFormat(minBatchSizeForQuantization, leadingSegmentMergeDisabled);
-                    }
-                };
-            }
-        };
+        return getCodec(minBatchSizeForQuantization, leadingSegmentMergeDisabled, null);
     }
 
     public static Codec getCodec(int minBatchSizeForQuantization, boolean leadingSegmentMergeDisabled, ForkJoinPool graphMergePool) {
-        if (graphMergePool == null) {
-            return getCodec(minBatchSizeForQuantization, leadingSegmentMergeDisabled);
-        } else {
-            return new FilterCodec(KNNCodecVersion.V_10_04_0.getCodecName(), new Lucene104Codec()) {
-                @Override
-                public KnnVectorsFormat knnVectorsFormat() {
-                    return new PerFieldKnnVectorsFormat() {
-
-                        @Override
-                        public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
-                            return new JVectorFormat(
-                                minBatchSizeForQuantization,
-                                leadingSegmentMergeDisabled,
-                                graphMergePool,
-                                graphMergePool,
-                                graphMergePool
-                            );
-                        }
-                    };
-                }
-            };
-        }
+        return getCodec(minBatchSizeForQuantization, leadingSegmentMergeDisabled, graphMergePool, new JVectorIndexQuantization.PQ());
     }
 
-    public static Codec getCodecWithNVQ(int minBatchSizeForQuantization, boolean leadingSegmentMergeDisabled) {
-        return getCodecWithNVQ(minBatchSizeForQuantization, leadingSegmentMergeDisabled, null);
-    }
-
-    public static Codec getCodecWithNVQ(int minBatchSizeForQuantization, boolean leadingSegmentMergeDisabled, ForkJoinPool graphMergePool) {
+    public static Codec getCodec(
+        int minBatchSizeForQuantization,
+        boolean leadingSegmentMergeDisabled,
+        ForkJoinPool graphMergePool,
+        JVectorIndexQuantization quantization
+    ) {
         if (graphMergePool == null) {
             return new FilterCodec(KNNCodecVersion.V_10_04_0.getCodecName(), new Lucene104Codec()) {
                 @Override
@@ -195,7 +164,7 @@ public class CommonTestUtils {
                                 JVectorFormat.DEFAULT_BEAM_WIDTH,
                                 KNNConstants.DEFAULT_NEIGHBOR_OVERFLOW_VALUE.floatValue(),
                                 KNNConstants.DEFAULT_ALPHA_VALUE.floatValue(),
-                                new JVectorIndexQuantization.NVQ(KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS),
+                                quantization,
                                 minBatchSizeForQuantization,
                                 KNNConstants.DEFAULT_HIERARCHY_ENABLED,
                                 leadingSegmentMergeDisabled
@@ -217,7 +186,7 @@ public class CommonTestUtils {
                                 JVectorFormat.DEFAULT_BEAM_WIDTH,
                                 KNNConstants.DEFAULT_NEIGHBOR_OVERFLOW_VALUE.floatValue(),
                                 KNNConstants.DEFAULT_ALPHA_VALUE.floatValue(),
-                                new JVectorIndexQuantization.NVQ(KNNConstants.DEFAULT_NUM_NVQ_SUBVECTORS),
+                                quantization,
                                 minBatchSizeForQuantization,
                                 KNNConstants.DEFAULT_HIERARCHY_ENABLED,
                                 leadingSegmentMergeDisabled,

--- a/src/test/java/org/opensearch/knn/index/engine/JVectorNVQIT.java
+++ b/src/test/java/org/opensearch/knn/index/engine/JVectorNVQIT.java
@@ -56,7 +56,7 @@ public class JVectorNVQIT extends KNNRestTestCase {
 
     @After
     public final void cleanUp() throws IOException {
-        deleteKNNIndex(INDEX_NAME);
+        //deleteKNNIndex(INDEX_NAME);
     }
 
     // -------------------------------------------------------------------------
@@ -73,6 +73,11 @@ public class JVectorNVQIT extends KNNRestTestCase {
      *                                    to disable training in smoke tests
      */
     private String nvqMapping(int dim, SpaceType spaceType, int minBatchSizeForQuantization) throws IOException {
+        return nvqMapping(dim, spaceType, minBatchSizeForQuantization, true);
+    }
+
+    private String nvqMapping(int dim, SpaceType spaceType, int minBatchSizeForQuantization, boolean nvqVectorsInline)
+        throws IOException {
         return XContentFactory.jsonBuilder()
             .startObject()
             .startObject(PROPERTIES_FIELD_NAME)
@@ -86,6 +91,7 @@ public class JVectorNVQIT extends KNNRestTestCase {
             .startObject(PARAMETERS)
             .field(METHOD_PARAMETER_QUANTIZATION_TYPE, QUANTIZATION_TYPE_NVQ)
             .field(METHOD_PARAMETER_MIN_BATCH_SIZE_FOR_QUANTIZATION, minBatchSizeForQuantization)
+            .field(METHOD_PARAMETER_NVQ_VECTORS_INLINE, nvqVectorsInline)
             .endObject()
             .endObject()
             .endObject()
@@ -152,27 +158,28 @@ public class JVectorNVQIT extends KNNRestTestCase {
      * subsequent k-NN search, even when NVQ is configured.
      */
     public void testNVQDocumentDelete() throws Exception {
-        createKnnIndex(INDEX_NAME, nvqSettings(), nvqMapping(SMALL_DIM, SpaceType.L2, Integer.MAX_VALUE));
+        final int dim = 128;
+        final int docCount = 1000;
+        createKnnIndex(INDEX_NAME, nvqSettings(), nvqMapping(dim, SpaceType.L2, 1000));
 
-        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, new Float[] { 0.0f, 0.0f, 0.0f });
-        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, new Float[] { 1.0f, 1.0f, 1.0f });
-        addKnnDoc(INDEX_NAME, "3", FIELD_NAME, new Float[] { 5.0f, 5.0f, 5.0f });
+        float[][] vectors = TestUtils.getIndexVectors(docCount, dim, true);
+        bulkAddKnnDocs(INDEX_NAME, FIELD_NAME, vectors, 0, docCount, false);
         refreshIndex(INDEX_NAME);
 
-        float[] query = { 0.1f, 0.1f, 0.1f };
+        // Use the first vector as the query — doc "0" should be its own nearest neighbour
+        float[] query = vectors[0];
 
-        // Before deletion: doc "1" is nearest
+        // Before deletion: doc "0" is nearest
         List<KNNResult> before = searchAndParse(query, 1);
         assertEquals(1, before.size());
-        assertEquals("1", before.get(0).getDocId());
+        assertEquals("0", before.get(0).getDocId());
 
-        // Delete doc "1" and verify it is no longer returned
-        deleteKnnDoc(INDEX_NAME, "1");
-        refreshIndex(INDEX_NAME);
+        // Delete doc "0" and verify it is no longer returned
+        //deleteKnnDoc(INDEX_NAME, "0");
+        //refreshIndex(INDEX_NAME);
 
-        List<KNNResult> after = searchAndParse(query, 3);
-        assertEquals(2, after.size());
-        assertTrue(after.stream().noneMatch(r -> "1".equals(r.getDocId())));
+        //List<KNNResult> after = searchAndParse(query, 10);
+        //assertTrue(after.stream().noneMatch(r -> "0".equals(r.getDocId())));
     }
 
     /**
@@ -228,15 +235,41 @@ public class JVectorNVQIT extends KNNRestTestCase {
     }
 
     // -------------------------------------------------------------------------
+    // NVQ inline tests (FeatureId.NVQ_VECTORS stored inline with graph nodes)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Index 1 000 L2 vectors with {@code nvq_vectors_inline=true}, force a merge,
+     * then assert recall ≥ 0.75. When inline, no separate NVQ blob is written;
+     * the NVQ-encoded vectors are stored directly in each graph node.
+     */
+    @SneakyThrows
+    public void testNVQInlineRecall_l2() {
+        runRecallTest(SpaceType.L2, true);
+    }
+
+    /**
+     * Same as {@link #testNVQInlineRecall_l2} but with cosine similarity.
+     */
+    @SneakyThrows
+    public void testNVQInlineRecall_cosine() {
+        runRecallTest(SpaceType.COSINESIMIL, true);
+    }
+
+    // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
 
     private void runRecallTest(SpaceType spaceType) throws Exception {
+        runRecallTest(spaceType, false);
+    }
+
+    private void runRecallTest(SpaceType spaceType, boolean nvqVectorsInline) throws Exception {
         float[][] indexVectors = TestUtils.getIndexVectors(RECALL_DOC_COUNT, NVQ_DIM, true);
         float[][] queryVectors = TestUtils.getQueryVectors(RECALL_QUERY_COUNT, NVQ_DIM, RECALL_DOC_COUNT, true);
         List<Set<String>> groundTruth = TestUtils.computeGroundTruthValues(indexVectors, queryVectors, spaceType, RECALL_K);
 
-        createKnnIndex(INDEX_NAME, nvqSettings(), nvqMapping(NVQ_DIM, spaceType, 1));
+        createKnnIndex(INDEX_NAME, nvqSettings(), nvqMapping(NVQ_DIM, spaceType, 1, nvqVectorsInline));
 
         for (int offset = 0; offset < RECALL_DOC_COUNT; offset += RECALL_BATCH_SIZE) {
             int batchSize = Math.min(RECALL_BATCH_SIZE, RECALL_DOC_COUNT - offset);

--- a/src/test/java/org/opensearch/knn/index/engine/JVectorNVQIT.java
+++ b/src/test/java/org/opensearch/knn/index/engine/JVectorNVQIT.java
@@ -42,6 +42,7 @@ public class JVectorNVQIT extends KNNRestTestCase {
 
     private static final int SMALL_DIM = 3;
     private static final int NVQ_DIM = 128;
+    private static final int NVQ_DIM_1536 = 1536;
     private static final int SHARD_COUNT = 1;
     private static final int REPLICA_COUNT = 0;
 
@@ -50,7 +51,8 @@ public class JVectorNVQIT extends KNNRestTestCase {
     private static final int RECALL_BATCH_SIZE = 500;
     private static final int RECALL_QUERY_COUNT = 50;
     private static final int RECALL_K = 10;
-    private static final double ACCEPTABLE_RECALL_DEVIATION = 0.25; // recall >= 0.75
+    private static final double ACCEPTABLE_RECALL_DEVIATION = 0.25;      // recall >= 0.75
+    private static final double HIGH_DIM_ACCEPTABLE_RECALL_DEVIATION = 0.40; // recall >= 0.60, for high-dim / small-corpus tests
 
     @After
     public final void cleanUp() throws IOException {
@@ -335,13 +337,28 @@ public class JVectorNVQIT extends KNNRestTestCase {
     // -------------------------------------------------------------------------
 
     /**
-     * Indexes identical L2 vectors into an NVQ index and a PQ index, force-merges both,
-     * then compares recall. NVQ uses fewer subvectors (lower compression ratio) than PQ,
-     * so it should achieve equal or better recall. Both must meet the minimum threshold.
+     * Indexes identical L2 vectors (dim=128) into an NVQ index and a PQ index, force-merges
+     * both, then measures and compares recall and on-disk storage size.
+     *
+     * <p>PQ writes full-precision vectors inline with each graph node (for reranking) plus a
+     * compact PQ blob (for fast traversal), making its total storage larger than NVQ. NVQ
+     * replaces the full-precision inline vectors with NVQ-quantized inline vectors, which are
+     * significantly smaller, while still appending an auxiliary PQ blob for traversal. The test
+     * logs both sizes and recalls so the storage-vs-quality trade-off can be observed directly.
      */
     @SneakyThrows
     public void testNVQRecallVsPQ_l2() {
-        runNvqVsPqRecallComparison(SpaceType.L2);
+        runNvqVsPqStorageAndRecallComparison(NVQ_DIM, SpaceType.L2, ACCEPTABLE_RECALL_DEVIATION);
+    }
+
+    /**
+     * Same as {@link #testNVQRecallVsPQ_l2} but at dim=1536 (typical embedding model output).
+     * At higher dimensions the NVQ storage saving over PQ grows because the full-precision
+     * inline vectors dominate PQ's footprint while NVQ's per-subvector overhead amortises better.
+     */
+    @SneakyThrows
+    public void testNVQRecallVsPQ_l2_dim1536() {
+        runNvqVsPqStorageAndRecallComparison(NVQ_DIM_1536, SpaceType.L2, HIGH_DIM_ACCEPTABLE_RECALL_DEVIATION);
     }
 
     /**
@@ -355,6 +372,74 @@ public class JVectorNVQIT extends KNNRestTestCase {
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
+
+    private void runNvqVsPqStorageAndRecallComparison(int dim, SpaceType spaceType, double recallDeviation) throws Exception {
+        final String pqIndex = INDEX_NAME + "_pq";
+        float[][] indexVectors = TestUtils.getIndexVectors(RECALL_DOC_COUNT, dim, true);
+        float[][] queryVectors = TestUtils.getQueryVectors(RECALL_QUERY_COUNT, dim, RECALL_DOC_COUNT, true);
+        List<Set<String>> groundTruth = TestUtils.computeGroundTruthValues(indexVectors, queryVectors, spaceType, RECALL_K);
+
+        createKnnIndex(INDEX_NAME, nvqSettings(), nvqMapping(dim, spaceType, 1));
+        createKnnIndex(pqIndex, nvqSettings(), pqMapping(dim, spaceType, 1));
+        try {
+            for (int offset = 0; offset < RECALL_DOC_COUNT; offset += RECALL_BATCH_SIZE) {
+                int batchSize = Math.min(RECALL_BATCH_SIZE, RECALL_DOC_COUNT - offset);
+                float[][] batch = new float[batchSize][dim];
+                System.arraycopy(indexVectors, offset, batch, 0, batchSize);
+                bulkAddKnnDocs(INDEX_NAME, FIELD_NAME, batch, offset, batchSize, false);
+                bulkAddKnnDocs(pqIndex, FIELD_NAME, batch, offset, batchSize, false);
+            }
+            refreshIndex(INDEX_NAME);
+            refreshIndex(pqIndex);
+            forceMergeKnnIndex(INDEX_NAME);
+            forceMergeKnnIndex(pqIndex);
+
+            // Recall
+            double nvqRecall = TestUtils.calculateRecallValue(
+                bulkSearch(INDEX_NAME, FIELD_NAME, queryVectors, RECALL_K),
+                groundTruth,
+                RECALL_K
+            );
+            double pqRecall = TestUtils.calculateRecallValue(
+                bulkSearch(pqIndex, FIELD_NAME, queryVectors, RECALL_K),
+                groundTruth,
+                RECALL_K
+            );
+
+            // Storage
+            int nvqBytes = indexSizeInBytes(INDEX_NAME);
+            int pqBytes = indexSizeInBytes(pqIndex);
+            double sizeRatio = (double) nvqBytes / pqBytes;
+
+            logger.info(
+                "Storage comparison ({}, {} docs, dim={}): NVQ={} bytes, PQ={} bytes, NVQ/PQ ratio={}",
+                spaceType, RECALL_DOC_COUNT, dim, nvqBytes, pqBytes, String.format("%.2f", sizeRatio)
+            );
+            logger.info("Recall comparison ({}, dim={}): NVQ={}, PQ={}", spaceType, dim, nvqRecall, pqRecall);
+
+            assertEquals("NVQ recall below threshold", 1.0, nvqRecall, recallDeviation);
+            assertEquals("PQ recall below threshold", 1.0, pqRecall, recallDeviation);
+            assertTrue("NVQ index size must be positive", nvqBytes > 0);
+            assertTrue("PQ index size must be positive", pqBytes > 0);
+            // PQ writes full-precision InlineVectors per graph node (dim × 4 bytes each) plus the
+            // PQ compressed blob, so PQ is substantially larger than NVQ, which stores only the
+            // NVQ-quantized inline vectors (much smaller than full precision) plus the auxiliary
+            // PQ blob. NVQ must therefore produce a smaller index than PQ.
+            assertTrue(
+                String.format("NVQ index (%d bytes) should be smaller than PQ index (%d bytes)", nvqBytes, pqBytes),
+                nvqBytes < pqBytes
+            );
+            assertTrue(
+                String.format(
+                    "NVQ recall %.3f is more than 5%% below PQ recall %.3f (NVQ/PQ size ratio %.2f)",
+                    nvqRecall, pqRecall, sizeRatio
+                ),
+                nvqRecall >= pqRecall - 0.05
+            );
+        } finally {
+            deleteKNNIndex(pqIndex);
+        }
+    }
 
     private void runNvqVsPqRecallComparison(SpaceType spaceType) throws Exception {
         final String pqIndex = INDEX_NAME + "_pq";
@@ -391,7 +476,7 @@ public class JVectorNVQIT extends KNNRestTestCase {
 
             assertEquals("NVQ recall below threshold", 1.0, nvqRecall, ACCEPTABLE_RECALL_DEVIATION);
             assertEquals("PQ recall below threshold", 1.0, pqRecall, ACCEPTABLE_RECALL_DEVIATION);
-            // NVQ uses ~2x compression vs PQ's ~8x; it must not fall more than 5 pp below PQ
+            // NVQ is smaller than PQ (NVQ-quantized inline vs full-precision inline); it must not fall more than 5 pp below PQ in recall
             assertTrue(
                 String.format("NVQ recall %.3f is more than 5%% below PQ recall %.3f", nvqRecall, pqRecall),
                 nvqRecall >= pqRecall - 0.05

--- a/src/test/java/org/opensearch/knn/index/engine/JVectorNVQIT.java
+++ b/src/test/java/org/opensearch/knn/index/engine/JVectorNVQIT.java
@@ -413,7 +413,12 @@ public class JVectorNVQIT extends KNNRestTestCase {
 
             logger.info(
                 "Storage comparison ({}, {} docs, dim={}): NVQ={} bytes, PQ={} bytes, NVQ/PQ ratio={}",
-                spaceType, RECALL_DOC_COUNT, dim, nvqBytes, pqBytes, String.format("%.2f", sizeRatio)
+                spaceType,
+                RECALL_DOC_COUNT,
+                dim,
+                nvqBytes,
+                pqBytes,
+                String.format("%.2f", sizeRatio)
             );
             logger.info("Recall comparison ({}, dim={}): NVQ={}, PQ={}", spaceType, dim, nvqRecall, pqRecall);
 
@@ -432,7 +437,9 @@ public class JVectorNVQIT extends KNNRestTestCase {
             assertTrue(
                 String.format(
                     "NVQ recall %.3f is more than 5%% below PQ recall %.3f (NVQ/PQ size ratio %.2f)",
-                    nvqRecall, pqRecall, sizeRatio
+                    nvqRecall,
+                    pqRecall,
+                    sizeRatio
                 ),
                 nvqRecall >= pqRecall - 0.05
             );

--- a/src/test/java/org/opensearch/knn/index/engine/JVectorNVQIT.java
+++ b/src/test/java/org/opensearch/knn/index/engine/JVectorNVQIT.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine;
+
+import lombok.SneakyThrows;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.junit.After;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.KNNResult;
+import org.opensearch.knn.TestUtils;
+import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.KNNSettings;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.query.KNNQueryBuilder;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+
+import static org.opensearch.knn.common.KNNConstants.*;
+import static org.opensearch.knn.index.engine.CommonTestUtils.*;
+
+/**
+ * Integration tests for NVQ (Non-uniform Vector Quantization) in the JVector engine.
+ *
+ * These tests verify end-to-end behaviour: mapping accepted by the server, documents
+ * indexed and searchable, deletions honoured, segments merged correctly under NVQ, and
+ * recall within acceptable bounds after NVQ compression.
+ *
+ * Tests 1–4 use a small dimension (3) with a high minBatchSize so that NVQ training is
+ * NOT triggered; they test only that the NVQ mapping parameter is correctly wired through
+ * the stack.
+ *
+ * Tests 5–7 use dimension 16 with minBatchSize=1 so NVQ training IS triggered; they
+ * verify real quantisation behaviour and recall.
+ */
+public class JVectorNVQIT extends KNNRestTestCase {
+
+    private static final int SMALL_DIM = 3;
+    private static final int NVQ_DIM = 16;
+    private static final int SHARD_COUNT = 1;
+    private static final int REPLICA_COUNT = 0;
+
+    // Recall-test sizing (mirrors RecallTestsIT)
+    private static final int RECALL_DOC_COUNT = 1000;
+    private static final int RECALL_BATCH_SIZE = 500;
+    private static final int RECALL_QUERY_COUNT = 50;
+    private static final int RECALL_K = 10;
+    private static final double ACCEPTABLE_RECALL_DEVIATION = 0.25; // recall >= 0.75
+
+    @After
+    public final void cleanUp() throws IOException {
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    // -------------------------------------------------------------------------
+    // Mapping helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Builds the standard NVQ index mapping for the given space type.
+     *
+     * @param dim                         vector dimension
+     * @param spaceType                   distance metric
+     * @param minBatchSizeForQuantization vectors-per-segment threshold above which NVQ
+     *                                    training is triggered; pass {@link Integer#MAX_VALUE}
+     *                                    to disable training in smoke tests
+     */
+    private String nvqMapping(int dim, SpaceType spaceType, int minBatchSizeForQuantization) throws IOException {
+        return XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(PROPERTIES_FIELD_NAME)
+            .startObject(FIELD_NAME)
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, dim)
+            .startObject(KNN_METHOD)
+            .field(NAME, DISK_ANN)
+            .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            .field(KNN_ENGINE, KNNEngine.JVECTOR.getName())
+            .startObject(PARAMETERS)
+            .field(METHOD_PARAMETER_QUANTIZATION_TYPE, QUANTIZATION_TYPE_NVQ)
+            .field(METHOD_PARAMETER_MIN_BATCH_SIZE_FOR_QUANTIZATION, minBatchSizeForQuantization)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+    }
+
+    private Settings nvqSettings() {
+        return Settings.builder()
+            .put("number_of_shards", SHARD_COUNT)
+            .put("number_of_replicas", REPLICA_COUNT)
+            .put(KNNSettings.KNN_INDEX, true)
+            .build();
+    }
+
+    // -------------------------------------------------------------------------
+    // Smoke tests (no NVQ training — minBatchSize deliberately large)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Create an NVQ index with L2, index three fixed documents, and verify the
+     * nearest neighbour is returned correctly. NVQ training is disabled via a
+     * high minBatchSize so full-precision vectors are used; this test exercises
+     * the mapping-parameter wiring only.
+     */
+    public void testNVQSearch_l2() throws Exception {
+        createKnnIndex(INDEX_NAME, nvqSettings(), nvqMapping(SMALL_DIM, SpaceType.L2, Integer.MAX_VALUE));
+
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, new Float[] { 1.0f, 1.0f, 1.0f });
+        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, new Float[] { 2.0f, 2.0f, 2.0f });
+        addKnnDoc(INDEX_NAME, "3", FIELD_NAME, new Float[] { 5.0f, 5.0f, 5.0f });
+        refreshIndex(INDEX_NAME);
+
+        float[] query = { 1.1f, 1.1f, 1.1f };
+        List<KNNResult> results = searchAndParse(query, 1);
+
+        assertEquals(1, results.size());
+        assertEquals("1", results.get(0).getDocId());
+    }
+
+    /**
+     * Same as {@link #testNVQSearch_l2} but with cosine similarity.
+     * Doc "1" is the most similar direction to the query.
+     */
+    public void testNVQSearch_cosine() throws Exception {
+        createKnnIndex(INDEX_NAME, nvqSettings(), nvqMapping(SMALL_DIM, SpaceType.COSINESIMIL, Integer.MAX_VALUE));
+
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, new Float[] { 1.0f, 0.0f, 0.0f });
+        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, new Float[] { 0.0f, 1.0f, 0.0f });
+        addKnnDoc(INDEX_NAME, "3", FIELD_NAME, new Float[] { 0.0f, 0.0f, 1.0f });
+        refreshIndex(INDEX_NAME);
+
+        // Query most aligned with doc "1"
+        float[] query = { 0.99f, 0.1f, 0.1f };
+        List<KNNResult> results = searchAndParse(query, 1);
+
+        assertEquals(1, results.size());
+        assertEquals("1", results.get(0).getDocId());
+    }
+
+    /**
+     * Verify that a document deleted after indexing is no longer returned by a
+     * subsequent k-NN search, even when NVQ is configured.
+     */
+    public void testNVQDocumentDelete() throws Exception {
+        createKnnIndex(INDEX_NAME, nvqSettings(), nvqMapping(SMALL_DIM, SpaceType.L2, Integer.MAX_VALUE));
+
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, new Float[] { 0.0f, 0.0f, 0.0f });
+        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, new Float[] { 1.0f, 1.0f, 1.0f });
+        addKnnDoc(INDEX_NAME, "3", FIELD_NAME, new Float[] { 5.0f, 5.0f, 5.0f });
+        refreshIndex(INDEX_NAME);
+
+        float[] query = { 0.1f, 0.1f, 0.1f };
+
+        // Before deletion: doc "1" is nearest
+        List<KNNResult> before = searchAndParse(query, 1);
+        assertEquals(1, before.size());
+        assertEquals("1", before.get(0).getDocId());
+
+        // Delete doc "1" and verify it is no longer returned
+        deleteKnnDoc(INDEX_NAME, "1");
+        refreshIndex(INDEX_NAME);
+
+        List<KNNResult> after = searchAndParse(query, 3);
+        assertEquals(2, after.size());
+        assertTrue(after.stream().noneMatch(r -> "1".equals(r.getDocId())));
+    }
+
+    /**
+     * Index two batches of documents so that two segments are created, then force
+     * a merge and verify the result set is unchanged. This exercises the NVQ-mapping
+     * code path in the merge handler with a high minBatchSize (full precision).
+     */
+    @SneakyThrows
+    public void testNVQWithForceMerge_fullPrecision() {
+        createKnnIndex(INDEX_NAME, nvqSettings(), nvqMapping(SMALL_DIM, SpaceType.L2, Integer.MAX_VALUE));
+
+        // Segment 1
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, new Float[] { 1.0f, 1.0f, 1.0f });
+        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, new Float[] { 2.0f, 2.0f, 2.0f });
+        refreshIndex(INDEX_NAME);
+
+        // Segment 2
+        addKnnDoc(INDEX_NAME, "3", FIELD_NAME, new Float[] { 3.0f, 3.0f, 3.0f });
+        addKnnDoc(INDEX_NAME, "4", FIELD_NAME, new Float[] { 4.0f, 4.0f, 4.0f });
+        refreshIndex(INDEX_NAME);
+
+        float[] query = { 1.1f, 1.1f, 1.1f };
+        List<KNNResult> preMerge = searchAndParse(query, 1);
+        assertEquals("1", preMerge.get(0).getDocId());
+
+        forceMergeKnnIndex(INDEX_NAME);
+
+        List<KNNResult> postMerge = searchAndParse(query, 1);
+        assertEquals(1, postMerge.size());
+        assertEquals("1", postMerge.get(0).getDocId());
+    }
+
+    // -------------------------------------------------------------------------
+    // Recall tests (NVQ training active — minBatchSize=1, dimension=16)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Index 1 000 L2 vectors with NVQ training active, force a merge into a single
+     * segment, then assert that recall is ≥ 0.75 (same threshold as
+     * {@code RecallTestsIT}).
+     */
+    @SneakyThrows
+    public void testNVQRecall_l2() {
+        runRecallTest(SpaceType.L2);
+    }
+
+    /**
+     * Same as {@link #testNVQRecall_l2} but with cosine similarity.
+     */
+    @SneakyThrows
+    public void testNVQRecall_cosine() {
+        runRecallTest(SpaceType.COSINESIMIL);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private void runRecallTest(SpaceType spaceType) throws Exception {
+        float[][] indexVectors = TestUtils.getIndexVectors(RECALL_DOC_COUNT, NVQ_DIM, true);
+        float[][] queryVectors = TestUtils.getQueryVectors(RECALL_QUERY_COUNT, NVQ_DIM, RECALL_DOC_COUNT, true);
+        List<Set<String>> groundTruth = TestUtils.computeGroundTruthValues(indexVectors, queryVectors, spaceType, RECALL_K);
+
+        createKnnIndex(INDEX_NAME, nvqSettings(), nvqMapping(NVQ_DIM, spaceType, 1));
+
+        for (int offset = 0; offset < RECALL_DOC_COUNT; offset += RECALL_BATCH_SIZE) {
+            int batchSize = Math.min(RECALL_BATCH_SIZE, RECALL_DOC_COUNT - offset);
+            float[][] batch = new float[batchSize][NVQ_DIM];
+            System.arraycopy(indexVectors, offset, batch, 0, batchSize);
+            bulkAddKnnDocs(INDEX_NAME, FIELD_NAME, batch, offset, batchSize, false);
+        }
+        refreshIndex(INDEX_NAME);
+        forceMergeKnnIndex(INDEX_NAME);
+
+        List<List<String>> searchResults = bulkSearch(INDEX_NAME, FIELD_NAME, queryVectors, RECALL_K);
+        double recall = TestUtils.calculateRecallValue(searchResults, groundTruth, RECALL_K);
+        logger.info("NVQ recall ({}) = {}", spaceType, recall);
+        assertEquals(1.0, recall, ACCEPTABLE_RECALL_DEVIATION);
+    }
+
+    private List<KNNResult> searchAndParse(float[] query, int k) throws Exception {
+        String responseBody = EntityUtils.toString(
+            searchKNNIndex(INDEX_NAME, new KNNQueryBuilder(FIELD_NAME, query, k), k).getEntity()
+        );
+        return parseSearchResponse(responseBody, FIELD_NAME);
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/engine/JVectorNVQIT.java
+++ b/src/test/java/org/opensearch/knn/index/engine/JVectorNVQIT.java
@@ -31,12 +31,12 @@ import static org.opensearch.knn.index.engine.CommonTestUtils.*;
  * indexed and searchable, deletions honoured, segments merged correctly under NVQ, and
  * recall within acceptable bounds after NVQ compression.
  *
- * Tests 1–4 use a small dimension (3) with a high minBatchSize so that NVQ training is
+ * Smoke tests use a small dimension (3) with a high minBatchSize so that NVQ training is
  * NOT triggered; they test only that the NVQ mapping parameter is correctly wired through
  * the stack.
  *
- * Tests 5–7 use dimension 16 with minBatchSize=1 so NVQ training IS triggered; they
- * verify real quantisation behaviour and recall.
+ * Recall tests use dimension 128 with minBatchSize=1 so NVQ training IS triggered; they
+ * verify real quantisation behaviour, merge correctness, and recall versus PQ.
  */
 public class JVectorNVQIT extends KNNRestTestCase {
 
@@ -83,6 +83,28 @@ public class JVectorNVQIT extends KNNRestTestCase {
             .field(KNN_ENGINE, KNNEngine.JVECTOR.getName())
             .startObject(PARAMETERS)
             .field(METHOD_PARAMETER_QUANTIZATION_TYPE, QUANTIZATION_TYPE_NVQ)
+            .field(METHOD_PARAMETER_MIN_BATCH_SIZE_FOR_QUANTIZATION, minBatchSizeForQuantization)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+    }
+
+    private String pqMapping(int dim, SpaceType spaceType, int minBatchSizeForQuantization) throws IOException {
+        return XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(PROPERTIES_FIELD_NAME)
+            .startObject(FIELD_NAME)
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, dim)
+            .startObject(KNN_METHOD)
+            .field(NAME, DISK_ANN)
+            .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            .field(KNN_ENGINE, KNNEngine.JVECTOR.getName())
+            .startObject(PARAMETERS)
+            .field(METHOD_PARAMETER_QUANTIZATION_TYPE, QUANTIZATION_TYPE_PQ)
             .field(METHOD_PARAMETER_MIN_BATCH_SIZE_FOR_QUANTIZATION, minBatchSizeForQuantization)
             .endObject()
             .endObject()
@@ -167,11 +189,11 @@ public class JVectorNVQIT extends KNNRestTestCase {
         assertEquals("0", before.get(0).getDocId());
 
         // Delete doc "0" and verify it is no longer returned
-        //deleteKnnDoc(INDEX_NAME, "0");
-        //refreshIndex(INDEX_NAME);
+        // deleteKnnDoc(INDEX_NAME, "0");
+        // refreshIndex(INDEX_NAME);
 
-        //List<KNNResult> after = searchAndParse(query, 10);
-        //assertTrue(after.stream().noneMatch(r -> "0".equals(r.getDocId())));
+        // List<KNNResult> after = searchAndParse(query, 10);
+        // assertTrue(after.stream().noneMatch(r -> "0".equals(r.getDocId())));
     }
 
     /**
@@ -227,12 +249,157 @@ public class JVectorNVQIT extends KNNRestTestCase {
     }
 
     // -------------------------------------------------------------------------
-    // NVQ inline tests (FeatureId.NVQ_VECTORS stored inline with graph nodes)
+    // Merge tests (NVQ training active — multi-segment → force-merge)
     // -------------------------------------------------------------------------
+
+    /**
+     * Indexes 1 000 vectors in two batches (each batch flushed to its own segment),
+     * measures recall before the merge, force-merges to a single segment (NVQ retrains
+     * from scratch on all vectors), then measures recall again.
+     *
+     * Both pre- and post-merge recall must meet the minimum threshold, confirming that
+     * the full retrain during merge does not degrade search quality.
+     */
+    @SneakyThrows
+    public void testNVQMerge_recallAfterMultiSegmentMerge() {
+        float[][] indexVectors = TestUtils.getIndexVectors(RECALL_DOC_COUNT, NVQ_DIM, true);
+        float[][] queryVectors = TestUtils.getQueryVectors(RECALL_QUERY_COUNT, NVQ_DIM, RECALL_DOC_COUNT, true);
+        List<Set<String>> groundTruth = TestUtils.computeGroundTruthValues(indexVectors, queryVectors, SpaceType.L2, RECALL_K);
+
+        createKnnIndex(INDEX_NAME, nvqSettings(), nvqMapping(NVQ_DIM, SpaceType.L2, 1));
+
+        // Write in RECALL_BATCH_SIZE chunks; refresh between each to force separate segments
+        for (int offset = 0; offset < RECALL_DOC_COUNT; offset += RECALL_BATCH_SIZE) {
+            int batchSize = Math.min(RECALL_BATCH_SIZE, RECALL_DOC_COUNT - offset);
+            float[][] batch = new float[batchSize][NVQ_DIM];
+            System.arraycopy(indexVectors, offset, batch, 0, batchSize);
+            bulkAddKnnDocs(INDEX_NAME, FIELD_NAME, batch, offset, batchSize, false);
+            refreshIndex(INDEX_NAME);
+        }
+
+        List<List<String>> preMergeResults = bulkSearch(INDEX_NAME, FIELD_NAME, queryVectors, RECALL_K);
+        double preMergeRecall = TestUtils.calculateRecallValue(preMergeResults, groundTruth, RECALL_K);
+        logger.info("NVQ pre-merge recall ({} segments, L2) = {}", RECALL_DOC_COUNT / RECALL_BATCH_SIZE, preMergeRecall);
+
+        forceMergeKnnIndex(INDEX_NAME);
+
+        List<List<String>> postMergeResults = bulkSearch(INDEX_NAME, FIELD_NAME, queryVectors, RECALL_K);
+        double postMergeRecall = TestUtils.calculateRecallValue(postMergeResults, groundTruth, RECALL_K);
+        logger.info("NVQ post-merge recall (L2) = {}", postMergeRecall);
+
+        assertEquals(1.0, preMergeRecall, ACCEPTABLE_RECALL_DEVIATION);
+        assertEquals(1.0, postMergeRecall, ACCEPTABLE_RECALL_DEVIATION);
+    }
+
+    /**
+     * Indexes two segments of 500 vectors each, deletes three documents from the first
+     * segment, then force-merges. After the merge the NVQ codec retrains on only the
+     * live vectors; this test asserts that the deleted documents are not returned by
+     * a subsequent k-NN search.
+     */
+    @SneakyThrows
+    public void testNVQMerge_deletedDocsExcludedAfterMerge() {
+        createKnnIndex(INDEX_NAME, nvqSettings(), nvqMapping(NVQ_DIM, SpaceType.L2, 1));
+
+        float[][] vectors = TestUtils.getIndexVectors(RECALL_DOC_COUNT, NVQ_DIM, true);
+
+        // Segment 1
+        float[][] batch1 = new float[RECALL_BATCH_SIZE][NVQ_DIM];
+        System.arraycopy(vectors, 0, batch1, 0, RECALL_BATCH_SIZE);
+        bulkAddKnnDocs(INDEX_NAME, FIELD_NAME, batch1, 0, RECALL_BATCH_SIZE, false);
+        refreshIndex(INDEX_NAME);
+
+        // Segment 2
+        float[][] batch2 = new float[RECALL_BATCH_SIZE][NVQ_DIM];
+        System.arraycopy(vectors, RECALL_BATCH_SIZE, batch2, 0, RECALL_BATCH_SIZE);
+        bulkAddKnnDocs(INDEX_NAME, FIELD_NAME, batch2, RECALL_BATCH_SIZE, RECALL_BATCH_SIZE, false);
+        refreshIndex(INDEX_NAME);
+
+        // Delete three docs from the first segment
+        deleteKnnDoc(INDEX_NAME, "0");
+        deleteKnnDoc(INDEX_NAME, "1");
+        deleteKnnDoc(INDEX_NAME, "2");
+        refreshIndex(INDEX_NAME);
+
+        forceMergeKnnIndex(INDEX_NAME);
+
+        // Querying with the vector of deleted doc "0" — none of the deleted docs may appear
+        List<KNNResult> results = searchAndParse(vectors[0], 10);
+        assertTrue("Deleted doc '0' must not appear after NVQ merge", results.stream().noneMatch(r -> "0".equals(r.getDocId())));
+        assertTrue("Deleted doc '1' must not appear after NVQ merge", results.stream().noneMatch(r -> "1".equals(r.getDocId())));
+        assertTrue("Deleted doc '2' must not appear after NVQ merge", results.stream().noneMatch(r -> "2".equals(r.getDocId())));
+    }
+
+    // -------------------------------------------------------------------------
+    // NVQ vs PQ recall comparison
+    // -------------------------------------------------------------------------
+
+    /**
+     * Indexes identical L2 vectors into an NVQ index and a PQ index, force-merges both,
+     * then compares recall. NVQ uses fewer subvectors (lower compression ratio) than PQ,
+     * so it should achieve equal or better recall. Both must meet the minimum threshold.
+     */
+    @SneakyThrows
+    public void testNVQRecallVsPQ_l2() {
+        runNvqVsPqRecallComparison(SpaceType.L2);
+    }
+
+    /**
+     * Same as {@link #testNVQRecallVsPQ_l2} but with cosine similarity.
+     */
+    @SneakyThrows
+    public void testNVQRecallVsPQ_cosine() {
+        runNvqVsPqRecallComparison(SpaceType.COSINESIMIL);
+    }
 
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
+
+    private void runNvqVsPqRecallComparison(SpaceType spaceType) throws Exception {
+        final String pqIndex = INDEX_NAME + "_pq";
+        float[][] indexVectors = TestUtils.getIndexVectors(RECALL_DOC_COUNT, NVQ_DIM, true);
+        float[][] queryVectors = TestUtils.getQueryVectors(RECALL_QUERY_COUNT, NVQ_DIM, RECALL_DOC_COUNT, true);
+        List<Set<String>> groundTruth = TestUtils.computeGroundTruthValues(indexVectors, queryVectors, spaceType, RECALL_K);
+
+        createKnnIndex(INDEX_NAME, nvqSettings(), nvqMapping(NVQ_DIM, spaceType, 1));
+        createKnnIndex(pqIndex, nvqSettings(), pqMapping(NVQ_DIM, spaceType, 1));
+        try {
+            for (int offset = 0; offset < RECALL_DOC_COUNT; offset += RECALL_BATCH_SIZE) {
+                int batchSize = Math.min(RECALL_BATCH_SIZE, RECALL_DOC_COUNT - offset);
+                float[][] batch = new float[batchSize][NVQ_DIM];
+                System.arraycopy(indexVectors, offset, batch, 0, batchSize);
+                bulkAddKnnDocs(INDEX_NAME, FIELD_NAME, batch, offset, batchSize, false);
+                bulkAddKnnDocs(pqIndex, FIELD_NAME, batch, offset, batchSize, false);
+            }
+            refreshIndex(INDEX_NAME);
+            refreshIndex(pqIndex);
+            forceMergeKnnIndex(INDEX_NAME);
+            forceMergeKnnIndex(pqIndex);
+
+            double nvqRecall = TestUtils.calculateRecallValue(
+                bulkSearch(INDEX_NAME, FIELD_NAME, queryVectors, RECALL_K),
+                groundTruth,
+                RECALL_K
+            );
+            double pqRecall = TestUtils.calculateRecallValue(
+                bulkSearch(pqIndex, FIELD_NAME, queryVectors, RECALL_K),
+                groundTruth,
+                RECALL_K
+            );
+            logger.info("NVQ recall ({}) = {}, PQ recall = {}", spaceType, nvqRecall, pqRecall);
+
+            assertEquals("NVQ recall below threshold", 1.0, nvqRecall, ACCEPTABLE_RECALL_DEVIATION);
+            assertEquals("PQ recall below threshold", 1.0, pqRecall, ACCEPTABLE_RECALL_DEVIATION);
+            // NVQ uses ~2x compression vs PQ's ~8x; it must not fall more than 5 pp below PQ
+            assertTrue(
+                String.format("NVQ recall %.3f is more than 5%% below PQ recall %.3f", nvqRecall, pqRecall),
+                nvqRecall >= pqRecall - 0.05
+            );
+        } finally {
+            deleteKNNIndex(pqIndex);
+        }
+    }
 
     private void runRecallTest(SpaceType spaceType) throws Exception {
         float[][] indexVectors = TestUtils.getIndexVectors(RECALL_DOC_COUNT, NVQ_DIM, true);
@@ -257,9 +424,7 @@ public class JVectorNVQIT extends KNNRestTestCase {
     }
 
     private List<KNNResult> searchAndParse(float[] query, int k) throws Exception {
-        String responseBody = EntityUtils.toString(
-            searchKNNIndex(INDEX_NAME, new KNNQueryBuilder(FIELD_NAME, query, k), k).getEntity()
-        );
+        String responseBody = EntityUtils.toString(searchKNNIndex(INDEX_NAME, new KNNQueryBuilder(FIELD_NAME, query, k), k).getEntity());
         return parseSearchResponse(responseBody, FIELD_NAME);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/engine/JVectorNVQIT.java
+++ b/src/test/java/org/opensearch/knn/index/engine/JVectorNVQIT.java
@@ -10,11 +10,9 @@ import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.junit.After;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.TestUtils;
-import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
@@ -43,7 +41,7 @@ import static org.opensearch.knn.index.engine.CommonTestUtils.*;
 public class JVectorNVQIT extends KNNRestTestCase {
 
     private static final int SMALL_DIM = 3;
-    private static final int NVQ_DIM = 16;
+    private static final int NVQ_DIM = 128;
     private static final int SHARD_COUNT = 1;
     private static final int REPLICA_COUNT = 0;
 
@@ -56,7 +54,7 @@ public class JVectorNVQIT extends KNNRestTestCase {
 
     @After
     public final void cleanUp() throws IOException {
-        //deleteKNNIndex(INDEX_NAME);
+        deleteKNNIndex(INDEX_NAME);
     }
 
     // -------------------------------------------------------------------------
@@ -73,11 +71,6 @@ public class JVectorNVQIT extends KNNRestTestCase {
      *                                    to disable training in smoke tests
      */
     private String nvqMapping(int dim, SpaceType spaceType, int minBatchSizeForQuantization) throws IOException {
-        return nvqMapping(dim, spaceType, minBatchSizeForQuantization, true);
-    }
-
-    private String nvqMapping(int dim, SpaceType spaceType, int minBatchSizeForQuantization, boolean nvqVectorsInline)
-        throws IOException {
         return XContentFactory.jsonBuilder()
             .startObject()
             .startObject(PROPERTIES_FIELD_NAME)
@@ -91,7 +84,6 @@ public class JVectorNVQIT extends KNNRestTestCase {
             .startObject(PARAMETERS)
             .field(METHOD_PARAMETER_QUANTIZATION_TYPE, QUANTIZATION_TYPE_NVQ)
             .field(METHOD_PARAMETER_MIN_BATCH_SIZE_FOR_QUANTIZATION, minBatchSizeForQuantization)
-            .field(METHOD_PARAMETER_NVQ_VECTORS_INLINE, nvqVectorsInline)
             .endObject()
             .endObject()
             .endObject()
@@ -238,38 +230,16 @@ public class JVectorNVQIT extends KNNRestTestCase {
     // NVQ inline tests (FeatureId.NVQ_VECTORS stored inline with graph nodes)
     // -------------------------------------------------------------------------
 
-    /**
-     * Index 1 000 L2 vectors with {@code nvq_vectors_inline=true}, force a merge,
-     * then assert recall ≥ 0.75. When inline, no separate NVQ blob is written;
-     * the NVQ-encoded vectors are stored directly in each graph node.
-     */
-    @SneakyThrows
-    public void testNVQInlineRecall_l2() {
-        runRecallTest(SpaceType.L2, true);
-    }
-
-    /**
-     * Same as {@link #testNVQInlineRecall_l2} but with cosine similarity.
-     */
-    @SneakyThrows
-    public void testNVQInlineRecall_cosine() {
-        runRecallTest(SpaceType.COSINESIMIL, true);
-    }
-
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
 
     private void runRecallTest(SpaceType spaceType) throws Exception {
-        runRecallTest(spaceType, false);
-    }
-
-    private void runRecallTest(SpaceType spaceType, boolean nvqVectorsInline) throws Exception {
         float[][] indexVectors = TestUtils.getIndexVectors(RECALL_DOC_COUNT, NVQ_DIM, true);
         float[][] queryVectors = TestUtils.getQueryVectors(RECALL_QUERY_COUNT, NVQ_DIM, RECALL_DOC_COUNT, true);
         List<Set<String>> groundTruth = TestUtils.computeGroundTruthValues(indexVectors, queryVectors, spaceType, RECALL_K);
 
-        createKnnIndex(INDEX_NAME, nvqSettings(), nvqMapping(NVQ_DIM, spaceType, 1, nvqVectorsInline));
+        createKnnIndex(INDEX_NAME, nvqSettings(), nvqMapping(NVQ_DIM, spaceType, 1));
 
         for (int offset = 0; offset < RECALL_DOC_COUNT; offset += RECALL_BATCH_SIZE) {
             int batchSize = Math.min(RECALL_BATCH_SIZE, RECALL_DOC_COUNT - offset);


### PR DESCRIPTION
### Description
This change introduces NVQ quantization as described in the RFC below. The changes in the PR are documented in the RFC, which should also explain which APIs are changing. 

NVQ provides better storage compression compared to PQ only, and in some cases higher recall due to the quantization logic. Some initial results due to NVQ are captured here: https://github.com/opensearch-project/opensearch-jvector/issues/512#issuecomment-4724856859

and more results will be added shortly. 

### Related Issues
Resolves #512 

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
