### PR TITLE
Update me.champeau.jmh to 0.7.3

### DIFF
--- a/benchmark-jmh/build.gradle
+++ b/benchmark-jmh/build.gradle
@@ -30,8 +30,8 @@ dependencies {
     api "org.opensearch:opensearch:${opensearch_version}"
 
     // Add JMH dependencies
-    jmh 'org.openjdk.jmh:jmh-core:1.37'
-    jmh 'org.openjdk.jmh:jmh-generator-annprocess:1.37'
+    jmh 'org.openjdk.jmh:jmh-core:1.36'
+    jmh 'org.openjdk.jmh:jmh-generator-annprocess:1.36'
 
     // Add logging dependencies
     api "org.apache.logging.log4j:log4j-api:${versions.log4j}"

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ plugins {
     id "com.diffplug.spotless" version "8.4.0" apply false
     id 'io.freefair.lombok' version '8.14.4'
     id "de.undercouch.download" version "5.3.0"
-    id "me.champeau.jmh" version "0.7.1"
+    id "me.champeau.jmh" version "0.7.2"
 }
 
 apply from: 'gradle/formatting.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ plugins {
     id "com.diffplug.spotless" version "8.4.0" apply false
     id 'io.freefair.lombok' version '8.14.4'
     id "de.undercouch.download" version "5.3.0"
-    id "me.champeau.jmh" version "0.7.2"
+    id "me.champeau.jmh" version "0.7.3"
 }
 
 apply from: 'gradle/formatting.gradle'


### PR DESCRIPTION
### Description
Update me.champeau.jmh to 0.7.2

### Related Issues

```
* What went wrong:
Execution failed for task ':benchmark-jmh:compileJmhJava' (registered by plugin class 'org.gradle.api.plugins.JavaBasePlugin').
> Could not resolve all files for configuration ':benchmark-jmh:jmhCompileClasspath'.
   > Could not resolve org.openjdk.jmh:jmh-core:1.36.
     Required by:
         project ':benchmark-jmh'
         project ':benchmark-jmh' > org.openjdk.jmh:jmh-generator-bytecode:1.36
         project ':benchmark-jmh' > org.openjdk.jmh:jmh-generator-bytecode:1.36 > org.openjdk.jmh:jmh-generator-reflection:1.36
         project ':benchmark-jmh' > org.openjdk.jmh:jmh-generator-bytecode:1.36 > org.openjdk.jmh:jmh-generator-asm:1.36
      > Conflict found for module 'org.openjdk.jmh:jmh-core': between versions 1.37 and 1.36
> There is 1 more failure with an identical cause.

```

<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
