### PR TITLE
Disable AVX512 for tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -79,7 +79,7 @@ jobs:
               su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx512_spr.enabled=true -Dnproc.count=`nproc`"
             else
               echo "avx512 available on system"
-              su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx512_spr.enabled=false -Dnproc.count=`nproc`"
+              su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx512.enabled=true -Dnproc.count=`nproc`"
             fi
           elif lscpu  | grep -i avx2
           then

--- a/build.gradle
+++ b/build.gradle
@@ -367,6 +367,9 @@ dependencies {
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-custom-codecs', version: "${opensearch_build}"
 }
 
+var avx512_spr = System.getProperty("avx512_spr.enabled")
+var avx512 = System.getProperty("avx512.enabled")
+
 test {
     systemProperty 'tests.security.manager', 'false'
     systemProperty 'opensearch.set.netty.runtime.available.processors', 'false'
@@ -385,6 +388,9 @@ test {
             "-javaagent:${configurations.mockitoAgent.asPath}"
     ]
 
+    if ("true".equals(avx512_spr) || "true".equals(avx512)) {
+        jvmArgs += [ '-XX:UseAVX=2' /* only AVX2, disable AVX512 */ ]
+    }
 
     //this change enables mockito-inline that supports mocking of static classes/calls
     systemProperty "jdk.attach.allowAttachSelf", true
@@ -446,6 +452,10 @@ integTest {
                 '-Dio.netty.tryReflectionSetAccessible=true',
                 '--enable-preview'
         ]
+
+        if ("true".equals(avx512_spr) || "true".equals(avx512)) {
+            jvmArgs += [ '-XX:UseAVX=2' /* only AVX2, disable AVX512 */ ]
+        }
 
         // There seems to be an issue when running multi node run or integ tasks with unicast_hosts
         // not being written, the waitForAllConditions ensures it's written

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -2075,31 +2075,10 @@ public class KNNRestTestCase extends ODFERestTestCase {
     }
 
     protected void refreshIndex(final String index) throws IOException {
-        try {
-            Request request = new Request("POST", "/" + index + "/_refresh");
-            Response response = client().performRequest(request);
-            assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
-        } catch (java.net.SocketTimeoutException ex) {
-            Request request = new Request("GET", "/_nodes/hot_threads");
-            request.addParameter("ignore_idle_threads", "false");
-            request.addParameter("threads", "200");
-            Response response = client().performRequest(request);
+        Request request = new Request("POST", "/" + index + "/_refresh");
 
-            try {
-                log.error(EntityUtils.toString(response.getEntity()));
-                assertEquals(
-                    request.getEndpoint() + ": failed",
-                    RestStatus.OK,
-                    RestStatus.fromCode(response.getStatusLine().getStatusCode())
-                );
-            } catch (ParseException e) {
-                final IOException exception = new IOException(e);
-                exception.addSuppressed(ex);
-                throw exception;
-            }
-
-            throw ex;
-        }
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
     }
 
     protected void flushIndex(final String index) throws IOException {

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -2075,10 +2075,31 @@ public class KNNRestTestCase extends ODFERestTestCase {
     }
 
     protected void refreshIndex(final String index) throws IOException {
-        Request request = new Request("POST", "/" + index + "/_refresh");
+        try {
+            Request request = new Request("POST", "/" + index + "/_refresh");
+            Response response = client().performRequest(request);
+            assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+        } catch (java.net.SocketTimeoutException ex) {
+            Request request = new Request("GET", "/_nodes/hot_threads");
+            request.addParameter("ignore_idle_threads", "false");
+            request.addParameter("threads", "200");
+            Response response = client().performRequest(request);
 
-        Response response = client().performRequest(request);
-        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+            try {
+                log.error(EntityUtils.toString(response.getEntity()));
+                assertEquals(
+                    request.getEndpoint() + ": failed",
+                    RestStatus.OK,
+                    RestStatus.fromCode(response.getStatusLine().getStatusCode())
+                );
+            } catch (ParseException e) {
+                final IOException exception = new IOException(e);
+                exception.addSuppressed(ex);
+                throw exception;
+            }
+
+            throw ex;
+        }
     }
 
     protected void flushIndex(final String index) throws IOException {


### PR DESCRIPTION
### Description
Disable AVX512 for tests

context:
Several test runs intermittently fail on linux systems (timeout - see linked issue) with avx512 enabled. This seems to be due to the specific implementation of Distance64 method in jvector, which in-turn calls the fma (fused multiply-add) instruction implemented in Panama (JDK). More details in issue below. 

### Related Issues
Closes https://github.com/opensearch-project/opensearch-jvector/issues/623
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
