### PR TITLE
Rework avx512 on/off switch to consider native vectorization provider preference

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -137,7 +137,7 @@ jobs:
             echo "avx512 available on system"
             ulimit -n 65536
             chown -R 1000:1000 `pwd`      
-            su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx512_spr.enabled=true -Dnproc.count=`nproc` -Djvector.experimental.enable_native_vectorization=true"
+            su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx512.enabled=true -Davx512_spr.enabled=true -Dnproc.count=`nproc` -Djvector.experimental.enable_native_vectorization=true"
           else
             echo "avx512 not available on system"
             exit 0

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -143,6 +143,14 @@ jobs:
             exit 0
           fi
 
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: always()
+        with:
+          name: ${{ matrix.java }}-linux-native-reports
+          path: |
+            ./build/reports/
+            ./build/testclusters/*/logs
+
       - name: Upload Coverage Report
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:

--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -105,7 +105,7 @@ jobs:
             ./gradlew :qa:restart-upgrade:testRestartUpgrade -Dtests.bwc.version=$BWC_VERSION_RESTART_UPGRADE -Dnproc.count=`nproc` -Davx512_spr.enabled=true
           else
             echo "avx512 available on system"
-            ./gradlew :qa:restart-upgrade:testRestartUpgrade -Dtests.bwc.version=$BWC_VERSION_RESTART_UPGRADE -Dnproc.count=`nproc` -Davx512_spr.enabled=false
+            ./gradlew :qa:restart-upgrade:testRestartUpgrade -Dtests.bwc.version=$BWC_VERSION_RESTART_UPGRADE -Dnproc.count=`nproc` -Davx512.enabled=true
           fi
           elif lscpu  | grep -i avx2
           then

--- a/build.gradle
+++ b/build.gradle
@@ -377,6 +377,7 @@ test {
     systemProperty 'tests.security.manager', 'false'
     systemProperty 'opensearch.set.netty.runtime.available.processors', 'false'
     systemProperty 'log4j.configurationFile', "$rootDir/src/test/resources/log4j2.properties"
+    systemProperty 'jvector.experimental.enable_native_vectorization', getNativeVectorizationProviderFlag()
 
     // Enable preview features for Foreign Memory API
     jvmArgs = [
@@ -391,8 +392,11 @@ test {
             "-javaagent:${configurations.mockitoAgent.asPath}"
     ]
 
-    if ("true".equals(avx512_spr) || "true".equals(avx512)) {
-        jvmArgs += [ '-XX:UseAVX=2' /* only AVX2, disable AVX512 */ ]
+        // The current native vectorization provider in jvector relies on avx512 support 
+    if (getNativeVectorizationProviderFlag().equals('false')) {
+        if ("true".equals(avx512_spr) || "true".equals(avx512)) {
+            jvmArgs += [ '-XX:UseAVX=2' /* only AVX2, disable AVX512 */ ]
+        }
     }
 
     //this change enables mockito-inline that supports mocking of static classes/calls
@@ -457,8 +461,11 @@ integTest {
                 "-Djvector.experimental.enable_native_vectorization=${getNativeVectorizationProviderFlag()}"
         ]
 
-        if ("true".equals(avx512_spr) || "true".equals(avx512)) {
-            jvmArgs += [ '-XX:UseAVX=2' /* only AVX2, disable AVX512 */ ]
+        // The current native vectorization provider in jvector relies on avx512 support 
+        if (getNativeVectorizationProviderFlag().equals('false')) {
+            if ("true".equals(avx512_spr) || "true".equals(avx512)) {
+                jvmArgs += [ '-XX:UseAVX=2' /* only AVX2, disable AVX512 */ ]
+            }
         }
 
         // There seems to be an issue when running multi node run or integ tasks with unicast_hosts
@@ -552,9 +559,12 @@ testClusters.integTest { cluster ->
         }
     }
 
-    if ("true".equals(avx512_spr) || "true".equals(avx512)) {
-        nodes.forEach { node ->
-            node.jvmArgs("-XX:UseAVX=2" /* only AVX2, disable AVX512 */)
+    // The current native vectorization provider in jvector relies on avx512 support
+    if (getNativeVectorizationProviderFlag().equals('false')) {
+        if ("true".equals(avx512_spr) || "true".equals(avx512)) {
+            nodes.forEach { node ->
+                node.jvmArgs("-XX:UseAVX=2" /* only AVX2, disable AVX512 */)
+            }
         }
     }
 


### PR DESCRIPTION
### Description
Rework avx512 on/off switch to consider native vectorization provider preference. Right now we try to disable `avx512` instructions support by explicitly passing `-XX:UseAVX` system flags, however the native vectorization provider (as of jvector 4.0.0-rc.9) only activates when `avx512` is available. 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
