### PR TITLE
fix testJVectorKnnIndex_simpleCase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Bug Fixes
 - Fix flaky testJVectorKnnIndex_filter_maxInnerProduct test case [681](https://github.com/opensearch-project/opensearch-jvector/pull/681)
+- Fix flaky testJVectorKnnIndex_simpleCase  test case [692](https://github.com/opensearch-project/opensearch-jvector/pull/692)
 
 ### Infrastructure
 ### Documentation

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/KNNJVectorTests.java
@@ -94,7 +94,7 @@ public class KNNJVectorTests extends LuceneTestCase {
             try (IndexReader reader = DirectoryReader.open(w)) {
                 int expectedNumOfSegments = indexWriterConfig.getMaxBufferedDocs() < 0 ? 1
                     : totalNumberOfDocs > indexWriterConfig.getMaxBufferedDocs()
-                        ? totalNumberOfDocs / indexWriterConfig.getMaxBufferedDocs() + 1
+                        ? Math.ceilDiv(totalNumberOfDocs, indexWriterConfig.getMaxBufferedDocs())
                     : 1;
                 log.info("We should now have a {} segment(s) with 10 documents", expectedNumOfSegments);
                 Assert.assertEquals(expectedNumOfSegments, reader.getContext().leaves().size());


### PR DESCRIPTION
### Description
The problem was when 

`totalNumberOfDocs / maxDoc` has remainder old solution was working fine. However, when there is no remainder adding _+1_ was causing error. For example, 2 doc and 10 maxDoc. 

### Related Issues
Resolves #304 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

### Testing

```bash
./gradlew test --tests KNNJVectorTests.testJVectorKnnIndex_simpleCase -Dtests.iters=7000
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
