### PR TITLE
feat: implement native vectorization provider

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,6 +41,10 @@ jobs:
       - id: check
         # Native provider (without Google Highway requires "avx512f", "avx512cd", "avx512dq", "avx512bw" and "avx512vl")
         run: |
+          echo "hostname: $(hostname)"
+          echo "machine-id: $(cat /etc/machine-id)"
+          echo "runner name: $RUNNER_NAME"
+          echo "kernel/boot: $(cat /proc/sys/kernel/random/boot_id)"
           if lscpu  | grep -i avx512f | grep -i avx512cd | grep -i avx512vl | grep -i avx512dq | grep -i avx512bw; then
             echo "avx512 available on system"
             echo "supports_native=true" >> "$GITHUB_OUTPUT"
@@ -150,9 +154,19 @@ jobs:
       - name: Run build
         # switching the user, as OpenSearch cluster can only be started as root/Administrator on linux-deb/linux-rpm/windows-zip.
         run: |
-          ulimit -n 65536
-          chown -R 1000:1000 `pwd`      
-          su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx512_spr.enabled=true -Dnproc.count=`nproc` -Djvector.experimental.enable_native_vectorization=true"
+          echo "hostname: $(hostname)"
+          echo "machine-id: $(cat /etc/machine-id)"
+          echo "runner name: $RUNNER_NAME"
+          echo "kernel/boot: $(cat /proc/sys/kernel/random/boot_id)"
+          
+          if lscpu  | grep -i avx512f | grep -i avx512cd | grep -i avx512vl | grep -i avx512dq | grep -i avx512bw; then
+            ulimit -n 65536
+            chown -R 1000:1000 `pwd`      
+            su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx512_spr.enabled=true -Dnproc.count=`nproc` -Djvector.experimental.enable_native_vectorization=true"
+          else
+            echo "avx512 not available on system"
+            exit 0
+          fi
 
       - name: Upload Coverage Report
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,8 +42,10 @@ jobs:
         # Native provider (without Google Highway requires "avx512f", "avx512cd", "avx512dq", "avx512bw" and "avx512vl")
         run: |
           if lscpu  | grep -i avx512f | grep -i avx512cd | grep -i avx512vl | grep -i avx512dq | grep -i avx512bw; then
+            echo "avx512 available on system"
             echo "supports_native=true" >> "$GITHUB_OUTPUT"
           else
+            echo "avx512 not available on system"
             echo "supports_native=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -114,7 +116,7 @@ jobs:
       matrix:
         java: [21, 25]
 
-    name: Build and Test jVector k-NN Plugin on Linux
+    name: Build and Test jVector k-NN Plugin on Linux (Native)
     runs-on: ubuntu-latest
     needs: [Get-CI-Image-Tag, Detect-Native-Support]
     if: needs.Detect-Native-Support.outputs.supports_native == 'true'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,6 +37,7 @@ jobs:
     strategy:
       matrix:
         java: [21, 25]
+        provider: [non_native, native]
 
     env:
        CC: gcc10-gcc
@@ -71,23 +72,30 @@ jobs:
         run: |
           ulimit -n 65536
           chown -R 1000:1000 `pwd`
+          if [ "${{ matrix.provider }}" = "native" ]
+          then
+            OPENSEARCH_JAVA_OPTS="-Djvector.experimental.enable_native_vectorization=true"
+          else
+            OPENSEARCH_JAVA_OPTS="-Djvector.experimental.enable_native_vectorization=false"
+          fi
+          
           if lscpu  | grep -i avx512f | grep -i avx512cd | grep -i avx512vl | grep -i avx512dq | grep -i avx512bw          
           then
             if lscpu | grep -q "GenuineIntel" && lscpu | grep -i avx512_fp16 | grep -i avx512_bf16 | grep -i avx512_vpopcntdq
             then
               echo "the system is an Intel(R) Sapphire Rapids or a newer-generation processor"
-              su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx512_spr.enabled=true -Dnproc.count=`nproc`"
+              su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx512_spr.enabled=true -Dnproc.count=`nproc` $OPENSEARCH_JAVA_OPTS"
             else
               echo "avx512 available on system"
-              su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx512_spr.enabled=false -Dnproc.count=`nproc`"
+              su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx512_spr.enabled=false -Dnproc.count=`nproc` $OPENSEARCH_JAVA_OPTS"
             fi
           elif lscpu  | grep -i avx2
           then
             echo "avx2 available on system"
-            su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx512.enabled=false -Davx512_spr.enabled=false -Dnproc.count=`nproc`"
+            su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx512.enabled=false -Davx512_spr.enabled=false -Dnproc.count=`nproc` $OPENSEARCH_JAVA_OPTS"
           else
             echo "avx512 and avx2 not available on system"
