### PR TITLE
Update JVector to 4.0.0-rc.8 (#370)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix derived nested fields processing [484] (https://github.com/opensearch-project/opensearch-jvector/pull/484)
 ### Infrastructure
 * Update Spotless to 8.4.0 [495](https://github.com/opensearch-project/opensearch-jvector/pull/495)
+* Upgrade jvector from 4.0.0-rc.6 to 4.0.0-rc.8 [370](https://github.com/opensearch-project/opensearch-jvector/pull/370)
 ### Documentation
 ### Maintenance
 * Fix String.format() uses the default system locale [465](https://github.com/opensearch-project/opensearch-jvector/pull/465)

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@
 
 version=1.0.0
 systemProp.bwc.version=3.2.0
-jvector_version=4.0.0-rc.6
+jvector_version=4.0.0-rc.8
 java_release_version=21
 
 # org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -968,15 +968,7 @@ public class JVectorWriter extends KnnVectorsWriter {
                 final long trainingTime = end - start;
                 log.info("Refined PQ codebooks for field {}, in {} millis", fieldName, trainingTime);
                 KNNCounter.KNN_QUANTIZATION_TRAINING_TIME.add(trainingTime);
-                compactPqVectors = PQVectors.encodeAndBuild(
-                    leadingCompressor,
-                    // graphNodeIdsToRavvOrds.length,
-                    // graphNodeIdsToRavvOrds,
-                    compactOrdsToRavvOrds.length,
-                    compactOrdsToRavvOrds,
-                    this,
-                    simdPoolMerge
-                );
+                compactPqVectors = PQVectors.encodeAndBuild(leadingCompressor, compactRavv.size(), compactRavv, simdPoolMerge);
             }
 
             if (compactPqVectors == null) {


### PR DESCRIPTION
### Description
Update JVector to 4.0.0-rc.8 (#370)

### Related Issues
Backport of https://github.com/opensearch-project/opensearch-jvector/pull/370 to `3.6`

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
