### PR TITLE
[3.7] Fix derived source bug by preserving non-xcontent (#624)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 ### Enhancements
 ### Bug Fixes
+- Preserve non-XContent `_source` fields when derived source is enabled [623] (https://github.com/opensearch-project/opensearch-jvector/pull/623)
 ### Infrastructure
 ### Documentation
 ### Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 ### Enhancements
 ### Bug Fixes
-- Preserve non-XContent `_source` fields when derived source is enabled [623] (https://github.com/opensearch-project/opensearch-jvector/pull/623)
+- Preserve non-XContent `_source` fields when derived source is enabled [624] (https://github.com/opensearch-project/opensearch-jvector/pull/624)
 ### Infrastructure
 ### Documentation
 ### Documentation

--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsWriter.java
@@ -11,7 +11,6 @@ import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.StoredFieldDataInput;
 import org.apache.lucene.util.BytesRef;
-import org.opensearch.OpenSearchParseException;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentHelper;
@@ -115,30 +114,26 @@ public class KNN10010DerivedSourceStoredFieldsWriter extends StoredFieldsWriter 
             // net.
             Tuple<? extends MediaType, Map<String, Object>> mapTuple;
 
-            // If the content is not XContent, skip writing altogether. See:
-            // https://github.com/opensearch-project/k-NN/issues/2880
             try {
+                // Use null for auto-detection so CBOR/SMILE sources are handled correctly.
+                // Passing a fixed MediaType (e.g. JSON) causes OpenSearchParseException when the
+                // source was serialized in a different format, and storing those raw bytes then
+                // breaks the read path. Auto-detection lets the parser match the actual format and
+                // only throws NotXContentException for truly non-XContent bytes.
                 mapTuple = XContentHelper.convertToMap(
                     BytesReference.fromByteBuffer(ByteBuffer.wrap(bytesRef.bytes, bytesRef.offset, bytesRef.length)),
                     true,
-                    MediaTypeRegistry.JSON
+                    null
                 );
             } catch (NotXContentException e) {
+                // Bytes are not any known XContent format (e.g. a plain error string). Fall back to
+                // writing the raw bytes unmasked so the _source is preserved rather than dropped.
                 log.warn(
                     "Encountered NotXContent while deserializing _source field. Instead found String: [{}]",
-                    // Limit max string length in case of long bytes object
-                    new String(bytesRef.bytes, 0, Math.min(bytesRef.bytes.length, 512)),
-                    e
-                );
-                return;
-            } catch (OpenSearchParseException e) {
-                // Catch any other parsing exceptions (e.g., OpenSearchParseException for invalid JSON)
-                log.warn(
-                    "Failed to parse _source field as XContent. Instead found bytes: [{}]",
-                    // Limit max string length in case of long bytes object
                     new String(bytesRef.bytes, bytesRef.offset, Math.min(bytesRef.length, 512)),
                     e
                 );
+                delegate.writeField(fieldInfo, bytesRef);
                 return;
             }
             Map<String, Object> filteredSource = vectorMask.apply(mapTuple.v2());

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorTransformer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorTransformer.java
@@ -12,6 +12,7 @@ import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.support.XContentMapValues;
 import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.compress.NotXContentException;
 import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -140,11 +141,16 @@ public class DerivedSourceVectorTransformer {
         // Reference:
         // https://github.com/opensearch-project/OpenSearch/blob/2.18.0/server/src/main/java/org/opensearch/index/mapper/SourceFieldMapper.java#L322
         // Deserialize the source into a modifiable map
-        Tuple<? extends MediaType, Map<String, Object>> mapTuple = XContentHelper.convertToMap(
-            BytesReference.fromByteBuffer(ByteBuffer.wrap(sourceAsBytes)),
-            true,
-            MediaTypeRegistry.getDefaultMediaType()
-        );
+        Tuple<? extends MediaType, Map<String, Object>> mapTuple;
+        try {
+            // Use null for auto-detection so CBOR/SMILE sources are handled correctly
+            mapTuple = XContentHelper.convertToMap(BytesReference.fromByteBuffer(ByteBuffer.wrap(sourceAsBytes)), true, null);
+        } catch (NotXContentException e) {
+            // Derived source can only mask vector fields after parsing XContent, so preserve
+            // non-XContent part in _source.
+            log.warn("Encountered NotXContent while deserializing _source for vector injection; returning source unchanged", e);
+            return sourceAsBytes;
+        }
         // Have to create a copy of the map here to ensure that is mutable
         Map<String, Object> sourceAsMap = mapTuple.v2();
 

--- a/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/DerivedSourceStoredFieldsWriterTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/DerivedSourceStoredFieldsWriterTests.java
@@ -18,7 +18,9 @@ import org.opensearch.knn.index.codec.KNNCodecTestUtil;
 import java.util.List;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class DerivedSourceStoredFieldsWriterTests extends KNNTestCase {
 
@@ -42,5 +44,22 @@ public class DerivedSourceStoredFieldsWriterTests extends KNNTestCase {
         byte[] shiftedBytes = new byte[originalBytes.length + 2];
         System.arraycopy(originalBytes, 0, shiftedBytes, 1, originalBytes.length);
         derivedSourceStoredFieldsWriter.writeField(fieldInfo, new BytesRef(shiftedBytes, 1, originalBytes.length));
+        derivedSourceStoredFieldsWriter.close();
+    }
+
+    @SneakyThrows
+    public void testWriteFieldPreservesNonXContentSource() {
+        StoredFieldsWriter delegate = mock(StoredFieldsWriter.class);
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("_source").build();
+        BytesRef rawSource = new BytesRef("filling gaps");
+        KNN10010DerivedSourceStoredFieldsWriter derivedSourceStoredFieldsWriter = new KNN10010DerivedSourceStoredFieldsWriter(
+            "mock-codec",
+            delegate,
+            List.of("my_vector")
+        );
+
+        derivedSourceStoredFieldsWriter.writeField(fieldInfo, rawSource);
+
+        verify(delegate).writeField(same(fieldInfo), same(rawSource));
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorTransformerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorTransformerTests.java
@@ -13,6 +13,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -116,6 +117,16 @@ public class DerivedSourceVectorTransformerTests extends OpenSearchTestCase {
             new String[] { "test_vector", "temp_vector", "user_vector" },
             new String[] {}
         );
+    }
+
+    public void testInjectVectors_whenSourceIsNonXContent_thenPreservesOriginalSource() throws Exception {
+        DerivedSourceVectorTransformer transformer = createTransformerWithFields("test_vector");
+        transformer.initialize(null, null);
+        byte[] rawSource = "filling gaps".getBytes(StandardCharsets.UTF_8);
+
+        byte[] result = transformer.injectVectors(0, rawSource);
+
+        assertTrue(Arrays.equals(rawSource, result));
     }
 
     private void assertFieldFiltering(String[] includes, String[] excludes, String[] expectedPresent, String[] expectedAbsent) {


### PR DESCRIPTION
backport for https://github.com/opensearch-project/opensearch-jvector/pull/624

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
