### PR TITLE
[DRAFT] Add FusedPQ on-disk layout for jVector graph traversal codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 3.8](https://github.com/opensearch-project/opensearch-jvector/compare/3.8...HEAD)
 ### Features
+- Add FusedPQ on-disk layout for jVector graph traversal codes [733](https://github.com/opensearch-project/opensearch-jvector/pull/733)
 
 ### Enhancements
 - [Storage perf] Stop writing the redundant binary doc values copy of the vector for jVector fields from 3.9.0 onwards. Preserve existing indices. [715] (https://github.com/opensearch-project/opensearch-jvector/pull/715) 

--- a/build.gradle
+++ b/build.gradle
@@ -381,6 +381,8 @@ test {
 
     // Enable preview features for Foreign Memory API
     jvmArgs = [
+            '-Xms8g',
+            '-Xmx8g',
             '--add-modules', 'jdk.incubator.vector',
             '--add-opens', 'java.base/java.nio=ALL-UNNAMED',
             '--add-opens', 'java.base/sun.nio.ch=ALL-UNNAMED',

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -108,6 +108,9 @@ public class KNNConstants {
     public static final int DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION = 1024; // above this batch size we will trigger quantization by
                                                                                 // default
     public static final Boolean DEFAULT_HIERARCHY_ENABLED = false;
+    // When enabled, PQ codes are stored inline with the graph adjacency lists (FusedPQ layout) instead of a separate blob.
+    public static final String METHOD_PARAMETER_FUSED_PQ_ENABLED = "advanced.fused_pq_enabled";
+    public static final Boolean DEFAULT_FUSED_PQ_ENABLED = false;
 
     // Parameters that only affect merge
     public static final String METHOD_PARAMETER_LEADING_SEGMENT_MERGE_DISABLED = "advanced.leading_segment_merge_disabled";

--- a/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120PerFieldKnnVectorsFormat.java
@@ -71,7 +71,8 @@ public class KNN9120PerFieldKnnVectorsFormat extends BasePerFieldKnnVectorsForma
                             knnVectorsFormatParams.getQuantization(),
                             knnVectorsFormatParams.getMinBatchSizeForQuantization(),
                             knnVectorsFormatParams.isHierarchyEnabled(),
-                            knnVectorsFormatParams.isLeadingSegmentMergeDisabled()
+                            knnVectorsFormatParams.isLeadingSegmentMergeDisabled(),
+                            knnVectorsFormatParams.isFusedPqEnabled()
                         );
                     default:
                         throw new IllegalArgumentException("Unsupported java engine: " + knnEngine);

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorDiskANNMethod.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorDiskANNMethod.java
@@ -109,6 +109,14 @@ public class JVectorDiskANNMethod extends AbstractKNNMethod {
                     (v, context) -> v != null && v > 0 && v <= context.getDimension()
                 )
             )
+            .addParameter(
+                METHOD_PARAMETER_FUSED_PQ_ENABLED,
+                new Parameter.BooleanParameter(
+                    METHOD_PARAMETER_FUSED_PQ_ENABLED,
+                    KNNConstants.DEFAULT_FUSED_PQ_ENABLED,
+                    (v, context) -> true
+                )
+            )
             .build();
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorFormat.java
@@ -30,7 +30,9 @@ public class JVectorFormat extends KnnVectorsFormat {
 
     public static final int VERSION_START = 0;
     public static final int VERSION_WITH_QUANTIZATION_TYPE = 1;
-    public static final int VERSION_CURRENT = VERSION_WITH_QUANTIZATION_TYPE;
+    // Adds the per-field {@code quantizationLayout} byte to segment metadata (SEPARATE vs FUSED_PQ).
+    public static final int VERSION_WITH_FUSED_PQ = 2;
+    public static final int VERSION_CURRENT = VERSION_WITH_FUSED_PQ;
     public static final int DEFAULT_MAX_CONN = 32;
     public static final int DEFAULT_BEAM_WIDTH = 100;
     // Unfortunately, this can't be managed yet by the OpenSearch ThreadPool because it's not supporting {@link ForkJoinPool} types
@@ -46,6 +48,7 @@ public class JVectorFormat extends KnnVectorsFormat {
     private final float neighborOverflow;
     private final boolean hierarchyEnabled;
     private final boolean leadingSegmentMergeDisabled;
+    private final boolean fusedPqEnabled;
     private final ForkJoinPool simdPoolMerge;
     private final ForkJoinPool simdPoolFlush;
     private final ForkJoinPool parallelismPool;
@@ -61,6 +64,7 @@ public class JVectorFormat extends KnnVectorsFormat {
             KNNConstants.DEFAULT_MINIMUM_BATCH_SIZE_FOR_QUANTIZATION,
             KNNConstants.DEFAULT_HIERARCHY_ENABLED,
             KNNConstants.DEFAULT_LEADING_SEGMENT_MERGE_DISABLED,
+            KNNConstants.DEFAULT_FUSED_PQ_ENABLED,
             SIMD_POOL_MERGE,
             SIMD_POOL_FLUSH,
             PARALLELISM_POOL
@@ -82,6 +86,7 @@ public class JVectorFormat extends KnnVectorsFormat {
             minBatchSizeForQuantization,
             KNNConstants.DEFAULT_HIERARCHY_ENABLED,
             leadingSegmentMergeDisabled,
+            KNNConstants.DEFAULT_FUSED_PQ_ENABLED,
             SIMD_POOL_MERGE,
             SIMD_POOL_FLUSH,
             PARALLELISM_POOL
@@ -105,6 +110,7 @@ public class JVectorFormat extends KnnVectorsFormat {
             minBatchSizeForQuantization,
             KNNConstants.DEFAULT_HIERARCHY_ENABLED,
             leadingSegmentMergeDisabled,
+            KNNConstants.DEFAULT_FUSED_PQ_ENABLED,
             simdPoolMerge,
             simdPoolFlush,
             parallelismPool
@@ -122,6 +128,30 @@ public class JVectorFormat extends KnnVectorsFormat {
         boolean leadingSegmentMergeDisabled
     ) {
         this(
+            maxConn,
+            beamWidth,
+            neighborOverflow,
+            alpha,
+            quantization,
+            minBatchSizeForQuantization,
+            hierarchyEnabled,
+            leadingSegmentMergeDisabled,
+            KNNConstants.DEFAULT_FUSED_PQ_ENABLED
+        );
+    }
+
+    public JVectorFormat(
+        int maxConn,
+        int beamWidth,
+        float neighborOverflow,
+        float alpha,
+        JVectorIndexQuantization quantization,
+        int minBatchSizeForQuantization,
+        boolean hierarchyEnabled,
+        boolean leadingSegmentMergeDisabled,
+        boolean fusedPqEnabled
+    ) {
+        this(
             NAME,
             maxConn,
             beamWidth,
@@ -131,6 +161,7 @@ public class JVectorFormat extends KnnVectorsFormat {
             minBatchSizeForQuantization,
             hierarchyEnabled,
             leadingSegmentMergeDisabled,
+            fusedPqEnabled,
             SIMD_POOL_MERGE,
             SIMD_POOL_FLUSH,
             PARALLELISM_POOL
@@ -147,6 +178,7 @@ public class JVectorFormat extends KnnVectorsFormat {
         int minBatchSizeForQuantization,
         boolean hierarchyEnabled,
         boolean leadingSegmentMergeDisabled,
+        boolean fusedPqEnabled,
         final ForkJoinPool simdPoolMerge,
         final ForkJoinPool simdPoolFlush,
         final ForkJoinPool parallelismPool
@@ -160,6 +192,7 @@ public class JVectorFormat extends KnnVectorsFormat {
         this.neighborOverflow = neighborOverflow;
         this.hierarchyEnabled = hierarchyEnabled;
         this.leadingSegmentMergeDisabled = leadingSegmentMergeDisabled;
+        this.fusedPqEnabled = fusedPqEnabled;
         this.simdPoolMerge = simdPoolMerge;
         this.simdPoolFlush = simdPoolFlush;
         this.parallelismPool = parallelismPool;
@@ -177,6 +210,7 @@ public class JVectorFormat extends KnnVectorsFormat {
             minBatchSizeForQuantization,
             hierarchyEnabled,
             leadingSegmentMergeDisabled,
+            fusedPqEnabled,
             simdPoolMerge,
             simdPoolFlush,
             parallelismPool

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorIndexQuantization.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorIndexQuantization.java
@@ -52,6 +52,11 @@ public sealed interface JVectorIndexQuantization {
     byte QUANTIZATION_TYPE_PQ = 1;
     byte QUANTIZATION_TYPE_NVQ_INLINE = 2;
 
+    // On-disk quantization LAYOUT bytes. Orthogonal to the *_TYPE_* bytes above: the type byte says what the
+    // exact scorer / reranker reads, the layout byte says where the PQ codes used for graph traversal live.
+    byte QUANTIZATION_LAYOUT_SEPARATE = 0; // PQ blob appended after the graph (legacy / default)
+    byte QUANTIZATION_LAYOUT_FUSED_PQ = 1; // PQ codes stored inline per adjacency entry via FeatureId.FUSED_PQ
+
     /** Holds the quantization objects loaded from disk for a single field. */
     record LoadedState(NVQuantization nvqInlineQuantization, PQVectors pqVectors, ReaderSupplier compressedVectorsReaderSupplier) {
     }

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
@@ -10,6 +10,7 @@ import io.github.jbellis.jvector.disk.ReaderSupplier;
 import io.github.jbellis.jvector.graph.GraphSearcher;
 import io.github.jbellis.jvector.graph.SearchResult;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
+import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
 import io.github.jbellis.jvector.graph.similarity.DefaultSearchScoreProvider;
 import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
 import io.github.jbellis.jvector.graph.similarity.SearchScoreProvider;
@@ -147,8 +148,9 @@ public class JVectorReader extends KnnVectorsReader {
         VectorFloat<?> q = VECTOR_TYPE_SUPPORT.createFloatVector(target);
         final FieldEntry fieldEntry = fieldEntryMap.get(field);
 
-        try (var view = index.getView()) {
+        try (var graphSearcher = new GraphSearcher(index)) {
             final long graphSearchStart = System.currentTimeMillis();
+            final OnDiskGraphIndex.View view = (OnDiskGraphIndex.View) graphSearcher.getView();
             final SearchScoreProvider ssp = fieldEntry.buildScoreFunctionProvider(q, view);
             final GraphNodeIdToDocMap jvectorLuceneDocMap = fieldEntry.graphNodeIdToDocMap;
             // Convert the acceptDocs bitmap from Lucene to jVector ordinal bitmap filter
@@ -162,49 +164,47 @@ public class JVectorReader extends KnnVectorsReader {
                     || (jvectorLuceneDocMap.getLuceneDocId(ord) != -1 && b.get(jvectorLuceneDocMap.getLuceneDocId(ord)));
             }
 
-            try (var graphSearcher = new GraphSearcher(index)) {
-                final var searchResults = graphSearcher.search(
-                    ssp,
-                    jvectorKnnCollector.k(),
-                    jvectorKnnCollector.k() * jvectorKnnCollector.getOverQueryFactor(),
-                    jvectorKnnCollector.getThreshold(),
-                    jvectorKnnCollector.getRerankFloor(),
-                    compatibleBits
-                );
+            final var searchResults = graphSearcher.search(
+                ssp,
+                jvectorKnnCollector.k(),
+                jvectorKnnCollector.k() * jvectorKnnCollector.getOverQueryFactor(),
+                jvectorKnnCollector.getThreshold(),
+                jvectorKnnCollector.getRerankFloor(),
+                compatibleBits
+            );
 
-                for (SearchResult.NodeScore ns : searchResults.getNodes()) {
-                    jvectorKnnCollector.collect(jvectorLuceneDocMap.getLuceneDocId(ns.node), ns.score);
-                }
-                final long graphSearchEnd = System.currentTimeMillis();
-                final long searchTime = graphSearchEnd - graphSearchStart;
-                log.debug("Search (including acquiring view) took {} ms", searchTime);
+            for (SearchResult.NodeScore ns : searchResults.getNodes()) {
+                jvectorKnnCollector.collect(jvectorLuceneDocMap.getLuceneDocId(ns.node), ns.score);
+            }
+            final long graphSearchEnd = System.currentTimeMillis();
+            final long searchTime = graphSearchEnd - graphSearchStart;
+            log.debug("Search (including acquiring view) took {} ms", searchTime);
 
-                // Collect the below metrics about the search and somehow wire this back to {@link @KNNStats}
-                final int visitedNodesCount = searchResults.getVisitedCount();
-                final int rerankedCount = searchResults.getRerankedCount();
+            // Collect the below metrics about the search and somehow wire this back to {@link @KNNStats}
+            final int visitedNodesCount = searchResults.getVisitedCount();
+            final int rerankedCount = searchResults.getRerankedCount();
 
-                final int expandedCount = searchResults.getExpandedCount();
-                final int expandedBaseLayerCount = searchResults.getExpandedCountBaseLayer();
+            final int expandedCount = searchResults.getExpandedCount();
+            final int expandedBaseLayerCount = searchResults.getExpandedCountBaseLayer();
 
-                KNNCounter.KNN_QUERY_VISITED_NODES.add(visitedNodesCount);
-                KNNCounter.KNN_QUERY_RERANKED_COUNT.add(rerankedCount);
-                KNNCounter.KNN_QUERY_EXPANDED_NODES.add(expandedCount);
-                KNNCounter.KNN_QUERY_EXPANDED_BASE_LAYER_NODES.add(expandedBaseLayerCount);
-                KNNCounter.KNN_QUERY_GRAPH_SEARCH_TIME.add(searchTime);
-                log.debug(
-                    "rerankedCount: {}, visitedNodesCount: {}, expandedCount: {}, expandedBaseLayerCount: {}",
-                    rerankedCount,
-                    visitedNodesCount,
-                    expandedCount,
-                    expandedBaseLayerCount
-                );
+            KNNCounter.KNN_QUERY_VISITED_NODES.add(visitedNodesCount);
+            KNNCounter.KNN_QUERY_RERANKED_COUNT.add(rerankedCount);
+            KNNCounter.KNN_QUERY_EXPANDED_NODES.add(expandedCount);
+            KNNCounter.KNN_QUERY_EXPANDED_BASE_LAYER_NODES.add(expandedBaseLayerCount);
+            KNNCounter.KNN_QUERY_GRAPH_SEARCH_TIME.add(searchTime);
+            log.debug(
+                "rerankedCount: {}, visitedNodesCount: {}, expandedCount: {}, expandedBaseLayerCount: {}",
+                rerankedCount,
+                visitedNodesCount,
+                expandedCount,
+                expandedBaseLayerCount
+            );
 
-                // Apache Lucene tracks visited counter so to validate scored docs/ total hits (
-                // see AbstractKnnVectorQuery please). The counter has to be updated manually.
-                final int visitedCount = visitedNodesCount + expandedCount;
-                if (visitedCount > 0) {
-                    jvectorKnnCollector.incVisitedCount(visitedCount);
-                }
+            // Apache Lucene tracks visited counter so to validate scored docs/ total hits (
+            // see AbstractKnnVectorQuery please). The counter has to be updated manually.
+            final int visitedCount = visitedNodesCount + expandedCount;
+            if (visitedCount > 0) {
+                jvectorKnnCollector.incVisitedCount(visitedCount);
             }
         }
     }
@@ -277,9 +277,11 @@ public class JVectorReader extends KnnVectorsReader {
         private final ReaderSupplier compressedVectorsReaderSupplier;
         private final ReaderSupplier neighborsScoreCacheIndexReaderSupplier;
         private final OnDiskGraphIndex index;
-        private final PQVectors pqVectors; // non-null when a PQ blob is present (PQ-only or NVQ+PQ)
+        private final PQVectors pqVectors; // non-null when a separate PQ blob is present (PQ-only or NVQ+PQ)
         // NVQuantization extracted from the graph when NVQ is stored inline; null otherwise
         private final NVQuantization nvqInlineQuantization;
+        // true when PQ traversal codes are stored inline with the adjacency lists (FusedPQ layout) instead of a blob
+        private final boolean fusedPqPresent;
 
         public FieldEntry(FieldInfo fieldInfo, JVectorWriter.VectorIndexFieldMetadata vectorIndexFieldMetadata) throws IOException {
             this.fieldInfo = fieldInfo;
@@ -329,6 +331,13 @@ public class JVectorReader extends KnnVectorsReader {
             this.nvqInlineQuantization = qs.nvqInlineQuantization();
             this.pqVectors = qs.pqVectors();
             this.compressedVectorsReaderSupplier = qs.compressedVectorsReaderSupplier();
+            this.fusedPqPresent = vectorIndexFieldMetadata.getQuantizationLayout() == JVectorIndexQuantization.QUANTIZATION_LAYOUT_FUSED_PQ;
+            if (fusedPqPresent && !this.index.getFeatureSet().contains(FeatureId.FUSED_PQ)) {
+                throw new CorruptIndexException(
+                    "Segment metadata declares the FusedPQ layout but the graph has no FUSED_PQ feature",
+                    vectorIndexFieldDataFileName
+                );
+            }
 
             final IndexInput indexInput = directory.openInput(neighborsScoreCacheIndexFieldFileName, state.context);
             CodecUtil.readIndexHeader(indexInput);
@@ -350,7 +359,17 @@ public class JVectorReader extends KnnVectorsReader {
         }
 
         SearchScoreProvider buildScoreFunctionProvider(VectorFloat<?> q, OnDiskGraphIndex.View view) {
-            if (pqVectors != null) {
+            if (fusedPqPresent) {
+                // FusedPQ is only written for the plain-PQ path (never alongside NVQ), so reranking always uses 
+                // the graph's INLINE_VECTORS feature here.
+                ScoreFunction.ApproximateScoreFunction asf = view.approximateScoreFunctionFor(q, similarityFunction);
+                ScoreFunction.ExactScoreFunction reranker = wrapExactScoreFunction(
+                    view.rerankerFor(q, similarityFunction),
+                    fieldInfo.getVectorSimilarityFunction(),
+                    similarityFunction
+                );
+                return new DefaultSearchScoreProvider(asf, reranker);
+            } else if (pqVectors != null) {
                 ScoreFunction.ApproximateScoreFunction asf = pqVectors.precomputedScoreFunctionFor(q, similarityFunction);
                 ScoreFunction.ExactScoreFunction reranker = view.rerankerFor(q, similarityFunction);
                 return new DefaultSearchScoreProvider(asf, reranker);

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorReader.java
@@ -360,7 +360,7 @@ public class JVectorReader extends KnnVectorsReader {
 
         SearchScoreProvider buildScoreFunctionProvider(VectorFloat<?> q, OnDiskGraphIndex.View view) {
             if (fusedPqPresent) {
-                // FusedPQ is only written for the plain-PQ path (never alongside NVQ), so reranking always uses 
+                // FusedPQ is only written for the plain-PQ path (never alongside NVQ), so reranking always uses
                 // the graph's INLINE_VECTORS feature here.
                 ScoreFunction.ApproximateScoreFunction asf = view.approximateScoreFunctionFor(q, similarityFunction);
                 ScoreFunction.ExactScoreFunction reranker = wrapExactScoreFunction(

--- a/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/jvector/JVectorWriter.java
@@ -9,6 +9,7 @@ import io.github.jbellis.jvector.graph.*;
 import io.github.jbellis.jvector.graph.disk.*;
 import io.github.jbellis.jvector.graph.disk.feature.Feature;
 import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
+import io.github.jbellis.jvector.graph.disk.feature.FusedPQ;
 import io.github.jbellis.jvector.graph.disk.feature.InlineVectors;
 import io.github.jbellis.jvector.graph.disk.feature.NVQ;
 import io.github.jbellis.jvector.graph.diversity.VamanaDiversityProvider;
@@ -40,6 +41,7 @@ import org.apache.lucene.util.IORunnable;
 import io.github.jbellis.jvector.util.FixedBitSet;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.plugin.stats.KNNCounter;
 
 import java.io.IOException;
@@ -47,6 +49,7 @@ import java.io.UnsupportedEncodingException;
 import java.time.Clock;
 import java.util.*;
 import java.util.concurrent.ForkJoinPool;
+import java.util.function.IntFunction;
 import java.util.stream.IntStream;
 
 import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsReader.readVectorEncoding;
@@ -97,6 +100,9 @@ public class JVectorWriter extends KnnVectorsWriter {
     private final int minimumBatchSizeForQuantization; // Threshold for the vector count above which we will trigger PQ quantization
     private final boolean hierarchyEnabled;
     private final boolean leadingSegmentMergeDisabled;
+    // When true, PQ codes for graph traversal are written inline with the adjacency lists (FusedPQ layout)
+    // rather than as a separate blob appended after the graph. Orthogonal to {@link #quantization}.
+    private final boolean fusedPqEnabled;
 
     private final ForkJoinPool simdPoolMerge;
     private final ForkJoinPool simdPoolFlush;
@@ -114,6 +120,7 @@ public class JVectorWriter extends KnnVectorsWriter {
         int minimumBatchSizeForQuantization,
         boolean hierarchyEnabled,
         boolean leadingSegmentMergeDisabled,
+        boolean fusedPqEnabled,
         final ForkJoinPool simdPoolMerge,
         final ForkJoinPool simdPoolFlush,
         final ForkJoinPool parallelismPool
@@ -127,6 +134,7 @@ public class JVectorWriter extends KnnVectorsWriter {
         this.minimumBatchSizeForQuantization = minimumBatchSizeForQuantization;
         this.hierarchyEnabled = hierarchyEnabled;
         this.leadingSegmentMergeDisabled = leadingSegmentMergeDisabled;
+        this.fusedPqEnabled = fusedPqEnabled;
         this.simdPoolMerge = simdPoolMerge;
         this.simdPoolFlush = simdPoolFlush;
         this.parallelismPool = parallelismPool;
@@ -404,12 +412,26 @@ public class JVectorWriter extends KnnVectorsWriter {
                 .vectorDimension(randomAccessVectorValues.dimension())
                 .graphNodeIdToDocMap(graphNodeIdToDocMap);
 
+            // Default layout; the fused writers below override it to FUSED_PQ when they actually inline the codes.
+            resultBuilder.quantizationLayout(JVectorIndexQuantization.QUANTIZATION_LAYOUT_SEPARATE);
+
             if (compressedVectors instanceof NVQVectors nvqVectors) {
                 writeNVQGraph(
                     graph,
                     fieldInfo,
                     nvqVectors,
                     auxiliaryPqVectors,
+                    jVectorIndexWriter,
+                    indexOutput,
+                    startOffset,
+                    resultBuilder
+                );
+            } else if (fusedPqEnabled && compressedVectors instanceof PQVectors pqVectors && fusedPqUsable(pqVectors, fieldInfo)) {
+                writeFusedPQGraph(
+                    graph,
+                    randomAccessVectorValues,
+                    fieldInfo,
+                    pqVectors,
                     jVectorIndexWriter,
                     indexOutput,
                     startOffset,
@@ -444,7 +466,18 @@ public class JVectorWriter extends KnnVectorsWriter {
         VectorIndexFieldMetadata.VectorIndexFieldMetadataBuilder resultBuilder
     ) throws IOException {
         final NVQuantization nvQuantization = nvqVectors.getNVQuantization();
+        // FusedPQ is intentionally not supported in combination with NVQ reranking yet; the NVQ path always
+        // uses the separate PQ blob layout, regardless of fusedPqEnabled.
+        if (fusedPqEnabled) {
+            log.warn(
+                "FusedPQ is enabled ({}) but is not supported together with NVQ reranking for field {}; "
+                    + "falling back to the separate PQ blob layout",
+                KNNConstants.METHOD_PARAMETER_FUSED_PQ_ENABLED,
+                fieldInfo.name
+            );
+        }
         log.info("Writing NVQ vectors inline with graph nodes for field {}", fieldInfo.name);
+
         try (var writer = new OnDiskSequentialGraphIndexWriter.Builder(graph, jVectorIndexWriter).with(new NVQ(nvQuantization)).build()) {
             var suppliers = Feature.singleStateFactory(FeatureId.NVQ_VECTORS, nodeId -> new NVQ.State(nvqVectors.get(nodeId)));
             writer.write(suppliers);
@@ -461,6 +494,63 @@ public class JVectorWriter extends KnnVectorsWriter {
                 resultBuilder.compressedVectorsLength(0);
             }
             resultBuilder.quantizationType(JVectorIndexQuantization.QUANTIZATION_TYPE_NVQ_INLINE);
+            resultBuilder.quantizationLayout(JVectorIndexQuantization.QUANTIZATION_LAYOUT_SEPARATE);
+            CodecUtil.writeFooter(indexOutput);
+        }
+    }
+
+    // FusedPQ packs neighbor codes assuming a full 256-entry codebook per subspace. Small segments train fewer
+    // clusters (see computePqVectors: Math.min(256, size)), so FusedPQ is only usable at >= 256 vectors.
+    private static final int FUSED_PQ_REQUIRED_CLUSTERS = 256;
+
+    /** Whether the given PQ codebook can be written in the FusedPQ inline layout; logs and returns false otherwise. */
+    private boolean fusedPqUsable(PQVectors pqVectors, FieldInfo fieldInfo) {
+        final int clusterCount = pqVectors.getCompressor().getClusterCount();
+        if (clusterCount < FUSED_PQ_REQUIRED_CLUSTERS) {
+            log.info(
+                "FusedPQ requires a {}-cluster codebook but field {} trained only {}; falling back to the separate PQ blob layout",
+                FUSED_PQ_REQUIRED_CLUSTERS,
+                fieldInfo.name,
+                clusterCount
+            );
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Writes the graph with full-precision vectors inline for reranking (FeatureId.INLINE_VECTORS) and the PQ
+     * codes for graph traversal inline per adjacency entry (FeatureId.FUSED_PQ) instead of as a separate blob.
+     */
+    private void writeFusedPQGraph(
+        OnHeapGraphIndex graph,
+        RandomAccessVectorValues randomAccessVectorValues,
+        FieldInfo fieldInfo,
+        PQVectors pqVectors,
+        JVectorIndexWriter jVectorIndexWriter,
+        IndexOutput indexOutput,
+        long startOffset,
+        VectorIndexFieldMetadata.VectorIndexFieldMetadataBuilder resultBuilder
+    ) throws IOException {
+        log.info("Writing FusedPQ graph with inline PQ codes for field {}", fieldInfo.name);
+        final FusedPQ fusedPQ = new FusedPQ(maxConn, pqVectors.getCompressor());
+        try (
+            var writer = new OnDiskSequentialGraphIndexWriter.Builder(graph, jVectorIndexWriter).with(
+                new InlineVectors(randomAccessVectorValues.dimension())
+            ).with(fusedPQ).build()
+        ) {
+            Map<FeatureId, IntFunction<Feature.State>> suppliers = new EnumMap<>(FeatureId.class);
+            suppliers.put(FeatureId.INLINE_VECTORS, nodeId -> new InlineVectors.State(randomAccessVectorValues.getVector(nodeId)));
+            suppliers.put(FeatureId.FUSED_PQ, nodeId -> new FusedPQ.State(graph.getView(), pqVectors, nodeId));
+            writer.write(suppliers);
+            long endGraphOffset = jVectorIndexWriter.position();
+            resultBuilder.vectorIndexOffset(startOffset);
+            resultBuilder.vectorIndexLength(endGraphOffset - startOffset);
+            // No separate PQ blob is written in the fused layout.
+            resultBuilder.compressedVectorsOffset(0);
+            resultBuilder.compressedVectorsLength(0);
+            resultBuilder.quantizationType(JVectorIndexQuantization.QUANTIZATION_TYPE_PQ);
+            resultBuilder.quantizationLayout(JVectorIndexQuantization.QUANTIZATION_LAYOUT_FUSED_PQ);
             CodecUtil.writeFooter(indexOutput);
         }
     }
@@ -522,6 +612,9 @@ public class JVectorWriter extends KnnVectorsWriter {
         long compressedVectorsOffset;
         long compressedVectorsLength;
         byte quantizationType; // QUANTIZATION_TYPE_NONE/PQ/NVQ; added in VERSION_WITH_QUANTIZATION_TYPE
+        // QUANTIZATION_LAYOUT_SEPARATE/FUSED_PQ; added in VERSION_WITH_FUSED_PQ. Orthogonal to quantizationType:
+        // where the PQ traversal codes are stored (separate blob vs inline with adjacency lists).
+        byte quantizationLayout;
         float degreeOverflow; // important when leveraging cache
         GraphNodeIdToDocMap graphNodeIdToDocMap;
 
@@ -535,6 +628,7 @@ public class JVectorWriter extends KnnVectorsWriter {
             out.writeVLong(compressedVectorsOffset);
             out.writeVLong(compressedVectorsLength);
             out.writeByte(quantizationType);
+            out.writeByte(quantizationLayout);
             out.writeInt(Float.floatToIntBits(degreeOverflow));
             graphNodeIdToDocMap.toOutput(out);
         }
@@ -555,6 +649,12 @@ public class JVectorWriter extends KnnVectorsWriter {
                 this.quantizationType = this.compressedVectorsLength > 0
                     ? JVectorIndexQuantization.QUANTIZATION_TYPE_PQ
                     : JVectorIndexQuantization.QUANTIZATION_TYPE_NONE;
+            }
+            if (version >= JVectorFormat.VERSION_WITH_FUSED_PQ) {
+                this.quantizationLayout = in.readByte();
+            } else {
+                // Pre-FusedPQ segments always used the separate PQ blob layout.
+                this.quantizationLayout = JVectorIndexQuantization.QUANTIZATION_LAYOUT_SEPARATE;
             }
             this.degreeOverflow = Float.intBitsToFloat(in.readInt());
             this.graphNodeIdToDocMap = new GraphNodeIdToDocMap(in);

--- a/src/main/java/org/opensearch/knn/index/codec/params/KNNVectorsFormatParams.java
+++ b/src/main/java/org/opensearch/knn/index/codec/params/KNNVectorsFormatParams.java
@@ -28,6 +28,9 @@ public class KNNVectorsFormatParams {
     private JVectorIndexQuantization quantization;
     private final SpaceType spaceType;
     private boolean leadingSegmentMergeDisabled;
+    // Orthogonal to {@link #quantization}: when true, PQ codes for graph traversal are stored inline
+    // with the adjacency lists (FusedPQ layout) rather than in a separate blob appended after the graph.
+    private boolean fusedPqEnabled;
 
     public KNNVectorsFormatParams(final Map<String, Object> params, int defaultMaxConnections, int defaultBeamWidth) {
         this(
@@ -60,6 +63,7 @@ public class KNNVectorsFormatParams {
         initHierarchyEnabled(params, defaultHierarchyEnabled);
         this.spaceType = spaceType;
         initLeadingSegmentMergeDisabled(params, KNNConstants.DEFAULT_LEADING_SEGMENT_MERGE_DISABLED);
+        initFusedPqEnabled(params, KNNConstants.DEFAULT_FUSED_PQ_ENABLED);
         initQuantization(params);
     }
 
@@ -121,6 +125,14 @@ public class KNNVectorsFormatParams {
             return;
         }
         this.leadingSegmentMergeDisabled = defaultLsmDisabled;
+    }
+
+    private void initFusedPqEnabled(final Map<String, Object> params, boolean defaultFusedPqEnabled) {
+        if (params != null && params.containsKey(KNNConstants.METHOD_PARAMETER_FUSED_PQ_ENABLED)) {
+            this.fusedPqEnabled = (boolean) params.get(KNNConstants.METHOD_PARAMETER_FUSED_PQ_ENABLED);
+            return;
+        }
+        this.fusedPqEnabled = defaultFusedPqEnabled;
     }
 
     private void initQuantization(final Map<String, Object> params) {

--- a/src/test/java/org/opensearch/knn/index/ThreadLeakFiltersForTests.java
+++ b/src/test/java/org/opensearch/knn/index/ThreadLeakFiltersForTests.java
@@ -25,6 +25,7 @@ public class ThreadLeakFiltersForTests implements ThreadFilter {
                 || threadGroup.getName().startsWith("TGRP-MemoryUsageAnalysisTests")
                 || threadGroup.getName().startsWith("TGRP-KNN1030CodecTests")
                 || threadGroup.getName().startsWith("TGRP-KNN1040CodecTests")
-                || threadGroup.getName().startsWith("TGRP-JVectorNVQTests"));
+                || threadGroup.getName().startsWith("TGRP-JVectorNVQTests")
+                || threadGroup.getName().startsWith("TGRP-JVectorFusedPQTests"));
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/jvector/JVectorFusedPQTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/jvector/JVectorFusedPQTests.java
@@ -1,0 +1,526 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.jvector;
+
+import static org.opensearch.knn.index.engine.CommonTestUtils.getCodec;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field.Store;
+import org.apache.lucene.document.IntField;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FilterLeafReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.BitSet;
+import org.apache.lucene.util.FixedBitSet;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.opensearch.knn.TestUtils;
+import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.ThreadLeakFiltersForTests;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
+import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
+import io.github.jbellis.jvector.util.DocIdSetIterator;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Builder.Default;
+import lombok.Singular;
+
+/**
+ * Tests for the FusedPQ write, merge, and search paths.
+ *
+ * <p>FusedPQ stores the PQ codes used for graph traversal inline per adjacency-list entry
+ * ({@link FeatureId#FUSED_PQ}) instead of appending them as a separate blob that is loaded
+ * into heap at segment open. Full-precision vectors are still kept inline for reranking
+ * ({@link FeatureId#INLINE_VECTORS}). It is an on-disk <em>layout</em> flag
+ * ({@code advanced.fused_pq_enabled}), orthogonal to the quantization type.
+ *
+ * <p>Coverage:
+ * <ul>
+ *   <li>Single-segment flush with FusedPQ enabled — recall + metadata flags</li>
+ *   <li>Fallback to full precision when the vector count is below the batch threshold</li>
+ *   <li>Two-segment and multi-segment merges (with deletions) under FusedPQ</li>
+ *   <li>Multi-phase progressive merge once the vector count crosses the threshold</li>
+ *   <li>All three similarity functions (EUCLIDEAN, COSINE, DOT_PRODUCT)</li>
+ *   <li>Concurrent search over a FusedPQ index</li>
+ *   <li>Merge with leading-segment merge disabled</li>
+ * </ul>
+ *
+ * FusedPQ uses the same codebook and codes as the separate-blob PQ path, so recall targets
+ * match the PQ equivalents.
+ */
+@ThreadLeakFilters(defaultFilters = true, filters = { ThreadLeakFiltersForTests.class })
+@LuceneTestCase.SuppressSysoutChecks(bugUrl = "")
+public class JVectorFusedPQTests extends LuceneTestCase {
+
+    static final int RANDOM_SEED = 42;
+    static final String ID_FIELD = "doc_id";
+    static final String VECTOR_FIELD = "vectors";
+
+    @AllArgsConstructor
+    static class DeletionRange {
+        int start;
+        int end;
+    }
+
+    @Builder
+    static class MergeTestRound {
+        @Default
+        List<Integer> segmentSizes = List.of();
+        @Default
+        List<DeletionRange> deletionRanges = List.of();
+    }
+
+    @Builder
+    static class MergeTestScenario {
+        @Singular
+        List<MergeTestRound> rounds;
+        @Default
+        int minFusedPqThreshold = 1; // always apply FusedPQ by default
+        @Default
+        int dimension = 128;
+        @Default
+        int nQueries = 10;
+        @Default
+        int topK = 10;
+        @Default
+        int overqueryFactor = 10;
+        @Default
+        double minimumRecall = 0.7;
+        @Default
+        boolean leadingSegmentMergeDisabled = KNNConstants.DEFAULT_LEADING_SEGMENT_MERGE_DISABLED;
+        @Default
+        VectorSimilarityFunction similarityFunction = VectorSimilarityFunction.EUCLIDEAN;
+    }
+
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
+    private ForkJoinPool singleThreadGraphMergePool;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        singleThreadGraphMergePool = new ForkJoinPool(1);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        singleThreadGraphMergePool.shutdown();
+        if (singleThreadGraphMergePool.awaitTermination(30, TimeUnit.SECONDS) == false) {
+            singleThreadGraphMergePool.shutdownNow();
+        }
+    }
+
+    void runScenario(MergeTestScenario scenario) throws IOException {
+        runScenarioWithPool(scenario, null);
+    }
+
+    void runScenarioWithPool(MergeTestScenario scenario, ForkJoinPool mergePool) throws IOException {
+        int nBase = scenario.rounds.stream().mapToInt(r -> r.segmentSizes.stream().mapToInt(x -> x).sum()).sum();
+        var baseVecs = TestUtils.randomlyGenerateStandardVectors(nBase, scenario.dimension, RANDOM_SEED);
+        var queryVecs = TestUtils.randomlyGenerateStandardVectors(scenario.nQueries, scenario.dimension, RANDOM_SEED + 1);
+
+        var liveVecs = new FixedBitSet(nBase);
+        liveVecs.clear();
+
+        IndexWriterConfig iwc = LuceneTestCase.newIndexWriterConfig();
+        iwc.setUseCompoundFile(false);
+        // Quantization type stays plain PQ; the trailing flag enables the FusedPQ on-disk layout.
+        iwc.setCodec(
+            getCodec(scenario.minFusedPqThreshold, scenario.leadingSegmentMergeDisabled, mergePool, new JVectorIndexQuantization.PQ(), true)
+        );
+        iwc.setMergePolicy(new ForceMergesOnlyMergePolicy(false));
+        iwc.setMaxBufferedDocs(-1);
+
+        try (var fsd = FSDirectory.open(tempDir.getRoot().toPath()); var writer = new IndexWriter(fsd, iwc)) {
+            int vectorOffset = 0;
+            for (int roundId = 0; roundId < scenario.rounds.size(); roundId++) {
+                var round = scenario.rounds.get(roundId);
+
+                for (int segInRound = 0; segInRound < round.segmentSizes.size(); segInRound++) {
+                    var segmentSize = round.segmentSizes.get(segInRound);
+
+                    for (int i = 0; i < segmentSize; i++) {
+                        int id = vectorOffset + i;
+                        Document doc = new Document();
+                        doc.add(new KnnFloatVectorField(VECTOR_FIELD, baseVecs[id], scenario.similarityFunction));
+                        doc.add(new IntField(ID_FIELD, id, Store.YES));
+                        writer.addDocument(doc);
+                        liveVecs.set(id);
+                    }
+                    writer.flush();
+                    writer.commit();
+                    vectorOffset += segmentSize;
+                }
+
+                for (var dl : round.deletionRanges) {
+                    var query = IntField.newRangeQuery(ID_FIELD, dl.start, dl.end - 1);
+                    writer.deleteDocuments(query);
+                    liveVecs.clear(dl.start, dl.end);
+                    writer.commit();
+                }
+
+                writer.forceMerge(1);
+                writer.commit();
+
+                try (var reader = DirectoryReader.open(writer)) {
+                    Assert.assertTrue("Should have one segment after merge", 1 >= reader.getContext().leaves().size());
+                    assertEquals(liveVecs.cardinality(), reader.numDocs());
+
+                    var searcher = LuceneTestCase.newSearcher(reader);
+                    int totalCorrect = 0;
+
+                    for (var queryVec : queryVecs) {
+                        var gt = computeGroundTruth(scenario.similarityFunction, baseVecs, liveVecs, queryVec, scenario.topK);
+                        var query = new JVectorKnnFloatVectorQuery(
+                            VECTOR_FIELD,
+                            queryVec,
+                            scenario.topK,
+                            scenario.overqueryFactor,
+                            0.0f,
+                            0.0f
+                        );
+                        var results = searcher.search(query, scenario.topK).scoreDocs;
+
+                        var pred = Arrays.stream(results).map(r -> {
+                            try {
+                                return reader.storedFields().document(r.doc).getField(ID_FIELD).numericValue().intValue();
+                            } catch (IOException e) {
+                                throw new UncheckedIOException(e);
+                            }
+                        }).collect(Collectors.toSet());
+
+                        assertEquals(scenario.topK, pred.size());
+                        for (var doc : pred) {
+                            if (gt.contains(doc)) {
+                                totalCorrect++;
+                            }
+                        }
+                    }
+
+                    double recall = totalCorrect / (double) (scenario.topK * queryVecs.length);
+                    Assert.assertTrue(
+                        String.format("FusedPQ recall too low [round %d]: got %.3f < %.3f", roundId, recall, scenario.minimumRecall),
+                        recall >= scenario.minimumRecall
+                    );
+                }
+            }
+        }
+    }
+
+    Set<Integer> computeGroundTruth(VectorSimilarityFunction vsf, float[][] baseVectors, BitSet liveVectors, float[] query, int k) {
+        if (liveVectors.length() == 0) {
+            return Set.of();
+        }
+        var pq = new PriorityQueue<ScoreDoc>(k, (a, b) -> Float.compare(a.score, b.score));
+        for (int i = liveVectors.nextSetBit(0); i != DocIdSetIterator.NO_MORE_DOCS; i = liveVectors.nextSetBit(i + 1)) {
+            var score = vsf.compare(baseVectors[i], query);
+            var sd = new ScoreDoc(i, score);
+            if (pq.size() < k) {
+                pq.add(sd);
+            } else if (pq.peek().score < sd.score) {
+                pq.poll();
+                pq.add(sd);
+            }
+            if (i + 1 >= liveVectors.length()) break;
+        }
+        return pq.stream().map(sd -> sd.doc).collect(Collectors.toSet());
+    }
+
+    private JVectorReader openJVectorReader(DirectoryReader reader) throws IOException {
+        LeafReaderContext ctx = reader.getContext().leaves().get(0);
+        SegmentReader segReader = (SegmentReader) FilterLeafReader.unwrap(ctx.reader());
+        PerFieldKnnVectorsFormat.FieldsReader outer = (PerFieldKnnVectorsFormat.FieldsReader) segReader.getVectorReader();
+        return (JVectorReader) outer.getFieldReader(VECTOR_FIELD);
+    }
+
+    /**
+     * Single segment, FusedPQ always active (minThreshold=1). Verifies the full
+     * flush -> FusedPQ encode -> search path including recall. 512 vectors guarantees
+     * a full 256-cluster codebook (the FusedPQ requirement).
+     */
+    @Test
+    public void testFusedPQFlushRecall() throws IOException {
+        var scenario = MergeTestScenario.builder()
+            .minFusedPqThreshold(1)
+            .round(MergeTestRound.builder().segmentSizes(List.of(512)).build())
+            .minimumRecall(0.7)
+            .build();
+        runScenario(scenario);
+    }
+
+    /**
+     * FusedPQ enabled but minThreshold=MAX_VALUE, so quantization never triggers.
+     * Recall must be perfect since full-precision vectors are used and there is no PQ layer.
+     */
+    @Test
+    public void testFusedPQBelowThresholdFallbackToFullPrecision() throws IOException {
+        var scenario = MergeTestScenario.builder()
+            .minFusedPqThreshold(Integer.MAX_VALUE)
+            .round(MergeTestRound.builder().segmentSizes(List.of(200)).build())
+            .minimumRecall(1.0)
+            .overqueryFactor(KNNConstants.DEFAULT_OVER_QUERY_FACTOR)
+            .build();
+        runScenario(scenario);
+    }
+
+    /**
+     * Two 300-vector segments merged into one under FusedPQ. Each flush segment gets 256
+     * clusters (min(256, 300)). Verifies the merge path produces a valid FusedPQ segment.
+     */
+    @Test
+    public void testFusedPQSimpleMerge() throws IOException {
+        var scenario = MergeTestScenario.builder()
+            .minFusedPqThreshold(1)
+            .round(MergeTestRound.builder().segmentSizes(List.of(300, 300)).build())
+            .minimumRecall(0.7)
+            .build();
+        runScenarioWithPool(scenario, singleThreadGraphMergePool);
+    }
+
+    /**
+     * Multiple segments with deletions merged under FusedPQ; each segment has >= 256 vectors
+     * so the 256-cluster codebook requirement holds at flush time.
+     */
+    @Test
+    public void testFusedPQMergeWithDeletions() throws IOException {
+        var scenario = MergeTestScenario.builder()
+            .minFusedPqThreshold(1)
+            .round(
+                MergeTestRound.builder()
+                    .segmentSizes(List.of(300, 300, 300))
+                    .deletionRanges(List.of(new DeletionRange(0, 50), new DeletionRange(500, 600)))
+                    .build()
+            )
+            .minimumRecall(0.7)
+            .build();
+        runScenarioWithPool(scenario, singleThreadGraphMergePool);
+    }
+
+    /**
+     * Progressive threshold: the first two rounds stay below it (full precision), the third
+     * crosses it and FusedPQ kicks in on merge. Individual flush segments stay below the
+     * threshold so they remain full-precision until merged.
+     */
+    @Test
+    public void testFusedPQMultiPhaseMergeProgressiveThreshold() throws IOException {
+        var scenario = MergeTestScenario.builder()
+            .minFusedPqThreshold(1200)
+            .round(MergeTestRound.builder().segmentSizes(List.of(100, 150, 150)).build())   // 400 < 1200
+            .round(MergeTestRound.builder().segmentSizes(List.of(100, 150, 150)).build())   // 800 < 1200
+            .round(MergeTestRound.builder().segmentSizes(List.of(200, 200, 200)).build())   // 1400 > 1200
+            .overqueryFactor(20)
+            .minimumRecall(0.7)
+            .build();
+        runScenarioWithPool(scenario, singleThreadGraphMergePool);
+    }
+
+    /**
+     * FusedPQ always active with complex deletions across rounds. All flush segments use
+     * >= 300 vectors to guarantee 256-cluster codebooks.
+     */
+    @Test
+    public void testFusedPQMultiPhaseMergeWithDeletions() throws IOException {
+        var scenario = MergeTestScenario.builder()
+            .minFusedPqThreshold(1)
+            .round(
+                MergeTestRound.builder()
+                    .segmentSizes(List.of(300, 300, 300))
+                    .deletionRanges(List.of(new DeletionRange(0, 30), new DeletionRange(600, 700)))
+                    .build()
+            )
+            .round(
+                MergeTestRound.builder()
+                    .segmentSizes(List.of(300, 300))
+                    .deletionRanges(List.of(new DeletionRange(900, 1000), new DeletionRange(50, 55)))
+                    .build()
+            )
+            .round(MergeTestRound.builder().segmentSizes(List.of(300)).build())
+            .overqueryFactor(20)
+            .minimumRecall(0.7)
+            .build();
+        runScenarioWithPool(scenario, singleThreadGraphMergePool);
+    }
+
+    /** FusedPQ with COSINE similarity (exercises the cosine decoder path). */
+    @Test
+    public void testFusedPQCosineRecall() throws IOException {
+        var scenario = MergeTestScenario.builder()
+            .minFusedPqThreshold(1)
+            .round(MergeTestRound.builder().segmentSizes(List.of(512)).build())
+            .similarityFunction(VectorSimilarityFunction.COSINE)
+            .minimumRecall(0.7)
+            .build();
+        runScenario(scenario);
+    }
+
+    /** FusedPQ with DOT_PRODUCT similarity (exercises the dot-product decoder path). */
+    @Test
+    public void testFusedPQDotProductRecall() throws IOException {
+        var scenario = MergeTestScenario.builder()
+            .minFusedPqThreshold(1)
+            .round(MergeTestRound.builder().segmentSizes(List.of(512)).build())
+            .similarityFunction(VectorSimilarityFunction.DOT_PRODUCT)
+            .minimumRecall(0.6)
+            .build();
+        runScenario(scenario);
+    }
+
+    /**
+     * After a FusedPQ flush the on-disk graph carries both INLINE_VECTORS (reranking) and
+     * FUSED_PQ (traversal), and no separate PQ blob is loaded.
+     */
+    @Test
+    public void testFusedPQMetadataFlags() throws IOException {
+        int numVectors = 512;
+
+        IndexWriterConfig iwc = LuceneTestCase.newIndexWriterConfig();
+        iwc.setUseCompoundFile(false);
+        iwc.setCodec(getCodec(1, KNNConstants.DEFAULT_LEADING_SEGMENT_MERGE_DISABLED, null, new JVectorIndexQuantization.PQ(), true));
+        iwc.setMergePolicy(new ForceMergesOnlyMergePolicy(false));
+        iwc.setMaxBufferedDocs(-1);
+
+        float[][] vecs = TestUtils.randomlyGenerateStandardVectors(numVectors, 128, RANDOM_SEED);
+
+        try (var fsd = FSDirectory.open(tempDir.getRoot().toPath()); var writer = new IndexWriter(fsd, iwc)) {
+            for (int i = 0; i < numVectors; i++) {
+                Document doc = new Document();
+                doc.add(new KnnFloatVectorField(VECTOR_FIELD, vecs[i], VectorSimilarityFunction.EUCLIDEAN));
+                writer.addDocument(doc);
+            }
+            writer.flush();
+            writer.commit();
+            writer.forceMerge(1);
+            writer.commit();
+
+            try (var reader = DirectoryReader.open(writer)) {
+                JVectorReader jvReader = openJVectorReader(reader);
+
+                Assert.assertTrue(
+                    "FusedPQ segment must not load a separate PQ blob",
+                    jvReader.getProductQuantizationForField(VECTOR_FIELD).isEmpty()
+                );
+
+                var featureSet = jvReader.getOnDiskGraphIndex(VECTOR_FIELD).getFeatureSet();
+                Assert.assertTrue("Graph must contain INLINE_VECTORS for reranking", featureSet.contains(FeatureId.INLINE_VECTORS));
+                Assert.assertTrue("Graph must contain FUSED_PQ for traversal", featureSet.contains(FeatureId.FUSED_PQ));
+            }
+        }
+    }
+
+    /**
+     * Concurrent searches over a FusedPQ index. Exercises the per-View lazily-read packed
+     * neighbor codes under contention.
+     */
+    @Test
+    public void testFusedPQConcurrentSearch() throws IOException, InterruptedException {
+        int numVectors = 512;
+        int numThreads = 4;
+        int queriesPerThread = 5;
+        float[][] vecs = TestUtils.randomlyGenerateStandardVectors(numVectors, 128, RANDOM_SEED);
+        float[][] queries = TestUtils.randomlyGenerateStandardVectors(numThreads * queriesPerThread, 128, RANDOM_SEED + 99);
+
+        IndexWriterConfig iwc = LuceneTestCase.newIndexWriterConfig();
+        iwc.setUseCompoundFile(false);
+        iwc.setCodec(getCodec(1, KNNConstants.DEFAULT_LEADING_SEGMENT_MERGE_DISABLED, null, new JVectorIndexQuantization.PQ(), true));
+        iwc.setMergePolicy(new ForceMergesOnlyMergePolicy(false));
+        iwc.setMaxBufferedDocs(-1);
+
+        try (var fsd = FSDirectory.open(tempDir.getRoot().toPath()); var writer = new IndexWriter(fsd, iwc)) {
+            for (int i = 0; i < numVectors; i++) {
+                Document doc = new Document();
+                doc.add(new KnnFloatVectorField(VECTOR_FIELD, vecs[i], VectorSimilarityFunction.EUCLIDEAN));
+                writer.addDocument(doc);
+            }
+            writer.flush();
+            writer.commit();
+
+            try (var reader = DirectoryReader.open(writer)) {
+                var searcher = LuceneTestCase.newSearcher(reader);
+                var latch = new CountDownLatch(1);
+                var errors = new AtomicReference<Throwable>(null);
+                var resultCounts = new ArrayList<Integer>(numThreads * queriesPerThread);
+                for (int i = 0; i < numThreads * queriesPerThread; i++)
+                    resultCounts.add(0);
+
+                ExecutorService pool = Executors.newFixedThreadPool(numThreads);
+                try {
+                    for (int t = 0; t < numThreads; t++) {
+                        final int threadIdx = t;
+                        pool.submit(() -> {
+                            try {
+                                latch.await();
+                                for (int q = 0; q < queriesPerThread; q++) {
+                                    int idx = threadIdx * queriesPerThread + q;
+                                    var query = new JVectorKnnFloatVectorQuery(VECTOR_FIELD, queries[idx], 10, 10, 0.0f, 0.0f);
+                                    var results = searcher.search(query, 10).scoreDocs;
+                                    resultCounts.set(idx, results.length);
+                                }
+                            } catch (Throwable e) {
+                                errors.compareAndSet(null, e);
+                            }
+                        });
+                    }
+                    latch.countDown();
+                    pool.shutdown();
+                    Assert.assertTrue("Concurrent search timed out", pool.awaitTermination(60, TimeUnit.SECONDS));
+                } finally {
+                    pool.shutdownNow();
+                }
+
+                Assert.assertNull("Concurrent search threw: " + errors.get(), errors.get());
+                for (int i = 0; i < resultCounts.size(); i++) {
+                    Assert.assertEquals("Thread " + i + " got wrong result count", 10, (int) resultCounts.get(i));
+                }
+            }
+        }
+    }
+
+    /**
+     * FusedPQ merge with leading-segment merge disabled: the merge rebuilds the graph from
+     * scratch but must still emit a FusedPQ-encoded segment.
+     */
+    @Test
+    public void testFusedPQLeadingSegmentMergeDisabled() throws IOException {
+        var scenario = MergeTestScenario.builder()
+            .minFusedPqThreshold(1)
+            .leadingSegmentMergeDisabled(true)
+            .round(MergeTestRound.builder().segmentSizes(List.of(300, 300)).build())
+            .minimumRecall(0.7)
+            .build();
+        runScenarioWithPool(scenario, singleThreadGraphMergePool);
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/engine/CommonTestUtils.java
+++ b/src/test/java/org/opensearch/knn/index/engine/CommonTestUtils.java
@@ -176,9 +176,44 @@ public class CommonTestUtils {
     public static Codec getCodec(
         int minBatchSizeForQuantization,
         boolean leadingSegmentMergeDisabled,
+        ForkJoinPool graphMergePool,
+        JVectorIndexQuantization quantization,
+        boolean fusedPqEnabled
+    ) {
+        return getCodec(
+            minBatchSizeForQuantization,
+            leadingSegmentMergeDisabled,
+            DEFAULT_HIERARCHY_ENABLED,
+            graphMergePool,
+            quantization,
+            fusedPqEnabled
+        );
+    }
+
+    public static Codec getCodec(
+        int minBatchSizeForQuantization,
+        boolean leadingSegmentMergeDisabled,
         boolean hierarchical,
         ForkJoinPool graphMergePool,
         JVectorIndexQuantization quantization
+    ) {
+        return getCodec(
+            minBatchSizeForQuantization,
+            leadingSegmentMergeDisabled,
+            hierarchical,
+            graphMergePool,
+            quantization,
+            KNNConstants.DEFAULT_FUSED_PQ_ENABLED
+        );
+    }
+
+    public static Codec getCodec(
+        int minBatchSizeForQuantization,
+        boolean leadingSegmentMergeDisabled,
+        boolean hierarchical,
+        ForkJoinPool graphMergePool,
+        JVectorIndexQuantization quantization,
+        boolean fusedPqEnabled
     ) {
         if (graphMergePool == null) {
             return new FilterCodec(KNNCodecVersion.V_10_04_0.getCodecName(), new Lucene104Codec()) {
@@ -195,7 +230,8 @@ public class CommonTestUtils {
                                 quantization,
                                 minBatchSizeForQuantization,
                                 hierarchical,
-                                leadingSegmentMergeDisabled
+                                leadingSegmentMergeDisabled,
+                                fusedPqEnabled
                             );
                         }
                     };
@@ -218,6 +254,7 @@ public class CommonTestUtils {
                                 minBatchSizeForQuantization,
                                 hierarchical,
                                 leadingSegmentMergeDisabled,
+                                fusedPqEnabled,
                                 graphMergePool,
                                 graphMergePool,
                                 graphMergePool


### PR DESCRIPTION
## Summary

First draft implementation of FusedPQ support as proposed in #675. Adds an opt-in on-disk layout (`advanced.fused_pq_enabled`, default `false`) that stores the PQ codes used for approximate graph-traversal scoring inline per adjacency-list entry (`FeatureId.FUSED_PQ`) instead of as a separate blob loaded fully into heap at segment open.

- New mapping parameter `advanced.fused_pq_enabled` (boolean, default `false`), wired through `KNNConstants`, `JVectorDiskANNMethod`, `KNNVectorsFormatParams`, and `JVectorFormat` (codec version bumped to `VERSION_WITH_FUSED_PQ`).
- `JVectorWriter` gains a `writeFusedPQGraph` path that writes `InlineVectors` (full precision, for reranking) + `FusedPQ` (inline codes, for traversal) instead of `InlineVectors` + a separate PQ blob, for the plain-PQ quantization path.
- Falls back to the separate-blob layout when a segment's trained PQ codebook has fewer than 256 clusters, since jVector's `FusedPQ` requires an exactly-256-cluster codebook (`FusedPQ` encodes codes as a single byte per subspace). Code reference (https://github.com/datastax/jvector/blob/main/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/feature/FusedPQ.java#L57)
- `JVectorReader` dispatches to `view.approximateScoreFunctionFor(...)` for FusedPQ segments, reading packed neighbor codes lazily from the `View` during traversal instead of an in-memory PQ lookup table. The `GraphSearcher`/`View` acquisition in `search()` was restructured so the score provider and the searcher share a single `View` instance.
- New `quantizationLayout` byte in segment metadata (`SEPARATE` vs `FUSED_PQ`), orthogonal to the existing `quantizationType` (PQ/NVQ/none), with backward-compatible defaults for pre-existing segment versions.

## Testing

Added `JVectorFusedPQTests` (new): single-segment flush, two/multi-segment merges with deletions, multi-phase progressive-threshold merges, all three similarity functions, concurrent search, metadata-flag assertions, below-threshold fallback to full precision, and merge with leading-segment-merge disabled. All passing locally.

Relates to #675 (RFC). This is a first draft covering the core layout change; the RFC's "Future Work" items (FusedPQ + NVQ combined path, broader recall benchmarking) remain as follow-up and are not addressed here.

For more details on benchmarking, see the linked issue. 