### PR TITLE
testJVectorKnnIndex_filter_maxInnerProduct fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 
 ### Bug Fixes
+- Fix flaky testJVectorKnnIndex_filter_maxInnerProduct test case [681](https://github.com/opensearch-project/opensearch-jvector/pull/681)
 
 ### Infrastructure
 ### Documentation

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
@@ -216,6 +216,7 @@ public class KNNJVectorTests extends LuceneTestCase {
         indexWriterConfig.setUseCompoundFile(false);
         indexWriterConfig.setCodec(getCodec(random().nextBoolean()));
         indexWriterConfig.setMergePolicy(new ForceMergesOnlyMergePolicy());
+        indexWriterConfig.setMaxBufferedDocs(totalNumberOfDocs);
         final Path indexPath = createTempDir();
         log.info("Index path: {}", indexPath);
         try (FSDirectory dir = FSDirectory.open(indexPath); IndexWriter w = new IndexWriter(dir, indexWriterConfig)) {
@@ -231,7 +232,8 @@ public class KNNJVectorTests extends LuceneTestCase {
             w.commit();
 
             try (IndexReader reader = DirectoryReader.open(w)) {
-                log.info("We should now have a single segment with 10 documents");
+                log.info("We should now have a single segment with {} documents", totalNumberOfDocs);
+
                 Assert.assertEquals(1, reader.getContext().leaves().size());
                 Assert.assertEquals(totalNumberOfDocs, reader.numDocs());
 


### PR DESCRIPTION
### Description
Similar as in [here](https://github.com/opensearch-project/opensearch-jvector/pull/569)

### Related Issues
Resolves #681 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

### Testing

```bash
./gradlew :test --tests "org.opensearch.knn.index.codec.jvector.KNNJVectorTests.testJVectorKnnIndex_filter_maxInnerProduct" -Dtests.iters=500 -Dtests.opensearch.logger.level=DEBUG

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
