### PR TITLE
testJVectorKnnIndex_simpleCase_maxInnerProduct flacky test fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Bug Fixes
 - Fix dynamic template and mixed cases [538](https://github.com/opensearch-project/opensearch-jvector/pull/538)
 - Fix flaky testMixedBatchSizesForQuantization test case [564](https://github.com/opensearch-project/opensearch-jvector/pull/564)
+- Fix flaky testJVectorKnnIndex_simpleCase_maxInnerProduct test case [569](https://github.com/opensearch-project/opensearch-jvector/pull/569)
 
 ### Infrastructure
 ### Documentation

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
@@ -139,13 +139,16 @@ public class KNNJVectorTests extends LuceneTestCase {
      */
     @Test
     public void testJVectorKnnIndex_simpleCase_maxInnerProduct() throws IOException {
-        int k = 3; // The number of nearest neighbors to gather
-        int totalNumberOfDocs = 10;
+        final int k = 3; // The number of nearest neighbors to gather
+        final int totalNumberOfDocs = 10;
+        final Path indexPath = createTempDir();
+
         IndexWriterConfig indexWriterConfig = LuceneTestCase.newIndexWriterConfig();
         indexWriterConfig.setUseCompoundFile(false);
         indexWriterConfig.setCodec(getCodec());
         indexWriterConfig.setMergePolicy(new ForceMergesOnlyMergePolicy());
-        final Path indexPath = createTempDir();
+        indexWriterConfig.setMaxBufferedDocs(totalNumberOfDocs);
+
         log.info("Index path: {}", indexPath);
         try (FSDirectory dir = FSDirectory.open(indexPath); IndexWriter w = new IndexWriter(dir, indexWriterConfig)) {
             final float[] target = new float[] { 1.0f, 0.0f };
@@ -159,11 +162,12 @@ public class KNNJVectorTests extends LuceneTestCase {
             w.commit();
 
             try (IndexReader reader = DirectoryReader.open(w)) {
-                log.info("We should now have a single segment with 10 documents");
+                log.info("We should now have a single segment with {} documents", totalNumberOfDocs);
+
                 Assert.assertEquals(1, reader.getContext().leaves().size());
                 Assert.assertEquals(totalNumberOfDocs, reader.numDocs());
 
-                final Query filterQuery = new MatchAllDocsQuery();
+                final Query filterQuery = MatchAllDocsQuery.INSTANCE;
                 final IndexSearcher searcher = newSearcher(reader);
                 KnnFloatVectorQuery knnFloatVectorQuery = getJVectorKnnFloatVectorQuery("test_field", target, k, filterQuery);
                 TopDocs topDocs = searcher.search(knnFloatVectorQuery, k);


### PR DESCRIPTION
### Description
The reason of flacky test was inconsistency of maxBufferedDocs field. When `maxBufferedDocs` is between 0 to `totalNumberOfDocs` which is 10 in the test. The size of the leaves can be more than 1. There are 2 ways of fix the issue. The first one is setting the `maxBufferedDocs` which has been implemented or handle it dynamicaly as in [here](https://github.com/opensearch-project/opensearch-jvector/blob/a4e0e5190fdd27fb62826f80aa760851a1daf0fe/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java#L95).

### Related Issues
Resolves #565 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
