### PR TITLE
Remove reflection from NVQ

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorIndexQuantization.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorIndexQuantization.java
@@ -19,7 +19,6 @@ import io.github.jbellis.jvector.vector.VectorizationProvider;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
-import io.github.jbellis.jvector.graph.disk.feature.NVQ;
 import java.io.IOException;
 import java.time.Clock;
 import java.util.concurrent.ForkJoinPool;
@@ -186,20 +185,13 @@ public sealed interface JVectorIndexQuantization {
         return new LoadedState(null, pqVectors, supplier);
     }
 
-    // TODO: replace reflection with nvqFeature.getNVQuantization() once jvector exposes it publicly in the released jar
-    private static NVQuantization nvqFromGraph(OnDiskGraphIndex index) throws IOException {
+    private static NVQuantization nvqFromGraph(OnDiskGraphIndex index) {
         io.github.jbellis.jvector.graph.disk.feature.NVQ nvqFeature = (io.github.jbellis.jvector.graph.disk.feature.NVQ) index.getFeatures()
             .get(FeatureId.NVQ_VECTORS);
         if (nvqFeature == null) {
             return null;
         }
-        try {
-            java.lang.reflect.Field nvqField = io.github.jbellis.jvector.graph.disk.feature.NVQ.class.getDeclaredField("nvq");
-            nvqField.setAccessible(true);
-            return (NVQuantization) nvqField.get(nvqFeature);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new IOException("Unable to extract NVQuantization from NVQ feature via reflection", e);
-        }
+        return nvqFeature.getNVQuantization();
     }
 
     /** String identifier used in REST params and on-disk serialization. */

--- a/src/test/java/org/opensearch/knn/search/processor/mmr/MMRUtilTests.java
+++ b/src/test/java/org/opensearch/knn/search/processor/mmr/MMRUtilTests.java
@@ -612,7 +612,7 @@ public class MMRUtilTests extends MMRTestCase {
         searchSourceBuilder.ext(Collections.singletonList(new MMRSearchExtBuilder.Builder().build()));
         searchRequest.source(searchSourceBuilder);
 
-        ProcessorGenerationContext ctx = new ProcessorGenerationContext(searchRequest);
+        ProcessorGenerationContext ctx = new ProcessorGenerationContext(searchRequest, null);
 
         assertTrue(MMRUtil.shouldGenerateMMRProcessor(ctx));
     }
@@ -620,7 +620,7 @@ public class MMRUtilTests extends MMRTestCase {
     public void testShouldGenerateMMRProcessor_whenNoExt_thenReturnFalse() {
         SearchRequest searchRequest = new SearchRequest();
 
-        ProcessorGenerationContext ctx = new ProcessorGenerationContext(searchRequest);
+        ProcessorGenerationContext ctx = new ProcessorGenerationContext(searchRequest, null);
 
         assertFalse(MMRUtil.shouldGenerateMMRProcessor(ctx));
     }


### PR DESCRIPTION
### Description
Remove the reflection usage from NVQ code, as it is now supported in JVector (supported from jvector rc9 onwards). 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
