### PR TITLE
Fix NPE due to an attempt to read the segment with no graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix dynamic template and mixed cases [538](https://github.com/opensearch-project/opensearch-jvector/pull/538)
 - Fix flaky testMixedBatchSizesForQuantization test case [564](https://github.com/opensearch-project/opensearch-jvector/pull/564)
 - Fix flaky testJVectorKnnIndex_simpleCase_maxInnerProduct test case [569](https://github.com/opensearch-project/opensearch-jvector/pull/569)
+- Fix NPE due to an attempt to read the segment with no graph [552](https://github.com/opensearch-project/opensearch-jvector/pull/552)
 
 ### Infrastructure
 ### Documentation

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@
 
 version=1.0.0
 systemProp.bwc.version=3.2.0
-jvector_version=4.0.0-rc.8
+jvector_version=4.0.0-rc.9
 java_release_version=21
 
 # org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -1009,12 +1009,15 @@ public class JVectorWriter extends KnnVectorsWriter {
          */
         public void merge() throws IOException {
             final RemappedRandomAccessVectorValues compactRavvEarly = new RemappedRandomAccessVectorValues(this, compactOrdsToRavvOrds);
+
+            // The merged segments ends up with no vectors (empty graph), nothing to merge there
             if (compactRavvEarly.size() == 0) {
                 log.info("No vectors for field {} in segment {}", fieldInfo.name, mergeState.segmentInfo.name);
-                return;
-            }
-
-            if (quantization instanceof JVectorIndexQuantization.NVQ) {
+                var bsp = BuildScoreProvider.randomAccessScoreProvider(compactRavvEarly, getVectorSimilarityFunction(fieldInfo));
+                var graph = getGraph(bsp, compactRavvEarly, fieldInfo, segmentWriteState.segmentInfo.name, simdPoolMerge);
+                graph.setAllMutationsCompleted();
+                writeField(fieldInfo, compactRavvEarly, null, compactOrdToDocMap, graph);
+            } else if (quantization instanceof JVectorIndexQuantization.NVQ) {
                 mergeNVQ(compactRavvEarly);
             } else {
                 mergePQ(compactRavvEarly);

--- a/src/test/java/org/opensearch/knn/KNNTestCase.java
+++ b/src/test/java/org/opensearch/knn/KNNTestCase.java
@@ -59,7 +59,7 @@ public class KNNTestCase extends OpenSearchTestCase {
             JVectorFormat.SIMD_POOL_MERGE.shutdown();
             JVectorFormat.SIMD_POOL_FLUSH.shutdown();
             JVectorFormat.PARALLELISM_POOL.shutdown();
-            PhysicalCoreExecutor.instance.close();
+            PhysicalCoreExecutor.instance().close();
         }));
 
     }

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/JVectorMergeWithDeletedDocsTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/JVectorMergeWithDeletedDocsTests.java
@@ -43,7 +43,7 @@ import org.opensearch.knn.index.ThreadLeakFiltersForTests;
 @LuceneTestCase.SuppressSysoutChecks(bugUrl = "")
 @Log4j2
 public class JVectorMergeWithDeletedDocsTests extends LuceneTestCase {
-
+    private static final String TEST_FIELD_2 = "test_field2";
     private static final String TEST_FIELD = "test_field";
     private static final String TEST_ID_FIELD = "id";
 
@@ -443,6 +443,83 @@ public class JVectorMergeWithDeletedDocsTests extends LuceneTestCase {
             }
         }
 
+    }
+
+    /**
+     * Comprehensive test combining merges with documents that
+     * have no vector fields populated, multiple segments with deletes and different vectors fields
+     * which lead to merges with no vectors (empty graph).
+     */
+    @Test
+    public void testMergesWithNoVectorsAndDifferentFields() throws IOException {
+        final int dimension = 3072;
+        final int k = 2;
+
+        IndexWriterConfig config = newIndexWriterConfig();
+        config.setUseCompoundFile(false);
+        config.setCodec(getCodec(1024, random().nextBoolean())); /* 1 to check empty PQ vectors, 10 to check empty graph */
+        config.setMergePolicy(new ForceMergesOnlyMergePolicy());
+        config.setMergeScheduler(new SerialMergeScheduler());
+
+        final Path indexPath = createTempDir();
+
+        try (FSDirectory dir = FSDirectory.open(indexPath); IndexWriter writer = new IndexWriter(dir, config)) {
+            int docId = 0;
+
+            // Segment 1: 2 documents with one document having no vector field populated
+            log.info("Creating segment 1: 2 docs");
+            for (int i = 0; i < 2; i++) {
+                Document doc = new Document();
+                if (i == 0) {
+                    float[] vector = new float[dimension];
+                    Arrays.fill(vector, docId * random().nextFloat(1.0f));
+                    doc.add(new KnnFloatVectorField(TEST_FIELD, vector, VectorSimilarityFunction.EUCLIDEAN));
+                }
+                doc.add(new StringField(TEST_ID_FIELD, String.valueOf(docId), Field.Store.YES));
+                writer.addDocument(doc);
+                docId++;
+            }
+            writer.commit();
+
+            // Segment 2: delete one document with vectors
+            writer.deleteDocuments(new Term(TEST_ID_FIELD, String.valueOf(0)));
+            writer.commit();
+
+            log.info("Performing intermediate merge after segment 2");
+            writer.forceMerge(1);
+
+            {
+                Document doc = new Document();
+                float[] vector = new float[dimension];
+                Arrays.fill(vector, docId * random().nextFloat(1.0f));
+                doc.add(new KnnFloatVectorField(TEST_FIELD_2, vector, VectorSimilarityFunction.EUCLIDEAN));
+                doc.add(new StringField(TEST_ID_FIELD, String.valueOf(docId), Field.Store.YES));
+                writer.addDocument(doc);
+                docId++;
+            }
+            writer.commit();
+
+            // Merge ends up with segment with no vector fields (empty graph)
+            log.info("Performing intermediate merge after segment 3");
+            writer.forceMerge(1);
+        }
+
+        // Verify the merged index
+        try (FSDirectory dir = FSDirectory.open(indexPath); IndexReader reader = DirectoryReader.open(dir)) {
+            Assert.assertEquals("Should have 1 segment after merge", 1, reader.getContext().leaves().size());
+            Assert.assertEquals("Should have correct number of live docs", 2, reader.numDocs());
+
+            // Verify search works correctly
+            final IndexSearcher searcher = newSearcher(reader);
+            TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), k);
+            Assert.assertEquals("Should return k results", 2, topDocs.totalHits.value());
+
+            for (int i = 0; i < topDocs.scoreDocs.length; i++) {
+                Document doc = reader.storedFields().document(topDocs.scoreDocs[i].doc);
+                String id = doc.get(TEST_ID_FIELD);
+                log.info("Result {}: doc ID = {}", i, id);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
### Description
Fix NPE due to an attempt to read the segment with no graph
```
java.lang.NullPointerException: Cannot read field "index" because "fieldEntry" is null
        at __randomizedtesting.SeedInfo.seed([F46459B671447DD1:36BEDB76EB0326DF]:0)
        at org.opensearch.knn.index.codec.jvector.JVectorReader.getFloatVectorValues(JVectorReader.java:101)
        at org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat$FieldsReader.getFloatVectorValues(PerFieldKnnVectorsFormat.java:290)
        at org.opensearch.knn.index.codec.jvector.JVectorWriter$RandomAccessMergedFloatVectorValues.<init>(JVectorWriter.java:687)
        at org.opensearch.knn.index.codec.jvector.JVectorWriter.mergeOneField(JVectorWriter.java:197)
        at org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat$FieldsWriter.mergeOneField(PerFieldKnnVectorsFormat.java:126)
        at org.apache.lucene.codecs.KnnVectorsWriter.merge(KnnVectorsWriter.java:105)
        at org.apache.lucene.index.SegmentMerger.mergeVectorValues(SegmentMerger.java:271)
        at org.apache.lucene.index.SegmentMerger.mergeWithLogging(SegmentMerger.java:314)
```

### Related Issues

The issue is coming from the OpenRag team, the cause of it two fold:
 - we cannot store empty graphs (see please https://github.com/opensearch-project/opensearch-jvector/pull/417)
 - the OpenRAG team mapping include many vector fields that are never indexed / updated together

The combination of two issues from above leads to cases, when Lucene segment has vector fields that it thinks should be in segment but which do not have corresponding graph on disk because it is empty. That leads to the exception from above.

Closes https://github.com/opensearch-project/opensearch-jvector/issues/572

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
