### PR TITLE
[Test only fix] Fix NVQ test reporting incorrect NVQ disk size

### DIFF
--- a/src/test/java/org/opensearch/knn/index/engine/JVectorNVQIT.java
+++ b/src/test/java/org/opensearch/knn/index/engine/JVectorNVQIT.java
@@ -406,8 +406,6 @@ public class JVectorNVQIT extends KNNRestTestCase {
                 RECALL_K
             );
 
-            // Storage: sum live segment sizes rather than raw store size, so the comparison is not
-            // skewed by force-merged-away segment files still awaiting reclamation on disk (#634).
             long nvqBytes = liveSegmentsSizeInBytes(INDEX_NAME);
             long pqBytes = liveSegmentsSizeInBytes(pqIndex);
             double sizeRatio = (double) nvqBytes / pqBytes;

--- a/src/test/java/org/opensearch/knn/index/engine/JVectorNVQIT.java
+++ b/src/test/java/org/opensearch/knn/index/engine/JVectorNVQIT.java
@@ -406,9 +406,10 @@ public class JVectorNVQIT extends KNNRestTestCase {
                 RECALL_K
             );
 
-            // Storage
-            int nvqBytes = indexSizeInBytes(INDEX_NAME);
-            int pqBytes = indexSizeInBytes(pqIndex);
+            // Storage: sum live segment sizes rather than raw store size, so the comparison is not
+            // skewed by force-merged-away segment files still awaiting reclamation on disk (#634).
+            long nvqBytes = liveSegmentsSizeInBytes(INDEX_NAME);
+            long pqBytes = liveSegmentsSizeInBytes(pqIndex);
             double sizeRatio = (double) nvqBytes / pqBytes;
 
             logger.info(

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -1078,6 +1078,47 @@ public class KNNRestTestCase extends ODFERestTestCase {
         return sizeInBytes;
     }
 
+    /**
+     * Sums the on-disk size of the index's live primary-shard segments.
+     */
+    @SneakyThrows
+    @SuppressWarnings("unchecked")
+    protected long liveSegmentsSizeInBytes(String indexName) throws IOException {
+        Request request = new Request("GET", indexName + "/_segments");
+        Response response = client().performRequest(request);
+        assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+        String responseBody = EntityUtils.toString(response.getEntity());
+
+        Map<String, Object> root = createParser(MediaTypeRegistry.getDefaultMediaType().xContent(), responseBody).map();
+        Map<String, Object> indices = (Map<String, Object>) root.get("indices");
+
+        long totalBytes = 0L;
+        for (Object indexValue : indices.values()) {
+            Map<String, Object> shards = (Map<String, Object>) ((Map<String, Object>) indexValue).get("shards");
+            for (Object shardValue : shards.values()) {
+                // Each shard entry is a list of shard copies (primary + replicas); count primaries only.
+                for (Object shardCopy : (List<Object>) shardValue) {
+                    Map<String, Object> shardCopyMap = (Map<String, Object>) shardCopy;
+                    Map<String, Object> routing = (Map<String, Object>) shardCopyMap.get("routing");
+                    if (routing == null || !Boolean.TRUE.equals(routing.get("primary"))) {
+                        continue;
+                    }
+                    Map<String, Object> segments = (Map<String, Object>) shardCopyMap.get("segments");
+                    if (segments == null) {
+                        continue;
+                    }
+                    for (Object segment : segments.values()) {
+                        Number size = (Number) ((Map<String, Object>) segment).get("size_in_bytes");
+                        if (size != null) {
+                            totalBytes += size.longValue();
+                        }
+                    }
+                }
+            }
+        }
+        return totalBytes;
+    }
+
     @SneakyThrows
     protected void doKnnWarmup(List<String> indices) {
         Response response = knnWarmup(indices);


### PR DESCRIPTION
### Description
Fix NVQ test. Previously, test was comparing index size using /_stats/store API and get the size_in_bytes. This counts size of all files on disk (including files not cleared after force-merge). If the files have not been cleared up before the API is called in the test, it can lead to incorrect results. 
Current version changes this to use /_segments API to get size_in_bytes. This should only count the live segments (ignore merged segments, even if they've not cleared up).

### Related Issues
Resolves #634 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