-            su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx2.enabled=false -Davx512.enabled=false -Davx512_spr.enabled=false -Dnproc.count=`nproc`"
+            su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx2.enabled=false -Davx512.enabled=false -Davx512_spr.enabled=false -Dnproc.count=`nproc` $OPENSEARCH_JAVA_OPTS"
           fi
 
       - name: Upload Coverage Report

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,26 +33,6 @@ jobs:
     with:
       product: opensearch
 
-  Detect-Native-Support:
-    runs-on: ubuntu-latest
-    outputs:
-      supports_native: ${{ steps.check.outputs.supports_native }}
-    steps:
-      - id: check
-        # Native provider (without Google Highway requires "avx512f", "avx512cd", "avx512dq", "avx512bw" and "avx512vl")
-        run: |
-          echo "hostname: $(hostname)"
-          echo "machine-id: $(cat /etc/machine-id)"
-          echo "runner name: $RUNNER_NAME"
-          echo "kernel/boot: $(cat /proc/sys/kernel/random/boot_id)"
-          if lscpu  | grep -i avx512f | grep -i avx512cd | grep -i avx512vl | grep -i avx512dq | grep -i avx512bw; then
-            echo "avx512 available on system"
-            echo "supports_native=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "avx512 not available on system"
-            echo "supports_native=false" >> "$GITHUB_OUTPUT"
-          fi
-
   Build-k-NN-Linux:
     strategy:
       matrix:
@@ -130,7 +110,7 @@ jobs:
 
     name: Build and Test jVector k-NN Plugin on Linux (Native)
     runs-on: ubuntu-latest
-    needs: [Get-CI-Image-Tag, Detect-Native-Support]
+    needs: Get-CI-Image-Tag
     container:
       # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
       # this image tag is subject to change as more dependencies and updates will arrive over time
@@ -153,12 +133,8 @@ jobs:
       - name: Run build
         # switching the user, as OpenSearch cluster can only be started as root/Administrator on linux-deb/linux-rpm/windows-zip.
         run: |
-          echo "hostname: $(hostname)"
-          echo "machine-id: $(cat /etc/machine-id)"
-          echo "runner name: $RUNNER_NAME"
-          echo "kernel/boot: $(cat /proc/sys/kernel/random/boot_id)"
-          
           if lscpu  | grep -i avx512f | grep -i avx512cd | grep -i avx512vl | grep -i avx512dq | grep -i avx512bw; then
+            echo "avx512 available on system"
             ulimit -n 65536
             chown -R 1000:1000 `pwd`      
             su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx512_spr.enabled=true -Dnproc.count=`nproc` -Djvector.experimental.enable_native_vectorization=true"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -131,7 +131,6 @@ jobs:
     name: Build and Test jVector k-NN Plugin on Linux (Native)
     runs-on: ubuntu-latest
     needs: [Get-CI-Image-Tag, Detect-Native-Support]
-    if: needs.Detect-Native-Support.outputs.supports_native == 'true'
     container:
       # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
       # this image tag is subject to change as more dependencies and updates will arrive over time

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -70,7 +70,7 @@ jobs:
         # switching the user, as OpenSearch cluster can only be started as root/Administrator on linux-deb/linux-rpm/windows-zip.
         run: |
           ulimit -n 65536
-          chown -R 1000:1000 `pwd`      
+          chown -R 1000:1000 `pwd`
           if lscpu  | grep -i avx512f | grep -i avx512cd | grep -i avx512vl | grep -i avx512dq | grep -i avx512bw          
           then
             if lscpu | grep -q "GenuineIntel" && lscpu | grep -i avx512_fp16 | grep -i avx512_bf16 | grep -i avx512_vpopcntdq

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,11 +33,24 @@ jobs:
     with:
       product: opensearch
 
+  Detect-Native-Support:
+    runs-on: ubuntu-latest
+    outputs:
+      supports_native: ${{ steps.check.outputs.supports_native }}
+    steps:
+      - id: check
+        # Native provider (without Google Highway requires "avx512f", "avx512cd", "avx512dq", "avx512bw" and "avx512vl")
+        run: |
+          if lscpu  | grep -i avx512f | grep -i avx512cd | grep -i avx512vl | grep -i avx512dq | grep -i avx512bw; then
+            echo "supports_native=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "supports_native=false" >> "$GITHUB_OUTPUT"
+          fi
+
   Build-k-NN-Linux:
     strategy:
       matrix:
         java: [21, 25]
-        provider: [non_native, native]
 
     env:
        CC: gcc10-gcc
@@ -71,32 +84,65 @@ jobs:
         # switching the user, as OpenSearch cluster can only be started as root/Administrator on linux-deb/linux-rpm/windows-zip.
         run: |
           ulimit -n 65536
