### PR TITLE
Fix release workflows to use pre-releases and update releasing.md with new process (#535)

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,7 +15,9 @@ jobs:
     name: Draft a release
     runs-on: ubuntu-latest
     if: github.repository == 'opensearch-project/opensearch-jvector'
-    permissions: write-all
+    permissions:
+      issues: write
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -45,10 +47,10 @@ jobs:
           ./gradlew --no-daemon -Dbuild.snapshot=false -Dopensearch.version=$OS_VERSION publishPluginZipPublicationToLocalRepoRepository
           tar -C build -czvf artifacts.tar.gz repository
       - name: Draft a release
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd
         with:
-          draft: true
-          generate_release_notes: true
-          files: |
-            artifacts.tar.gz
+          immutableCreate: true
+          generateReleaseNotes: true
+          artifacts: "artifacts.tar.gz"
+          prerelease: true
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -42,19 +42,16 @@ The release process is standard across repositories in this org and is run by a 
 
 **DO NOT cut a tag by going to release section of Github UI. It will mess up the Github Action.**
 
-Note: A maintainer must remember to perform steps 1, 2 and 4 (require total of 3 maintainers, 1 cut tag, 2 approve).
-1. Run these commands from the upstream opensearch-jvector repository, not a forked one: 
+Note: A maintainer must remember to perform steps 1, 2, 4 and 5 (require total of 2 maintainers, 1 to cut tag and another to approve).
+1. Identify the commit to release and create a tag on it from the upstream opensearch-jvector repository, not a forked one:
 ```
-git checkout main
 git fetch origin
-git rebase origin/main
-git tag <version>
-git push origin <version> 
+git tag <tag-name> <commit-sha>
+git push origin <tag-name>
 ```
 2. Wait for Github Actions to run and open the newly created issue. Two maintainers should comment `approve` in the issue.
-3. Wait for Jenkins to be triggered, pull the artifacts built by Actions, push to sonatype release channel on remote. Wait for an hour or so for Sonatype to copy it into Maven Central.
-4. Bump [build.gradle](./build.gradle), update [release-notes](./release-notes/), and clean up entries from [CHANGELOG.md](./CHANGELOG.md) via a PR.
-
-
-Thanks.
+3. The [release-drafter.yml](.github/workflows/release-drafter.yml) will be automatically kicked off and a pre-release will be created.
+4. This pre-release triggers the [jenkins release workflow](https://build.ci.opensearch.org/job/opensearch-jvector-release) as a result of which the client is released on [maven central](https://central.sonatype.com/). Please note that the release workflow is triggered only if created release is in pre-release state.
+5. Once the above release workflow is successful, it creates a GitHub issue requesting maintainers to manually publish the pre-release to release on GitHub.
+6. Bump [build.gradle](./build.gradle), update [release-notes](./release-notes/), and clean up entries from [CHANGELOG.md](./CHANGELOG.md) via a PR.
 

--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@10.2.2', retriever: modernSCM([
+lib = library(identifier: 'jenkins@13.0.1', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -7,8 +7,7 @@ standardReleasePipelineWithGenericTrigger(
     overrideDockerImage: 'opensearchstaging/ci-runner:release-centos7-clients-v4',
     tokenIdCredential: 'jenkins-opensearch-jvector-generic-webhook-token',
     causeString: 'A tag was cut on opensearch-project/opensearch-jvector repository causing this workflow to run',
-    downloadReleaseAsset: true,
-    publishRelease: true) {
+    downloadReleaseAsset: true) {
         publishToMaven(
             signingArtifactsPath: "$WORKSPACE/repository/",
             mavenArtifactsPath: "$WORKSPACE/repository/",


### PR DESCRIPTION
### Description
Backport of https://github.com/opensearch-project/opensearch-jvector/pull/535 to 3.6

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
