### PR TITLE
Disable AVX512 for integration tests (each node)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -551,6 +551,13 @@ testClusters.integTest { cluster ->
             debugPort += 1
         }
     }
+
+    if ("true".equals(avx512_spr) || "true".equals(avx512)) {
+        nodes.forEach { node ->
+            node.jvmArgs("-XX:UseAVX=2" /* only AVX2, disable AVX512 */)
+        }
+    }
+
     systemProperty propertyKeys.breaker.useRealMemory, getBreakerSetting()
     systemProperty 'jdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK', "0"
     setting 'path.repo', "${buildDir}/testSnapshotFolder"


### PR DESCRIPTION
### Description
Disable AVX512 for integration tests (each node)

### Related Issues
Passing the JVM command line to each cluster node.
Finalizes https://github.com/opensearch-project/opensearch-jvector/issues/623

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