-          chown -R 1000:1000 `pwd`
-          if [ "${{ matrix.provider }}" = "native" ]
-          then
-            OPENSEARCH_JAVA_OPTS="-Djvector.experimental.enable_native_vectorization=true"
-          else
-            OPENSEARCH_JAVA_OPTS="-Djvector.experimental.enable_native_vectorization=false"
-          fi
-          
+          chown -R 1000:1000 `pwd`      
           if lscpu  | grep -i avx512f | grep -i avx512cd | grep -i avx512vl | grep -i avx512dq | grep -i avx512bw          
           then
             if lscpu | grep -q "GenuineIntel" && lscpu | grep -i avx512_fp16 | grep -i avx512_bf16 | grep -i avx512_vpopcntdq
             then
               echo "the system is an Intel(R) Sapphire Rapids or a newer-generation processor"
-              su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx512_spr.enabled=true -Dnproc.count=`nproc` $OPENSEARCH_JAVA_OPTS"
+              su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx512_spr.enabled=true -Dnproc.count=`nproc`"
             else
               echo "avx512 available on system"
-              su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx512_spr.enabled=false -Dnproc.count=`nproc` $OPENSEARCH_JAVA_OPTS"
+              su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx512_spr.enabled=false -Dnproc.count=`nproc`"
             fi
           elif lscpu  | grep -i avx2
           then
             echo "avx2 available on system"
-            su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx512.enabled=false -Davx512_spr.enabled=false -Dnproc.count=`nproc` $OPENSEARCH_JAVA_OPTS"
+            su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx512.enabled=false -Davx512_spr.enabled=false -Dnproc.count=`nproc`"
           else
             echo "avx512 and avx2 not available on system"
-            su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx2.enabled=false -Davx512.enabled=false -Davx512_spr.enabled=false -Dnproc.count=`nproc` $OPENSEARCH_JAVA_OPTS"
+            su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx2.enabled=false -Davx512.enabled=false -Davx512_spr.enabled=false -Dnproc.count=`nproc`"
           fi
