### PR TITLE
chore: cleanup use_pruning related code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,4 +16,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Documentation
 - Update release procedure [690](https://github.com/opensearch-project/opensearch-jvector/pull/690)
 ### Maintenance
+- Remove deprecated use_pruning features [670](https://github.com/opensearch-project/opensearch-jvector/pull/670)
 ### Refactoring

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -728,7 +728,6 @@ curl -X POST "http://localhost:9200/my-vectors/_search" \
 | `overquery_factor` | `5` | Internal candidate list = `k × overquery_factor`. Higher values improve recall at the cost of latency. |
 | `advanced.threshold` | `0.0` | Minimum similarity score for a candidate to enter the result set. |
 | `advanced.rerank_floor` | `0.0` | Minimum score for a candidate to be re-ranked with full-precision vectors. |
-| `advanced.use_pruning` | `false` | Enable graph traversal pruning to reduce nodes visited. |
 
 **Guidelines:**
 - Start with `overquery_factor=5` (default)

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -86,11 +86,9 @@ public class KNNConstants {
     public static final String METHOD_PARAMETER_OVERQUERY_FACTOR = "overquery_factor";
     public static final String METHOD_PARAMETER_THRESHOLD = "advanced.threshold";
     public static final String METHOD_PARAMETER_RERANK_FLOOR = "advanced.rerank_floor";
-    public static final String METHOD_PARAMETER_USE_PRUNING = "advanced.use_pruning"; // TODO: wire this after jvector upgrade
     public static final int DEFAULT_OVER_QUERY_FACTOR = 5; // We will query 5x more than topKFor reranking
     public static final Double DEFAULT_QUERY_SIMILARITY_THRESHOLD = 0.0;
     public static final Double DEFAULT_QUERY_RERANK_FLOOR = 0.0;
-    public static final Boolean DEFAULT_QUERY_USE_PRUNING = false; // TODO: wire this after jvector upgrade
 
     // Construction related params
     public static final String METHOD_PARAMETER_ALPHA = "advanced.alpha";

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorKnnCollector.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorKnnCollector.java
@@ -18,7 +18,6 @@ public class JVectorKnnCollector implements KnnCollector {
     float threshold;
     float rerankFloor;
     int overQueryFactor;
-    boolean usePruning;
 
     @Override
     public boolean earlyTerminated() {

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorKnnFloatVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorKnnFloatVectorQuery.java
@@ -22,23 +22,13 @@ public class JVectorKnnFloatVectorQuery extends KnnFloatVectorQuery {
     private final int overQueryFactor;
     private final float threshold;
     private final float rerankFloor;
-    private final boolean usePruning;
     private static final KnnSearchStrategy DEFAULT_STRATEGY = new KnnSearchStrategy.Hnsw(100);
 
-    public JVectorKnnFloatVectorQuery(
-        String field,
-        float[] target,
-        int k,
-        int overQueryFactor,
-        float threshold,
-        float rerankFloor,
-        boolean usePruning
-    ) {
+    public JVectorKnnFloatVectorQuery(String field, float[] target, int k, int overQueryFactor, float threshold, float rerankFloor) {
         super(field, target, k);
         this.overQueryFactor = overQueryFactor;
         this.threshold = threshold;
         this.rerankFloor = rerankFloor;
-        this.usePruning = usePruning;
     }
 
     public JVectorKnnFloatVectorQuery(
@@ -48,14 +38,12 @@ public class JVectorKnnFloatVectorQuery extends KnnFloatVectorQuery {
         Query filter,
         int overQueryFactor,
         float threshold,
-        float rerankFloor,
-        boolean usePruning
+        float rerankFloor
     ) {
         super(field, target, k, filter);
         this.overQueryFactor = overQueryFactor;
         this.threshold = threshold;
         this.rerankFloor = rerankFloor;
-        this.usePruning = usePruning;
     }
 
     @Override
@@ -66,7 +54,7 @@ public class JVectorKnnFloatVectorQuery extends KnnFloatVectorQuery {
         KnnCollectorManager knnCollectorManager
     ) throws IOException {
         final KnnCollector delegateCollector = knnCollectorManager.newCollector(visitedLimit, DEFAULT_STRATEGY, context);
-        final KnnCollector knnCollector = new JVectorKnnCollector(delegateCollector, threshold, rerankFloor, overQueryFactor, usePruning);
+        final KnnCollector knnCollector = new JVectorKnnCollector(delegateCollector, threshold, rerankFloor, overQueryFactor);
         LeafReader reader = context.reader();
         FloatVectorValues floatVectorValues = reader.getFloatVectorValues(field);
         if (floatVectorValues == null) {

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
@@ -138,8 +138,7 @@ public class JVectorReader extends KnnVectorsReader {
                 knnCollector,
                 KNNConstants.DEFAULT_QUERY_SIMILARITY_THRESHOLD.floatValue(),
                 KNNConstants.DEFAULT_QUERY_RERANK_FLOOR.floatValue(),
-                KNNConstants.DEFAULT_OVER_QUERY_FACTOR,
-                KNNConstants.DEFAULT_QUERY_USE_PRUNING
+                KNNConstants.DEFAULT_OVER_QUERY_FACTOR
             );
 
         }

--- a/src/main/java/org/opensearch/knn/index/engine/JVectorDiskANNSearchContext.java
+++ b/src/main/java/org/opensearch/knn/index/engine/JVectorDiskANNSearchContext.java
@@ -35,10 +35,6 @@ public final class JVectorDiskANNSearchContext implements KNNLibrarySearchContex
             MethodParameter.RERANK_FLOOR.getName(),
             new Parameter.DoubleParameter(MethodParameter.RERANK_FLOOR.getName(), DEFAULT_QUERY_RERANK_FLOOR, (value, context) -> true)
         )
-        .put(
-            MethodParameter.USE_PRUNING.getName(),
-            new Parameter.BooleanParameter(MethodParameter.USE_PRUNING.getName(), DEFAULT_QUERY_USE_PRUNING, (value, context) -> true)
-        )
         .build();
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -73,7 +73,6 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
     public static final ParseField OVERQUERY_FACTOR_FIELD = new ParseField(METHOD_PARAMETER_OVERQUERY_FACTOR);
     public static final ParseField THRESHOLD_FIELD = new ParseField(METHOD_PARAMETER_THRESHOLD);
     public static final ParseField REREANK_FLOOR_FIELD = new ParseField(METHOD_PARAMETER_RERANK_FLOOR);
-    public static final ParseField USE_PRUNING_FIELD = new ParseField(METHOD_PARAMETER_USE_PRUNING);
     public static final ParseField METHOD_PARAMS_FIELD = new ParseField(METHOD_PARAMETER);
     public static final ParseField RESCORE_FIELD = new ParseField(RESCORE_PARAMETER);
     public static final ParseField RESCORE_OVERSAMPLE_FIELD = new ParseField(RESCORE_OVERSAMPLE_PARAMETER);
@@ -553,7 +552,6 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
                     final int overQueryFactor;
                     final float threshold;
                     final float rerankFloor;
-                    final boolean usePruning;
                     if (this.getMethodParameters() != null) {
                         Map<String, Object> methodParameters = (Map<String, Object>) this.getMethodParameters();
                         overQueryFactor = (Integer) methodParameters.getOrDefault(
@@ -564,12 +562,10 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
                             .floatValue();
                         rerankFloor = ((Double) methodParameters.getOrDefault(METHOD_PARAMETER_RERANK_FLOOR, DEFAULT_QUERY_RERANK_FLOOR))
                             .floatValue();
-                        usePruning = (Boolean) methodParameters.getOrDefault(METHOD_PARAMETER_USE_PRUNING, DEFAULT_QUERY_USE_PRUNING);
                     } else {
                         overQueryFactor = DEFAULT_OVER_QUERY_FACTOR;
                         threshold = DEFAULT_QUERY_SIMILARITY_THRESHOLD.floatValue();
                         rerankFloor = DEFAULT_QUERY_RERANK_FLOOR.floatValue();
-                        usePruning = DEFAULT_QUERY_USE_PRUNING;
                     }
 
                     if (byteVector.length > 0) {
@@ -577,16 +573,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
                     }
                     float[] target = getVectorForCreatingQueryRequest(vectorDataType, knnEngine);
                     assert target != null;
-                    return new JVectorKnnFloatVectorQuery(
-                        this.fieldName,
-                        target,
-                        k,
-                        filterQuery,
-                        overQueryFactor,
-                        threshold,
-                        rerankFloor,
-                        usePruning
-                    );
+                    return new JVectorKnnFloatVectorQuery(this.fieldName, target, k, filterQuery, overQueryFactor, threshold, rerankFloor);
                 default:
                     throw new RuntimeException("Unknown KNNEngine " + knnEngine);
             }

--- a/src/main/java/org/opensearch/knn/index/query/request/MethodParameter.java
+++ b/src/main/java/org/opensearch/knn/index/query/request/MethodParameter.java
@@ -124,18 +124,7 @@ public enum MethodParameter {
             validationException.addValidationError(METHOD_PARAMETER_RERANK_FLOOR + " should be greater than or equal to 0");
             return validationException;
         }
-    },
-    USE_PRUNING(METHOD_PARAMETER_USE_PRUNING, Version.V_3_0_0, USE_PRUNING_FIELD) {
-        @Override
-        public Boolean parse(Object value) {
-            return parseBoolean(value, METHOD_PARAMETER_USE_PRUNING);
-        }
-
-        @Override
-        public ValidationException validate(Object value) {
-            return null;
-        }
-    },;
+    };
 
     private final String name;
     private final Version version;

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/JVectorMergeWithDeletedDocsTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/JVectorMergeWithDeletedDocsTests.java
@@ -58,8 +58,7 @@ public class JVectorMergeWithDeletedDocsTests extends LuceneTestCase {
             filterQuery,
             KNNConstants.DEFAULT_OVER_QUERY_FACTOR,
             KNNConstants.DEFAULT_QUERY_SIMILARITY_THRESHOLD.floatValue(),
-            KNNConstants.DEFAULT_QUERY_RERANK_FLOOR.floatValue(),
-            KNNConstants.DEFAULT_QUERY_USE_PRUNING
+            KNNConstants.DEFAULT_QUERY_RERANK_FLOOR.floatValue()
         );
     }
 

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/JVectorNVQTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/JVectorNVQTests.java
@@ -196,8 +196,7 @@ public class JVectorNVQTests extends LuceneTestCase {
                             scenario.topK,
                             scenario.overqueryFactor,
                             0.0f,
-                            0.0f,
-                            false
+                            0.0f
                         );
                         var results = searcher.search(query, scenario.topK).scoreDocs;
 

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/JVectorWriterMergeTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/JVectorWriterMergeTests.java
@@ -182,8 +182,7 @@ public class JVectorWriterMergeTests extends LuceneTestCase {
                             scenario.topK,
                             scenario.overqueryFactor,
                             0.0f,
-                            0.0f,
-                            false
+                            0.0f
                         );
                         var results = searcher.search(query, scenario.topK).scoreDocs;
 

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
@@ -1781,8 +1781,7 @@ public class KNNJVectorTests extends LuceneTestCase {
             filterQuery,
             overQueryFactor,
             KNNConstants.DEFAULT_QUERY_SIMILARITY_THRESHOLD.floatValue(),
-            KNNConstants.DEFAULT_QUERY_RERANK_FLOOR.floatValue(),
-            KNNConstants.DEFAULT_QUERY_USE_PRUNING
+            KNNConstants.DEFAULT_QUERY_RERANK_FLOOR.floatValue()
         );
     }
 


### PR DESCRIPTION
### Description
After investigation of graph pruning from DataStax side, the feature found as deprecated. Thus, the task turned to a cleanup task.

### Related Issues
Resolves #670 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