+
+      - name: Upload Coverage Report
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  Build-k-NN-Linux-Native:
+    strategy:
+      matrix:
+        java: [21, 25]
+
+    name: Build and Test jVector k-NN Plugin on Linux
+    runs-on: ubuntu-latest
+    needs: [Get-CI-Image-Tag, Detect-Native-Support]
+    if: needs.Detect-Native-Support.outputs.supports_native == 'true'
+    container:
+      # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
+      # this image tag is subject to change as more dependencies and updates will arrive over time
+      image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
+      # need to switch to root so that github actions can install runner binary on container without permission issues.
+      options: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-options }}
+    steps:
+      - name: Run start commands
+        run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
+
+      - name: Checkout jVector k-NN
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'temurin'
+
+      - name: Run build
+        # switching the user, as OpenSearch cluster can only be started as root/Administrator on linux-deb/linux-rpm/windows-zip.
+        run: |
+          ulimit -n 65536
+          chown -R 1000:1000 `pwd`      
+          su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx512_spr.enabled=true -Dnproc.count=`nproc` -Djvector.experimental.enable_native_vectorization=true"
 
       - name: Upload Coverage Report
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 - Add NVQ Quantization [#539](https://github.com/opensearch-project/opensearch-jvector/pull/539) 
 - Added capability to retrieve float, binary and byte data types vectors using doc_values [#538](https://github.com/opensearch-project/opensearch-jvector/pull/538)
+- Enable native vectorization provider [622](https://github.com/opensearch-project/opensearch-jvector/pull/622)
 
 ### Enhancements
 ### Bug Fixes

--- a/build.gradle
+++ b/build.gradle
@@ -167,6 +167,9 @@ def getBreakerSetting() {
     return System.getProperty(propertyKeys.breaker.useRealMemory, 'true')
 }
 
+def getNativeVectorizationProviderFlag() {
+    return System.getProperty('jvector.experimental.enable_native_vectorization', 'false')
+}
 
 allprojects {
     group = 'org.opensearch.knn'
@@ -313,11 +316,11 @@ task release(type: Copy, group: 'build') {
 dependencies {
     api "org.opensearch:opensearch:${opensearch_version}"
     compileOnly "org.opensearch.plugin:opensearch-scripting-painless-spi:${versions.opensearch}"
-    
+
     // gRPC support dependencies (provided at runtime by OpenSearch)
     compileOnly "org.opensearch.plugin:transport-grpc-spi:${opensearch_version}"
     compileOnly "org.opensearch:protobufs:${versions.opensearchprotobufs}"
-    
+
     // Declare guava as compile time since guava will come from OpenSearch transport-grpc module.
     compileOnly group: 'com.google.guava', name: 'guava', version: "${versions.guava}"
     api "org.apache.commons:commons-lang3:${versions.commonslang}"
@@ -328,7 +331,7 @@ dependencies {
     // Add netty dependency so we can use it within internal test clusters (not just external ones)
     testImplementation "org.opensearch.plugin:transport-netty4-client:${opensearch_version}"
     testImplementation("com.google.guava:guava:${versions.guava}")
-    
+
     // gRPC integration test dependencies (following neural-search pattern)
     testImplementation "org.opensearch:protobufs:${versions.opensearchprotobufs}"
     testImplementation "org.opensearch.plugin:transport-grpc-spi:${opensearch_version}"
@@ -435,7 +438,8 @@ integTest {
                 '-Djdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK=0',
                 '--enable-native-access=ALL-UNNAMED',
                 '-Dio.netty.tryReflectionSetAccessible=true',
-                '--enable-preview'
+                '--enable-preview',
+                "-Djvector.experimental.enable_native_vectorization=${getNativeVectorizationProviderFlag()}"
         ]
 
         // There seems to be an issue when running multi node run or integ tasks with unicast_hosts
@@ -443,7 +447,7 @@ integTest {
         getClusters().forEach { cluster ->
             cluster.waitForAllConditions()
         }
-        
+
         // Discover the actual gRPC port from the cluster log.
         // The gRPC transport binds to the first available port in 9400-9500,
         // which may differ from 9400 due to port conflicts or dual-stack binding.
@@ -487,7 +491,7 @@ testClusters.integTest { cluster ->
     testDistribution = "ARCHIVE"
     systemProperty "java.security.policy", "file://${project.rootDir}/src/main/plugin-metadata/plugin-security.policy"
     systemProperty 'log4j.configurationFile', "${project.rootDir}/src/test/resources/log4j2.properties"
-    
+    systemProperty 'jvector.experimental.enable_native_vectorization', getNativeVectorizationProviderFlag()
     // Enable gRPC transport module (following neural-search pattern)
     setting("aux.transport.types", "[transport-grpc]")
     // Bind gRPC to IPv4 loopback to avoid dual-stack port mismatch
@@ -547,6 +551,7 @@ task integTestRemote(type: RestIntegTestTask) {
     systemProperty 'tests.security.manager', 'false'
     systemProperty("test.exhaustive", System.getProperty("test.exhaustive"))
     systemProperty "tests.path.repo", "${layout.buildDirectory.toString()}/testSnapshotFolder"
+    systemProperty 'jvector.experimental.enable_native_vectorization', getNativeVectorizationProviderFlag()
 
     systemProperty 'tests.output', 'true'
     // Run tests with remote cluster only if rest case is defined

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFloatVectorValues.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFloatVectorValues.java
@@ -160,6 +160,11 @@ public class JVectorFloatVectorValues extends FloatVectorValues {
     public float[] vectorValue(int i) throws IOException {
         try {
             final VectorFloat<?> vector = vectorFloatValue(i);
+
+            if (vector.get() instanceof float[] arr) {
+                return arr;
+            }
+
             float[] v = new float[vector.length()];
             for (int j = 0; j < v.length; j++) {
                 v[j] = vector.get(j);

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFloatVectorValues.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFloatVectorValues.java
@@ -160,7 +160,7 @@ public class JVectorFloatVectorValues extends FloatVectorValues {
     public float[] vectorValue(int i) throws IOException {
         try {
             final VectorFloat<?> vector = vectorFloatValue(i);
-            return (float[]) vector.get();
+            return vector.toArray();
         } catch (Throwable e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFloatVectorValues.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFloatVectorValues.java
@@ -160,7 +160,12 @@ public class JVectorFloatVectorValues extends FloatVectorValues {
     public float[] vectorValue(int i) throws IOException {
         try {
             final VectorFloat<?> vector = vectorFloatValue(i);
-            return vector.toArray();
+            float[] v = new float[vector.length()];
+            for (int j = 0; j < v.length; j++) {
+                v[j] = vector.get(j);
+            }
+
+            return v;
         } catch (Throwable e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
### Description
Add support for native vectorization provider with `jvector.experimental.enable_native_vectorization` flag. When enabled and CPU supports AVX-512 instructions, jvector will pick NativeVectorizationProvider.

Since https://github.com/datastax/jvector/pull/681 has been merged, there's no longer issue with byte order for native vect. provider. However, there's couple items that would be nice to have in future:
- https://github.com/datastax/jvector/pull/697 - interface for getting float[] vector
- https://github.com/datastax/jvector/pull/668 - google highway implementation

Testing:
- Tested on machine with AVX-512 support. Tested couple scenarios including backward compatibility (moving from Panama to Native, From native w/o Google Highway to native w/)

### Related Issues
Resolves #478 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
